### PR TITLE
feat(deploy): point servers at promoted refs, stage the rollout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ name: NixOS CI
 # NOTE: the `nixos ci` job name is the status-check context required by the
 # `protect-main` repository ruleset. Renaming that job silently blocks every
 # merge until the ruleset is updated to match, so treat the two as a pair.
+#
+# NOTE: never create a branch under `deploy/` or `deploy-stable/`. Git stores
+# refs as paths, so a `deploy/my-branch` ref makes `refs/heads/deploy` a
+# directory, and promotion then fails with "directory file conflict" for as long
+# as that branch exists. The `reserve-deploy-namespace` ruleset blocks this at
+# the server, but the failure is obscure enough to be worth naming here.
 
 on:
   push:

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -1,0 +1,81 @@
+name: promote deploy-stable
+
+# Advances `deploy-stable` to whatever `deploy` pointed at 24h ago (ADR 0001).
+#
+# homelab01 follows `deploy` and takes every promoted revision the night it
+# lands. homelab02 - the storage node, holding the ZFS pool and the NFS export
+# homelab01 depends on - follows `deploy-stable` and takes the same revision a
+# day later. A kernel or systemd bump that fails to boot therefore takes out the
+# compute node while the data node keeps serving.
+#
+# The lag is time-based only: it proves homelab01 has *had* the revision for a
+# day, not that homelab01 is well. Phase 4 adds the deployment metrics that
+# would let this gate on actual health instead.
+
+on:
+  schedule:
+    # 19:30 UTC = 03:30 Perth (UTC+8, no DST), which sits between homelab01's
+    # 04:00 upgrade and homelab02's 04:15 one. A revision promoted here has
+    # therefore been running on homelab01 since its 04:00 run the day before.
+    - cron: "30 19 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Need full history on every branch: the 24h cutoff is a walk over
+          # `deploy`, and the fast-forward check is an ancestry test.
+          fetch-depth: 0
+
+      - name: Advance deploy-stable
+        run: |
+          set -euo pipefail
+
+          if ! git rev-parse --verify -q origin/deploy >/dev/null; then
+            echo "::error::origin/deploy does not exist - has CI promoted yet?"
+            exit 1
+          fi
+
+          # First run: there is nothing to lag behind, so start level with
+          # `deploy`. No soak on day one, but the alternative is homelab02
+          # sitting on a pre-pipeline revision that still points at master.
+          if ! git rev-parse --verify -q origin/deploy-stable >/dev/null; then
+            target="$(git rev-parse origin/deploy)"
+            echo "::notice::bootstrapping deploy-stable at $target"
+            git push origin "$target:refs/heads/deploy-stable"
+            exit 0
+          fi
+
+          current="$(git rev-parse origin/deploy-stable)"
+
+          # Newest commit on `deploy` that has been there long enough to have
+          # soaked on homelab01.
+          target="$(git rev-list -1 --before='24 hours ago' origin/deploy)"
+
+          if [ -z "$target" ]; then
+            echo "::notice::nothing on deploy is 24h old yet; holding at $current"
+            exit 0
+          fi
+
+          if [ "$target" = "$current" ]; then
+            echo "::notice::deploy-stable already at $target; nothing to do"
+            exit 0
+          fi
+
+          # Only ever move forward. If deploy-stable is not an ancestor of the
+          # target, history was rewritten somewhere and this should stop rather
+          # than drag homelab02 sideways onto an unrelated revision.
+          if ! git merge-base --is-ancestor "$current" "$target"; then
+            echo "::error::$current is not an ancestor of $target - refusing to move deploy-stable"
+            exit 1
+          fi
+
+          echo "::notice::advancing deploy-stable $current -> $target"
+          git log --oneline "$current..$target"
+          git push origin "$target:refs/heads/deploy-stable"

--- a/docs/adr/0001-gitops-deployment-with-a-promoted-ref.md
+++ b/docs/adr/0001-gitops-deployment-with-a-promoted-ref.md
@@ -47,6 +47,23 @@ points at `github:corygyarmathy/dotfiles/deploy#hostname`. A host can therefore 
 fetch a revision proven to evaluate and build *for that host*. `master` stays the
 integration branch and may be red; `deploy` is the fleet's contract.
 
+**1a. The servers roll out in stages.** `homelab01` follows `deploy` and takes each
+promoted revision the night it lands. `homelab02` follows `deploy-stable`, which a
+scheduled job advances to whatever `deploy` pointed at 24 hours earlier. The two servers
+are not interchangeable: `homelab02` holds the ZFS pool and exports the NFS storage
+`homelab01` mounts, so it is the host whose failure cascades. Staging the rollout means a
+kernel or systemd bump that fails to boot takes out the compute node while the data node
+keeps serving.
+
+The soak is worth less than it looks for host-specific packages - a regression in ZFS or
+qBittorrent will not surface on `homelab01`, which runs neither - but the shared base
+(kernel, systemd, nix, glibc) is where an unattended update does catastrophic rather than
+annoying damage, and that is exactly what a day of uptime on another machine exercises.
+
+The lag is measured in elapsed time, not health: it establishes that `homelab01` has *had*
+the revision for a day, not that `homelab01` is well. Closing that gap needs the
+deployment metrics below, at which point the same job can gate on them.
+
 **2. `flake.lock` updates move to CI.** A scheduled workflow builds every host toplevel,
 runs `nix flake update`, builds again, and opens one pull request carrying the per-host
 `nix store diff-closures` output in the commit body. It auto-merges on green. Lock
@@ -126,10 +143,17 @@ deciding what to build - belongs to CI and is removed.
 - **Keep hosts on `master` and rely on CI running first.** No new branch, no promotion
   job. Rejected: it is a race, not a gate. CI usually finishes before 04:00, and "usually"
   is the whole problem.
-- **Per-host promotion branches (`deploy/homelab01`).** One host's build failure would not
-  block the other's deployment. Rejected as premature at two servers, and it trades a
-  fleet that is consistent by construction for one that can drift. Reconsider when hosts
-  diverge enough that one failing build routinely blocks unrelated hosts.
+- **Per-host promotion branches (`deploy/homelab01`).** A *different* idea to the staged
+  rollout in 1a: there, both servers traverse the same sequence of revisions at different
+  times; here, each host would advance independently so one host's build failure could not
+  block another's deployment. Rejected as premature at two servers, and it trades a fleet
+  that is consistent by construction for one that can drift arbitrarily. Reconsider when
+  hosts diverge enough that one failing build routinely blocks unrelated hosts.
+- **Staggering the servers by time of day instead of by revision.** Moving `homelab02`'s
+  upgrade a few hours after `homelab01`'s needs no second ref. Rejected because it is not
+  a soak: in a pull model both hosts fetch whatever the ref points at when they wake, so a
+  later hour gets the *same* revision the same night, and the failure it is meant to catch
+  happens at 3am with nobody watching either way.
 - **`DeterminateSystems/update-flake-lock` for the lock workflow.** Well-maintained, and
   its PR body lists input revision changes. Rejected because it does not build what it
   proposes and reports input revisions rather than package deltas; `nix store

--- a/hosts/homelab01/default.nix
+++ b/hosts/homelab01/default.nix
@@ -30,9 +30,12 @@
   # ============================================================================
   # Auto-Upgrade
   # ============================================================================
+  # Follows `deploy`, which CI fast-forwards only after every host builds
+  # (ADR 0001). This host is the canary: it takes each promoted revision first,
+  # and homelab02 follows the same revision 24h later via `deploy-stable`.
   system.autoUpgrade = {
     enable = true;
-    flake = "github:corygyarmathy/dotfiles#homelab01";
+    flake = "github:corygyarmathy/dotfiles/deploy#homelab01";
     dates = "04:00";
     allowReboot = true;
     rebootWindow = {

--- a/hosts/homelab02/default.nix
+++ b/hosts/homelab02/default.nix
@@ -37,9 +37,16 @@
   # ============================================================================
   # Auto-Upgrade
   # ============================================================================
+  # Follows `deploy-stable`, which trails `deploy` by 24h (ADR 0001). This is
+  # the storage node - ZFS, the NFS export homelab01 depends on - so it takes a
+  # revision only after homelab01 has run it for a day. A bad kernel or systemd
+  # bump therefore takes out the compute node, not the one holding the data.
+  #
+  # The lag is time-based, not health-based: nothing yet checks that homelab01
+  # is actually *well*, only that it has had the revision for 24h.
   system.autoUpgrade = {
     enable = true;
-    flake = "github:corygyarmathy/dotfiles#homelab02";
+    flake = "github:corygyarmathy/dotfiles/deploy-stable#homelab02";
     dates = "04:15"; # Offset from homelab01
     allowReboot = true;
     rebootWindow = {

--- a/secrets/homelab.yaml
+++ b/secrets/homelab.yaml
@@ -42,6 +42,11 @@ vikunja:
 digital-garden:
     deploy-key: ENC[AES256_GCM,data:AkYT0FJBEmr6g2/jlxRCuuLdysxLGfNfxtWJUDUMtxe0auOgy5knq8EibxnlIzMy3zgEuQveltIjiuhoz2SEgajknA/umb3J3MAa7doiEktUlfQa7WPuzsY4CI4i8UdBh0dU6XU+QX+G9/jOSIDZQNp03B/mtp54wzE23yFqgyYppaoVkoreA3mKo1bB9TvgvOur+MkJg9zRrcZk442+mzMh4KZ/KX2QtSAz8+JKfUjgI82EJ6za/eAcwo6yE0x/VPSMStgrkLGSgAj6g/sGKNsbfbcRfPEcmQgUzUiUPZgHJedrtjdvzlZyEYa6Y0p5C3PJN4wfT7yc6vhDw5Q0cRWNdHMIgd3Hdkig5ioeWBLjAQpySZt7NJh6TJW1fyglpiPOn/7u4V4lISDvCXutB4vX/plhNsTCxQExbOADNxjmAjiKy1t93brkJL+ISTrqHMALh0fkASqS27IEtsGDJ3Tmy17U3TsG4BQkgy/qUlJWHiYx9mu4RsgZqlu6WqZnQcEcGbAd9vrGiY1G+clyFU9uX0Y81tm6wKk/DbPwEgKvtcQ=,iv:2p/yRKO74tSEW+Gb8JVCPvce+deOYGIXTPat0m9XGE8=,tag:rxnH0bpjaghvbb1/ZElZsQ==,type:str]
     obsidian-token: ENC[AES256_GCM,data:/axo6tMkcHwxsptUsi5DHAQZGQXbXMIpM6sokifmvXw=,iv:qc+EzUIEmjDPAQ3bWBgrqfX1ZIqQ077d4HmoMsIr5kk=,tag:M6KqHTwjKkM+JBd31bw2Kw==,type:str]
+cachix:
+    auth-token: ENC[AES256_GCM,data:YP07dPNHZi2jCpUm/VJ6sPU5Ot2bXEjEiJuKCR9rm/i/zzUdvL3xYaxUlir7N+w8NfTJHZVhMUplWFF2aJamP4Rvpe7/4OCasRruvG+68XCSx6l3Zg3jSBVK/K9kPM/IoQMOT/87zESzqwDGGtEe7bb+7KmcnqNKEVln40wlkVRly9OwhJqoLZ9qF+Le2jV9MBvbZJ0=,iv:h506qjFlpUvglGY33cDYompU31S4ai2J01IrSZ7Gm6A=,tag:dfx4rUNTCs7ViFDv+q2j4w==,type:str]
+    public-key: ENC[AES256_GCM,data:6dM64N0YmgKb6PwePSVKjvqODwW974KNIC+uEYuHmYemUuXvZ+/DodV8+BbNW0W+NvWIhkOkn+q3uyB9+y4toQmEuMctws+uLT2EdMaoNAs=,iv:gn8mziaqew68qLzoSg1fMqmOrtIteSCnPqho0sUQUUM=,tag:a1FB22ax+lNVW3JoopwMGA==,type:str]
+gh-ci:
+    dotfiles-flake-update-PAT: ENC[AES256_GCM,data:pWz3D1qoplMuavKpq2mCCiRv4kDmPbKXHQ9xJ1tSn0oCHP0Sec8uzRSQvZJNZeUh60Uk8FSLIHgt3202PphVVox7/9H3hkf3d/x4DZAi5hbAiMpGDASgB5QLPAE6,iv:vwdIaBTnIcCcruGhdsSiKzxIVgSxJs461q+hyd34MiM=,tag:ySk/0AFr43MjQmU+lhKkVw==,type:str]
 sops:
     age:
         - enc: |
@@ -71,7 +76,7 @@ sops:
             etyrvYzGfOniMfKF2lh0A+hQyBCfBlSEA8thayi2JJowlVBZ/GNDjw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age15h2tcfx9dw5qeyx4cgg358wlzr489vvq272s6wm7gud6mrkmregsp9s6x6
-    lastmodified: "2026-08-14T04:13:07Z"
-    mac: ENC[AES256_GCM,data:hDx/g+zlLqFdbg+oyqOLQLvFLe4eISS2ek0WKc+AN5djvDTkRA9QuXJ9wnX9w3wGVaZCYrS8AcJYIvEFQZf3a6w4T80D3uAO352/MkjFa4CLTCUE2ZudiOh2PfMy2Co16G2ogCVdUMNADAVlQVHHoABOiQ0kKfJpc+iNBPguFBY=,iv:e8rPORFIxCbHf9shcvjnOLRngR3o/iuriQHvaSZsRlE=,tag:Cq17IkMk7HahxGUVZmmvfg==,type:str]
+    lastmodified: "2026-08-15T03:36:41Z"
+    mac: ENC[AES256_GCM,data:dFtfDkFHW+rHS8MfBod6jUVSwX/LBRHraHz+xxR7FUFO8wQEedlgHbfyddT7yPzwc2KxMyhvAQTcCBtqcE9oFGJn4xwD8AJC3UPdctm8KcC20UBb/9b4hyJAMBn3hEdS6cF7mzEbhj3GMrx/VlV8Bvw8gwF69xPPj6wBnozsCTI=,iv:/GAg6yJBh5A30ett5AevU1NDNV5zgWHhLsdNOOxGrrc=,tag:TqktIy95vU68QCUaB63K9A==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
Phase 3 of ADR 0001. Replaces #2, which GitHub closed when its head branch was renamed out of the `deploy/` namespace (see below).

## What changes

| Host | Follows | Takes a revision |
|---|---|---|
| `homelab01` | `deploy` | the night it is promoted |
| `homelab02` | `deploy-stable` | 24h later |

`promote-stable.yml` runs daily at 19:30 UTC (03:30 Perth, between homelab01's 04:00 upgrade and homelab02's 04:15) and fast-forwards `deploy-stable` to the newest commit on `deploy` older than 24h.

## Why the servers are staged rather than symmetric

homelab02 holds the ZFS pool and exports the NFS storage homelab01 mounts, so it is the host whose failure cascades. Giving homelab01 each revision first means a kernel or systemd bump that fails to boot takes out the compute node while the data node keeps serving.

A later *time of day* would not have done this. In a pull model both hosts fetch whatever the ref points at when they wake, so an offset of minutes gets the same revision the same night — it was never a soak, which is why this needs a second ref.

## Limits, stated plainly

- **The lag is time-based, not health-based.** It establishes that homelab01 has *had* the revision for a day, not that homelab01 is well. Phase 4's deployment metrics are what would let this gate on health.
- **The soak is worth less for host-specific packages.** A ZFS or qBittorrent regression will not surface on homelab01, which runs neither. The shared base — kernel, systemd, nix, glibc — is what gets exercised, and that is where an unattended update does catastrophic rather than annoying damage.
- **No soak on day one.** `deploy-stable` bootstraps level with `deploy`, because the alternative is homelab02 sitting on a pre-pipeline revision that still points at `master`.

## The `deploy/` namespace trap

The first promotion run failed with `remote rejected … (directory file conflict)`. This branch was originally named `deploy/point-hosts-at-promoted-refs`, and git stores refs as filesystem paths — so `refs/heads/deploy/…` made `refs/heads/deploy` a directory that could never hold a ref.

Fixed three ways: the branch was renamed, the `reserve-deploy-namespace` ruleset now blocks creation under `deploy/**` and `deploy-stable/**`, and `ci.yml` names the trap since the git error is obscure.

## Safety properties

- `deploy-stable` only ever fast-forwards; if it is not an ancestor of the target the job fails rather than dragging homelab02 sideways onto an unrelated revision.
- Both refs have rulesets blocking deletion and non-fast-forward pushes.

## After merge

`promote-stable` needs one `workflow_dispatch` to bootstrap `deploy-stable` before homelab02's next 04:15 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)