### PR TITLE
fix(deploy): let deploy-stable sit ahead of the 24h cutoff

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -63,16 +63,19 @@ jobs:
             exit 0
           fi
 
-          if [ "$target" = "$current" ]; then
-            echo "::notice::deploy-stable already at $target; nothing to do"
+          # Already at or beyond the cutoff, so there is nothing to advance to.
+          # Being *ahead* of it is normal, not an error: bootstrapping starts
+          # deploy-stable level with deploy, and it then sits ahead of the 24h
+          # cutoff until the revision it holds is itself a day old.
+          if git merge-base --is-ancestor "$target" "$current"; then
+            echo "::notice::deploy-stable ($current) is already at or ahead of $target; nothing to do"
             exit 0
           fi
 
-          # Only ever move forward. If deploy-stable is not an ancestor of the
-          # target, history was rewritten somewhere and this should stop rather
-          # than drag homelab02 sideways onto an unrelated revision.
+          # Neither ref contains the other, so history was rewritten somewhere.
+          # Stop rather than drag homelab02 sideways onto an unrelated revision.
           if ! git merge-base --is-ancestor "$current" "$target"; then
-            echo "::error::$current is not an ancestor of $target - refusing to move deploy-stable"
+            echo "::error::$current and $target have diverged - refusing to move deploy-stable"
             exit 1
           fi
 


### PR DESCRIPTION
Found by tracing tomorrow's scheduled run against the real history rather than waiting for it to fail.

## The bug

`promote-stable` computes a target — the newest commit on `deploy` older than 24h — then refuses to move unless `deploy-stable` is an ancestor of it. That guard only handles `deploy-stable` being *behind* the cutoff.

Bootstrapping starts `deploy-stable` level with `deploy`, so it is **ahead** of the cutoff until the revision it holds is itself a day old. The guard read that normal state as rewritten history.

Tomorrow's 19:30 run would have computed target `044c1894` — a commit from before the pipeline existed — against `deploy-stable` at `d46e408`, found no ancestry, and failed.

## The fix

Three cases instead of two:

| `deploy-stable` vs target | Action |
|---|---|
| at or ahead (target is an ancestor) | no-op |
| behind (is an ancestor of target) | fast-forward |
| neither contains the other | error |

Verified against the real repository history:

```
tomorrow 19:30 (bootstrap ahead of cutoff) NO-OP (at or ahead)
normal lag: behind the cutoff              ADVANCE 044c189 -> d46e408
already exactly at target                  NO-OP (at or ahead)
diverged history (stale refs/heads/main)   ERROR (diverged)
```

Divergence still errors, which was the point of the guard.

## Impact if unfixed

No host would have been harmed — `deploy-stable` simply would not have moved, so homelab02 would have kept running `d46e408`. But the job would have failed every night until the held revision aged past 24h, which is precisely the kind of recurring red that gets ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)