### PR TITLE
feat(monitoring): report deployment state, not just service state

### DIFF
--- a/docs/adr/0001-gitops-deployment-with-a-promoted-ref.md
+++ b/docs/adr/0001-gitops-deployment-with-a-promoted-ref.md
@@ -77,11 +77,37 @@ handle the rest. Attaching the updater to the package rather than listing packag
 means adding a package does not mean editing CI.
 
 **4. Reporting rides the monitoring stack that already exists.** Hosts export deployment
-state as node_exporter textfile metrics - success, timestamp, deployed revision - and
-`nixos-upgrade.service` gains an `onFailure` handler. Alert rules cover the upgrade
-failing, and, more importantly, a host whose last successful upgrade is older than 48
-hours. No new services; the existing `probe_success` and `node_systemd_unit_state` rules
-already cover "the service did not come back".
+state as node_exporter textfile metrics, recorded from `nixos-upgrade.service`'s
+`ExecStopPost` where `SERVICE_RESULT` is available - the same mechanism the restic backup
+metrics already use. No new services; the existing `probe_success` and
+`node_systemd_unit_state` rules already cover "the service did not come back".
+
+Three alerts, in ascending order of how badly they are needed:
+
+- `nixos_deploy_last_run_success == 0` - the upgrade failed. Largely redundant with the
+  existing failed-unit alert, but explicit and survives a restart of the unit.
+- `nixos_deploy_last_run_timestamp_seconds` older than 48h - **the host stopped
+  upgrading**. Nothing else catches this: no unit has failed, no probe is down, the
+  machine is simply falling behind in silence. This is the alert the whole exercise is
+  for.
+- `nixos_deploy_pending_reboot == 1` with a staged timestamp older than 26h - a
+  generation is built and staged but never activated.
+
+That third one exists because of what `nixos-upgrade` actually does. It runs
+`nixos-rebuild boot` first, then reboots only if the kernel changed *and* the clock is
+still inside the reboot window. A build that runs long - entirely plausible for a large
+nixpkgs bump on this hardware - pushes the clock past the window, at which point the unit
+prints `Outside of configured reboot window, skipping.` and **exits zero**. A host can sit
+on an unactivated kernel indefinitely while reporting success every night. Nothing in the
+original plan would have caught that.
+
+The duration is carried in a staged-timestamp metric rather than a long Prometheus `for:`
+clause, because Prometheus restarts on every deploy and a restart resets a pending alert's
+timer - a `for: 26h` on a daily-deploying host would never mature.
+
+Alert rules are validated by `promtool check rules` as a flake check, so a malformed rule
+fails the CI gate. Building a host proves its Nix evaluates, not that the config files it
+ships are valid; a bad rule builds perfectly and then takes Prometheus down on activation.
 
 **5. CI builds are shared through a binary cache.** CI pushes to Cachix; hosts substitute
 from it. Without this, the same closure is built four times - once in CI and once per host

--- a/flake.nix
+++ b/flake.nix
@@ -204,6 +204,27 @@
         import ./packages pkgs
       );
 
+      # Checks run by `nix flake check`, and therefore by the CI gate.
+      #
+      # Building a host proves its Nix evaluates, not that the config files it
+      # ships are valid. A malformed alert rule builds perfectly and then takes
+      # Prometheus down on activation, so validate it here where it is cheap.
+      checks = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          alert-rules =
+            # promtool lives in the `cli` output, not `out`.
+            pkgs.runCommand "check-alert-rules" { nativeBuildInputs = [ pkgs.prometheus.cli ]; }
+              ''
+                promtool check rules ${./modules/services/monitoring/alert-rules.yml}
+                touch $out
+              '';
+        }
+      );
+
       # Development shell for working on this config
       devShells = forAllSystems (system: {
         default = nixpkgs.legacyPackages.${system}.mkShell {

--- a/modules/services/monitoring/alert-rules.yml
+++ b/modules/services/monitoring/alert-rules.yml
@@ -272,6 +272,46 @@ groups:
           severity: warning
         annotations:
           summary: "Restic backup {{ $labels.job }} on {{ $labels.host }} hasn't run in over 26 hours"
+  - name: deploy
+    rules:
+      - alert: NixosDeployFailed
+        expr: nixos_deploy_last_run_success == 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "NixOS auto-upgrade failed on {{ $labels.host }}"
+          description: "The last nixos-upgrade run exited non-zero. The host keeps running its previous generation, so nothing is broken yet — but it has stopped receiving updates."
+
+      # The one that catches silence. A host that stops upgrading raises nothing
+      # at all otherwise: no failed unit, no failed probe, just a machine
+      # quietly falling behind. Only arms once a first run has been recorded.
+      - alert: NixosDeployStale
+        expr: time() - nixos_deploy_last_run_timestamp_seconds > 172800
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "NixOS auto-upgrade has not run on {{ $labels.host }} in over 48 hours"
+          description: "Neither a success nor a failure has been recorded. The timer, the network, the flake ref or the host itself has stopped."
+
+      # nixos-upgrade stages a generation with `nixos-rebuild boot`, then reboots
+      # only if the kernel changed AND the clock is still inside the reboot
+      # window. A long build pushes it past the window, and the unit reports
+      # success while the new kernel never activates.
+      #
+      # Deliberately not expressed as `for: 26h`: Prometheus restarts on every
+      # deploy, which resets a pending alert's timer, so a long `for` would
+      # never mature. The staged timestamp carries the duration instead.
+      - alert: NixosRebootPending
+        expr: nixos_deploy_pending_reboot == 1 and time() - nixos_deploy_staged_timestamp_seconds > 93600
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.host }} has a generation staged but not activated for over 26 hours"
+          description: "A new kernel is staged and waiting for a reboot that has not happened — most likely the build ran past the configured reboot window, which nixos-upgrade reports as success."
+
   - name: vpn
     rules:
       - alert: GluetunVpnDisconnected

--- a/modules/services/monitoring/deploy-metrics.nix
+++ b/modules/services/monitoring/deploy-metrics.nix
@@ -1,0 +1,165 @@
+# modules/services/monitoring/deploy-metrics.nix
+#
+# Exports deployment state as node_exporter textfile metrics (ADR 0001).
+#
+# The pull model's characteristic failure is silence: a host that quietly stops
+# upgrading looks identical to a host with nothing to do. Prometheus already
+# alerts on failed systemd units and on unreachable HTTP endpoints, so what is
+# missing is evidence that the deployment mechanism itself is still running.
+#
+# Three things are worth knowing about a host, and none of them are visible
+# today:
+#
+#   - when it last completed an upgrade run at all (staleness)
+#   - whether that run succeeded
+#   - whether a generation is staged but not yet activated
+#
+# That last one matters more than it looks. `nixos-upgrade` runs
+# `nixos-rebuild boot` first, then reboots only if the kernel changed *and* the
+# clock is inside the reboot window. If the build runs long enough to push the
+# clock past that window, the unit prints "Outside of configured reboot window,
+# skipping." and exits zero - so a host can sit on an unactivated kernel
+# indefinitely while reporting success every single night.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.cg.service.monitoring.deploy;
+
+  metricsDir = "/var/lib/prometheus-node-exporter";
+  metricsFile = "${metricsDir}/nixos_deploy.prom";
+  stateDir = "/var/lib/nixos-deploy";
+  stateFile = "${stateDir}/last-run";
+
+  host = config.networking.hostName;
+
+  # Baked in at build time, so this reports the revision of the generation that
+  # is actually *running* the script - not whatever happens to be staged.
+  revision = if config.system.configurationRevision != null then config.system.configurationRevision else "unknown";
+
+  metricsScript = pkgs.writeShellScript "nixos-deploy-metrics" ''
+      set -uo pipefail
+
+      METRICS_DIR="${metricsDir}"
+      METRICS_FILE="${metricsFile}"
+      STATE_DIR="${stateDir}"
+      STATE_FILE="${stateFile}"
+      mkdir -p "$METRICS_DIR" "$STATE_DIR"
+
+      # SERVICE_RESULT is set by systemd for ExecStopPost, so its presence means
+      # this invocation is recording the outcome of an upgrade run. When it is
+      # empty we are only re-rendering (at boot, or on the timer) and must not
+      # overwrite the recorded verdict with a fabricated one.
+      if [ -n "''${SERVICE_RESULT:-}" ]; then
+        if [ "$SERVICE_RESULT" = "success" ]; then
+          printf '%s %s\n' "$(date +%s)" 1 > "$STATE_FILE"
+        else
+          printf '%s %s\n' "$(date +%s)" 0 > "$STATE_FILE"
+        fi
+      fi
+
+      # Same comparison nixos-upgrade makes: a staged generation only needs a
+      # reboot when the kernel, initrd or modules differ from what is booted.
+      booted="$(readlink /run/booted-system/{initrd,kernel,kernel-modules} 2>/dev/null || true)"
+      built="$(readlink /nix/var/nix/profiles/system/{initrd,kernel,kernel-modules} 2>/dev/null || true)"
+      if [ -n "$booted" ] && [ "$booted" = "$built" ]; then
+        PENDING=0
+      else
+        PENDING=1
+      fi
+
+      # mtime of the profile symlink itself - when this generation was staged.
+      STAGED_TS="$(stat -c %Y /nix/var/nix/profiles/system 2>/dev/null || echo 0)"
+
+      TMP="$METRICS_FILE.tmp"
+
+      cat > "$TMP" <<EOF
+    # HELP nixos_deploy_pending_reboot Whether a staged generation needs a reboot to activate
+    # TYPE nixos_deploy_pending_reboot gauge
+    nixos_deploy_pending_reboot{host="${host}"} $PENDING
+    # HELP nixos_deploy_staged_timestamp_seconds Unix timestamp the current system generation was staged
+    # TYPE nixos_deploy_staged_timestamp_seconds gauge
+    nixos_deploy_staged_timestamp_seconds{host="${host}"} $STAGED_TS
+    # HELP nixos_deploy_revision_info Flake revision of the running system
+    # TYPE nixos_deploy_revision_info gauge
+    nixos_deploy_revision_info{host="${host}",revision="${revision}"} 1
+    EOF
+
+      # Emitted only once an upgrade run has actually been recorded. A host that
+      # has never completed one has no meaningful "last run", and seeding these
+      # with zeroes would fire the staleness alert on day one for every host.
+      if [ -r "$STATE_FILE" ]; then
+        read -r LAST_TS LAST_OK < "$STATE_FILE" || true
+        if [ -n "''${LAST_TS:-}" ] && [ -n "''${LAST_OK:-}" ]; then
+          cat >> "$TMP" <<EOF
+    # HELP nixos_deploy_last_run_timestamp_seconds Unix timestamp of the last nixos-upgrade run
+    # TYPE nixos_deploy_last_run_timestamp_seconds gauge
+    nixos_deploy_last_run_timestamp_seconds{host="${host}"} $LAST_TS
+    # HELP nixos_deploy_last_run_success Whether the last nixos-upgrade run succeeded (1=success, 0=failure)
+    # TYPE nixos_deploy_last_run_success gauge
+    nixos_deploy_last_run_success{host="${host}"} $LAST_OK
+    EOF
+        fi
+      fi
+
+      # Atomic swap: node_exporter reads this directory continuously and a
+      # half-written file is a parse error rather than a missing metric.
+      mv "$TMP" "$METRICS_FILE"
+  '';
+in
+{
+  options.cg.service.monitoring.deploy = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = config.system.autoUpgrade.enable;
+      description = ''
+        Export deployment state (last run, success, pending reboot, revision)
+        as node_exporter textfile metrics. Defaults on wherever
+        `system.autoUpgrade` is enabled, since that is exactly where a silent
+        deployment failure is possible.
+      '';
+    };
+  };
+
+  config = lib.mkIf (config.cg.service.monitoring.enable && cfg.enable) {
+    # Overrides the mkDefault in monitoring.nix, which otherwise leaves the
+    # textfile collector off on any host without ZFS or the VPN - homelab01.
+    cg.service.monitoring.textfileCollector.enable = true;
+
+    systemd.tmpfiles.rules = [
+      "d ${metricsDir} 0755 root root -"
+      "d ${stateDir} 0755 root root -"
+    ];
+
+    # Runs on both success and failure, with SERVICE_RESULT set. In the reboot
+    # path `shutdown -r +1` returns immediately, so the unit still finishes and
+    # this still records the run before the machine goes down.
+    systemd.services.nixos-upgrade = lib.mkIf config.system.autoUpgrade.enable {
+      serviceConfig.ExecStopPost = [ metricsScript ];
+    };
+
+    systemd.services.nixos-deploy-metrics = {
+      description = "Export NixOS deployment metrics for Prometheus";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = metricsScript;
+      };
+    };
+
+    # Keeps pending_reboot and the running revision honest after a manual
+    # `nixos-rebuild`, which is otherwise invisible until the next boot.
+    systemd.timers.nixos-deploy-metrics = {
+      description = "Timer for NixOS deployment metrics";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "2min";
+        OnUnitActiveSec = "15min";
+        Unit = "nixos-deploy-metrics.service";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Phase 4 of ADR 0001.

## The gap

Prometheus already alerts on failed systemd units and unreachable HTTP endpoints, so a deploy that *breaks* something is visible. A host that quietly **stops deploying** is not: no unit fails, no probe drops, the machine simply falls behind while everything looks green. That silence is the pull model's characteristic failure.

## What lands

Deployment state as node_exporter textfile metrics, recorded from `nixos-upgrade.service`'s `ExecStopPost` where `SERVICE_RESULT` is available — the same mechanism `modules/services/backup.nix` already uses for restic.

| Metric | Answers |
|---|---|
| `nixos_deploy_last_run_timestamp_seconds` | when did this host last try |
| `nixos_deploy_last_run_success` | did it work |
| `nixos_deploy_pending_reboot` | is a generation staged but not running |
| `nixos_deploy_staged_timestamp_seconds` | since when |
| `nixos_deploy_revision_info{revision}` | what is actually running |

Three alerts, in ascending order of how badly they are needed: upgrade failed (largely redundant with the existing failed-unit alert), **no run in 48h** (nothing else catches this — it is what the exercise is for), and a generation staged but unactivated for 26h.

## The alert I did not plan for

Reading what `nixos-upgrade` actually generates turned up a real silent-failure mode. It runs `nixos-rebuild boot` first, then reboots only if the kernel changed **and** the clock is still inside the reboot window:

```bash
if [ "${booted}" = "${built}" ]; then
  nixos-rebuild switch --refresh --flake ...
elif [ "${do_reboot}" != true ]; then
  echo "Outside of configured reboot window, skipping."
else
  shutdown -r +1
fi
```

A build that runs long — plausible for a large nixpkgs bump on this hardware — pushes the clock past the 04:00–05:00 window. The unit then prints that message and **exits zero**. A host can sit on an unactivated kernel indefinitely while reporting success every single night. `NixosRebootPending` covers it.

## Two details worth reviewing

**The pending duration is a metric, not a `for:` clause.** Prometheus restarts on every deploy, which resets a pending alert's timer, so `for: 26h` on a daily-deploying host would never mature. The staged timestamp carries the duration instead.

**`last_run_*` are omitted until a run is recorded.** Seeding them with zeroes would fire `NixosDeployStale` on day one for every host. The trade-off: a host that has *never* completed an upgrade stays silent. The other metrics still prove the exporter is alive.

## Also

Enables the textfile collector on **homelab01**, where it was silently off — it defaults to `zfs.enable || vpn.enable`, and homelab01 runs neither. The tmpfiles rule creating the directory also lived inside the ZFS block.

`promtool check rules` now runs as a flake check. Building a host proves its Nix evaluates, not that the config files it ships are valid — a malformed alert rule builds perfectly and then takes Prometheus down on activation.

## Verification

The generated script was run against redirected paths through all four paths:

| Run | Expected | Result |
|---|---|---|
| boot render, nothing recorded | no `last_run_*` series | ✓ |
| `SERVICE_RESULT=success` | success recorded | ✓ |
| `SERVICE_RESULT=exit-code` | failure recorded | ✓ |
| plain re-render | **verdict preserved, not fabricated** | ✓ |

Output passes `promtool check metrics` with no lint warnings. `nix flake check` was confirmed to fail on a deliberately malformed rule, so the guard is not vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)