### PR TITLE
ci: gate deployments behind a promoted ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,20 @@
 name: NixOS CI
 
+# Build gate and promotion (ADR 0001).
+#
+# Every host configuration is built on every pull request and on every push to
+# master. On master, once the gate passes, `deploy` is fast-forwarded to the
+# tested commit. Hosts run `system.autoUpgrade` against `deploy`, so a revision
+# that fails to build for any host can never reach a machine.
+#
+# Builds are pushed to the `corygyarmathy-dotfiles` Cachix cache, which the
+# hosts substitute from - CI builds the closure once instead of each host
+# rebuilding it independently at 04:00.
+#
+# NOTE: the `nixos ci` job name is the status-check context required by the
+# `protect-main` repository ruleset. Renaming that job silently blocks every
+# merge until the ruleset is updated to match, so treat the two as a pair.
+
 on:
   push:
     branches: [master]
@@ -7,27 +22,105 @@ on:
     branches: [master]
   workflow_dispatch: # Allows manual triggering
 
+# Read-only by default; the promote job opts into contents: write for itself.
+permissions:
+  contents: read
+
+# A newer commit on the same branch makes an in-flight run obsolete. Never
+# cancel on master, since those runs are what promote `deploy`.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  check:
+  flake-check:
+    name: flake check
     runs-on: ubuntu-latest
     steps:
-      # Clones your repo into the runner
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Installs Nix with flakes enabled (faster than the official installer and designed for CI)
-      - uses: DeterminateSystems/nix-installer-action@main
-
-      # Provides free build caching between CI runs without needing a Cachix account.
-      # It uploads your build artifacts to their cache and restores them on subsequent runs.
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
-          use-flakehub: false
+          # The hosts trust this cache for Hyprland; CI needs it too, or every
+          # Hyprland-adjacent path is built from source here.
+          extra-conf: |
+            extra-substituters = https://hyprland.cachix.org
+            extra-trusted-public-keys = hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc=
+
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: corygyarmathy-dotfiles
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Check flake
-        run: nix flake check
+        run: nix flake check --print-build-logs
 
-      - name: Build homelab01
-        run: nix build .#nixosConfigurations.homelab01.config.system.build.toplevel
+  build:
+    name: build ${{ matrix.host }}
+    runs-on: ubuntu-latest
+    strategy:
+      # Build every host even when one fails - knowing that two of three hosts
+      # are broken is more useful than knowing one is.
+      fail-fast: false
+      matrix:
+        host: [homelab01, homelab02, xps15]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Build homelab02
-        run: nix build .#nixosConfigurations.homelab02.config.system.build.toplevel
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          extra-conf: |
+            extra-substituters = https://hyprland.cachix.org
+            extra-trusted-public-keys = hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc=
+
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: corygyarmathy-dotfiles
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build ${{ matrix.host }}
+        run: |
+          nix build --print-build-logs --no-link \
+            ".#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel"
+
+  # Single stable status-check context for the ruleset. Matrix job names change
+  # whenever a host is added or renamed; this one does not.
+  gate:
+    name: nixos ci
+    runs-on: ubuntu-latest
+    needs: [flake-check, build]
+    # `always()` so the gate reports a real failure when a dependency fails.
+    # Without it the job is *skipped*, and a skipped required check does not
+    # block a merge - the gate would silently stop gating.
+    if: always()
+    steps:
+      - name: Verify all checks passed
+        run: |
+          echo "flake-check: ${{ needs.flake-check.result }}"
+          echo "build:       ${{ needs.build.result }}"
+          [ "${{ needs.flake-check.result }}" = "success" ] || exit 1
+          [ "${{ needs.build.result }}" = "success" ] || exit 1
+
+  # Fast-forward `deploy` to the commit that just passed the gate. This is the
+  # only thing that moves what the fleet runs (ADR 0001).
+  promote:
+    name: promote to deploy
+    runs-on: ubuntu-latest
+    needs: [gate]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # A shallow clone cannot be used to update another ref.
+          fetch-depth: 0
+
+      - name: Fast-forward deploy
+        run: |
+          set -euo pipefail
+          # Deliberately not a force push: if `deploy` has diverged from master,
+          # something manual happened and it should fail loudly rather than
+          # silently discard whatever is there.
+          git push origin "${{ github.sha }}:refs/heads/deploy"
+          echo "::notice::deploy now at ${{ github.sha }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         with:
           name: corygyarmathy-dotfiles
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # Substitute only; nothing worth pushing is built here.
+          skipPush: true
 
       - name: Check flake
         run: nix flake check --print-build-logs
@@ -77,11 +79,27 @@ jobs:
         with:
           name: corygyarmathy-dotfiles
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # The action's own push runs as a post-job step, where a failure fails
+          # the job - which would let a cache hiccup block a deployment. The
+          # cache is a performance dependency, not a correctness one (ADR 0001),
+          # so we push explicitly below instead.
+          skipPush: true
 
       - name: Build ${{ matrix.host }}
         run: |
-          nix build --print-build-logs --no-link \
-            ".#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel"
+          nix build --print-build-logs --no-link --print-out-paths \
+            ".#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel" \
+            | tee "$RUNNER_TEMP/toplevel"
+
+      # Deliberately non-fatal: if this fails, the hosts build from source at
+      # 04:00 instead of substituting. Slower, never wrong. Pushing the toplevel
+      # pushes its closure, which is exactly what a host needs - and nothing
+      # build-time-only, unlike the action's watch-the-whole-store approach.
+      - name: Push ${{ matrix.host }} closure to Cachix
+        continue-on-error: true
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: cachix push corygyarmathy-dotfiles < "$RUNNER_TEMP/toplevel"
 
   # Single stable status-check context for the ruleset. Matrix job names change
   # whenever a host is added or renamed; this one does not.

--- a/docs/adr/0001-gitops-deployment-with-a-promoted-ref.md
+++ b/docs/adr/0001-gitops-deployment-with-a-promoted-ref.md
@@ -1,0 +1,141 @@
+# ADR 0001: GitOps deployment with a promoted ref
+
+- **Status:** Accepted
+- **Date:** 2026-08-15
+- **Related Artefacts:**
+  - Implemented by: `.github/workflows/ci.yml` (build gate + promotion), `.github/workflows/flake-update.yml` (lock updates), `system.autoUpgrade` on each host
+  - Supersedes: the flake-update and apply logic in `packages/nixos-upgrade-scripts`
+  - Depends on: the `protect-main` repository ruleset, the `corygyarmathy-dotfiles` Cachix cache
+
+## Context
+
+Three machines run this flake: two servers (`homelab01`, `homelab02`) and one laptop
+(`xps15`). Keeping them current has been split across two mechanisms that do not know
+about each other.
+
+The servers pull. `system.autoUpgrade` fetches `github:corygyarmathy/dotfiles#hostname`
+nightly and rebuilds. This works and needs no inbound access, but it follows `master`
+unconditionally: CI runs on push, so a commit that fails to build is already what the
+servers will fetch at 04:00. The build result and the deployment are racing, and nothing
+enforces the ordering.
+
+The laptop pushes. `packages/nixos-upgrade-scripts` is 1834 lines of Python that runs
+`nix flake update`, builds in the background, drives a waybar indicator, applies on
+confirmation, and commits the result. It conflates two jobs: deciding what the *fleet*
+should run, which is a repository-wide question, and presenting an upgrade to an
+interactive user, which is genuinely local. Because the first job lives on the laptop,
+`flake.lock` only moves when the laptop is on - so server package versions are gated on
+a machine that has nothing to do with them.
+
+Neither path reports. A failed rebuild, a service that does not come back, or a host that
+quietly stops upgrading altogether are all invisible until noticed by hand. This is the
+gap that matters most: the failure mode of an automated deploy pipeline is not a loud
+error, it is silence.
+
+A Prometheus + blackbox + Alertmanager stack already runs on both servers, with HTTP
+probes on every public service and an alert on failed systemd units. The reporting
+primitives exist; they are simply not connected to deployment.
+
+## Decision
+
+Keep the pull model - it is correct for hosts with no inbound access and no dependency on
+an operator's machine - and add the two things it lacks: a gate and a report.
+
+**1. Hosts follow a promoted ref, not `master`.** A `deploy` branch is fast-forwarded to
+`master` by CI, and only after every host configuration builds. `system.autoUpgrade`
+points at `github:corygyarmathy/dotfiles/deploy#hostname`. A host can therefore only ever
+fetch a revision proven to evaluate and build *for that host*. `master` stays the
+integration branch and may be red; `deploy` is the fleet's contract.
+
+**2. `flake.lock` updates move to CI.** A scheduled workflow builds every host toplevel,
+runs `nix flake update`, builds again, and opens one pull request carrying the per-host
+`nix store diff-closures` output in the commit body. It auto-merges on green. Lock
+freshness stops depending on the laptop being awake, and server packages update on the
+same cadence as everything else.
+
+**3. Pinned packages update through `passthru.updateScript`.** Packages that cannot move
+via `nix flake update` - an upstream tag, an npm release - declare their own updater, and
+a workflow discovers and runs them. `nix-update` covers the common cases; bespoke scripts
+handle the rest. Attaching the updater to the package rather than listing packages in YAML
+means adding a package does not mean editing CI.
+
+**4. Reporting rides the monitoring stack that already exists.** Hosts export deployment
+state as node_exporter textfile metrics - success, timestamp, deployed revision - and
+`nixos-upgrade.service` gains an `onFailure` handler. Alert rules cover the upgrade
+failing, and, more importantly, a host whose last successful upgrade is older than 48
+hours. No new services; the existing `probe_success` and `node_systemd_unit_state` rules
+already cover "the service did not come back".
+
+**5. CI builds are shared through a binary cache.** CI pushes to Cachix; hosts substitute
+from it. Without this, the same closure is built four times - once in CI and once per host
+- on hardware chosen for storage and transcoding rather than compilation.
+
+**6. Interactive deployment stays out of the pipeline.** Iterating on a service is not a
+deployment; requiring a commit, a push, and a CI round-trip to test a config change would
+make the pipeline something to route around. `nixos-rebuild --target-host` from the
+working tree remains the supported path for that, and the nightly pull reconciles the host
+afterwards.
+
+The laptop keeps a reduced build-and-notify unit, because `system.autoUpgrade` has no
+notify-then-confirm mode and interrupting an interactive session to switch generations is
+not acceptable. Everything else it currently does - updating the lock, committing,
+deciding what to build - belongs to CI and is removed.
+
+## Consequences
+
+**Positive**
+
+- A broken `master` cannot reach a host. The gate is structural rather than a matter of
+  timing.
+- Lock updates no longer depend on any particular machine being online, and server
+  packages track the same lock as everything else.
+- `deploy` is a single, inspectable answer to "what is the fleet supposed to be running",
+  and holding a deployment back is just declining to promote.
+- Silent failure becomes loud: a host that stops upgrading alerts on staleness, which is
+  the failure this pipeline is otherwise most likely to hide.
+- `packages/nixos-upgrade-scripts` loses most of its reason to exist.
+
+**Negative**
+
+- **Building is the only pre-deploy gate, and building is not working.** A package that
+  compiles and then fails at runtime will auto-merge and deploy. Mitigated after the fact
+  by the alert rules, and to be narrowed by NixOS VM tests added per service module.
+  Accepted deliberately: the alternative is manual review of every nixpkgs-unstable bump,
+  which is the status quo that does not happen.
+- Unattended nixpkgs-unstable now reaches servers without a human ever looking. This is
+  the point, but it is a real change in posture.
+- A required status check whose name no longer matches the CI job blocks every merge with
+  no bypass. Renaming the gate job means updating the ruleset in lockstep - the gate job
+  exists partly to make that a one-line, rarely-touched name.
+- The laptop's auto-upgrade follows the promoted ref, so uncommitted local config is no
+  longer picked up automatically. Deliberate - the laptop should not silently run a
+  configuration CI never saw - but it is a behaviour change to get used to.
+- Cachix is an external dependency in the deploy path. Hosts degrade to building from
+  source if it is unreachable, so it is a performance dependency rather than a
+  correctness one.
+
+## Alternatives considered
+
+- **Push-based deployment with `deploy-rs` or `colmena`.** Better ergonomics for many
+  hosts, and `deploy-rs` adds magic rollback, which is real insurance against locking
+  yourself out with a firewall or network change. Rejected as the *primary* mechanism
+  because it inverts the connectivity requirement: something must reach the hosts, which
+  means either the laptop is online - the constraint being removed - or CI gets inbound
+  access to the homelab. Worth revisiting for the rollback alone if a host is ever bricked,
+  or past roughly four machines.
+- **Keep hosts on `master` and rely on CI running first.** No new branch, no promotion
+  job. Rejected: it is a race, not a gate. CI usually finishes before 04:00, and "usually"
+  is the whole problem.
+- **Per-host promotion branches (`deploy/homelab01`).** One host's build failure would not
+  block the other's deployment. Rejected as premature at two servers, and it trades a
+  fleet that is consistent by construction for one that can drift. Reconsider when hosts
+  diverge enough that one failing build routinely blocks unrelated hosts.
+- **`DeterminateSystems/update-flake-lock` for the lock workflow.** Well-maintained, and
+  its PR body lists input revision changes. Rejected because it does not build what it
+  proposes and reports input revisions rather than package deltas; `nix store
+  diff-closures` per host answers "what actually changes on my machines", which is the
+  question worth asking.
+- **Self-hosted Attic instead of Cachix.** No external dependency and full control.
+  Rejected for now: CI can only push to it if the homelab is reachable from GitHub, which
+  reintroduces the inbound-access problem the pull model exists to avoid. Cachix is free
+  for a public repository and needs no such exposure.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,29 @@
+# ADR NNNN: <title>
+
+- **Status:** Proposed | Accepted | Superseded by ADR XXXX
+- **Date:** YYYY-MM-DD
+- **Related Artefacts:** (Optional)
+  - Verb: Artefact_Name
+
+## Context
+
+What's the situation? What forces are at play? Keep this to a paragraph or two - the reader should understand why a decision is needed.
+
+## Decision
+
+What did we decide? Be specific. "Use Postgres" is a decision; "use a database" is not.
+
+## Consequences
+
+**Positive**
+
+- ...
+
+**Negative**
+
+- ...
+
+## Alternatives considered (Optional)
+
+- **<Option B>.** Why rejected.
+- **<Option C>.** Why rejected.

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,12 @@
             {
               networking.hostName = hostname;
 
+              # Record the flake revision this system was built from, so a host
+              # can report what it is actually running (see docs/adr/0001).
+              # `self.rev` only exists for a clean tree; fall back to dirtyRev
+              # for local `nixos-rebuild` from a working copy.
+              system.configurationRevision = self.rev or self.dirtyRev or "dirty";
+
               # Nix settings
               nix = {
                 settings = {
@@ -93,9 +99,18 @@
                     "nix-command"
                     "flakes"
                   ];
-                  # Hyprland cachix
-                  substituters = [ "https://hyprland.cachix.org" ];
-                  trusted-public-keys = [ "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc=" ];
+                  substituters = [
+                    # Hyprland cachix
+                    "https://hyprland.cachix.org"
+                    # Our own CI builds - every host toplevel is pushed here by
+                    # .github/workflows/ci.yml, so the nightly autoUpgrade
+                    # substitutes the closure instead of rebuilding it (ADR 0001).
+                    "https://corygyarmathy-dotfiles.cachix.org"
+                  ];
+                  trusted-public-keys = [
+                    "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
+                    "corygyarmathy-dotfiles.cachix.org-1:/DMVcdDI+4GCAzS6iDTtiwERF1py+MD+w1Z/NTAd2oU="
+                  ];
                 };
                 # Automatic garbage collection
                 gc = {


### PR DESCRIPTION
Phases 1 and 2 of the deployment pipeline work (ADR 0001, included in this PR).

## What changes

**The gate.** Every host configuration is built on every PR and every push to master. On master, once the gate passes, `deploy` is fast-forwarded to the tested commit. Hosts will be pointed at `deploy` in phase 3, so a revision that fails to build for any host can never reach a machine.

**Coverage.** `xps15` joins the build matrix - it was never gated at all.

**Cachix.** CI pushes every built closure to `corygyarmathy-dotfiles`; hosts substitute from it. Without this the same closure is built four times: once here and once per host, on hardware chosen for storage and transcoding rather than compilation.

**`system.configurationRevision`** is now recorded, so a host can report the revision it is actually running. That is the basis for the staleness alerting in phase 4.

## Things worth knowing

- The `nixos ci` job name **is** the status-check context required by the `protect-main` ruleset. Renaming it silently blocks every merge until the ruleset is updated. The gate job exists partly so that name is stable across matrix changes.
- The gate uses `if: always()` deliberately: without it, a failed dependency leaves the job *skipped*, and a skipped required check does not block a merge - the gate would stop gating without telling anyone.
- The promotion push is not forced. If `deploy` ever diverges from master, it fails loudly rather than discarding whatever is there.
- `deploy` does not exist yet; the first successful run on master creates it.

## Not in this PR

Phase 3 (pointing hosts at `deploy`, staggering homelab02 behind homelab01), phase 4 (deploy metrics + alert rules), phase 5 (the `flake.lock` updater), phases 6-7 (package updaters, slimming `nixos-upgrade-scripts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)