### PR TITLE
docs: explain the pipeline, and sketch what it still lacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,127 +1,195 @@
 # Cory's NixOS Configuration
 
-A modular NixOS configuration using flakes and home-manager.
+A three-machine NixOS fleet — two homelab servers and a laptop — deployed from this
+repository through a gated GitOps pipeline.
 
-## Structure
+Every machine runs a configuration built and proven by CI before it was allowed to reach
+them. Nothing is applied by hand, nothing is deployed from a developer's laptop, and a
+host that quietly stops updating raises an alert rather than drifting unnoticed.
 
-```
-dotfiles/
-├── flake.nix              # Main entry point
-├── hosts/                 # Per-machine configurations
-│   └── xps15/
-│       ├── default.nix    # Host configuration
-│       ├── hardware.nix   # Hardware-specific settings
-│       ├── home.nix       # User's home-manager config
-│       └── thermald-conf.xml
-├── modules/               # Reusable modules
-│   ├── nixos/             # System-level modules
-│   └── home/              # Home-manager modules
-│       ├── shell/         # Shell tools (starship, zellij)
-│       ├── desktop/       # Desktop environment (hyprland, waybar)
-│       ├── development/   # Dev tools (nvim, git)
-│       ├── terminals/     # Terminal emulators
-│       └── media/         # Media applications
-├── configs/               # Portable configuration files
-│   ├── nvim/              # Neovim configuration
-│   ├── zellij/            # Zellij configuration
-│   ├── starship/          # Starship prompt
-│   └── ...
-├── overlays/              # Package overlays
-├── packages/              # Custom package definitions
-├── secrets/               # SOPS-encrypted secrets
-└── wallpapers/            # Wallpaper images
+The reasoning behind the design, including the alternatives that were rejected and why,
+is in [ADR 0001](docs/adr/0001-gitops-deployment-with-a-promoted-ref.md).
+
+## How a change reaches a machine
+
+```mermaid
+flowchart LR
+    A[branch] --> B[pull request]
+    B --> C{"nixos ci<br/>builds all 3 hosts"}
+    C -->|fails| B
+    C -->|passes| D[master]
+    D -->|CI fast-forwards| E[deploy]
+    E --> F[homelab01<br/>04:00]
+    E --> G[xps15<br/>on click]
+    E -->|24h lag| H[deploy-stable]
+    H --> I[homelab02<br/>04:15]
 ```
 
-## Usage
+`master` is the integration branch and may be red. **`deploy` is the fleet's contract** —
+CI fast-forwards it only after every host configuration builds, so a host can never fetch
+a revision that fails to build for it.
 
-### Build and switch
+| Ref | Followed by | Takes a revision |
+| --- | --- | --- |
+| `deploy` | homelab01, xps15 | the night it is promoted |
+| `deploy-stable` | homelab02 | 24 hours later |
+
+The servers are not interchangeable. homelab02 holds the ZFS pool and exports the NFS
+storage homelab01 mounts, so it is the host whose failure cascades — it therefore takes
+each revision a day after homelab01 has been running it. A kernel that fails to boot takes
+out the compute node while the data node keeps serving.
+
+The laptop follows `deploy` too, but never switches on its own: it builds in the
+background and waits to be told, via a waybar indicator.
+
+## What runs on its own
+
+| Workflow | When | Does |
+| --- | --- | --- |
+| `ci.yml` | every PR and push to master | builds all three hosts, `nix flake check`, promotes `deploy` |
+| `flake-update.yml` | daily, 15:00 UTC | `nix flake update`, per-host closure diff, PR, auto-merge on green |
+| `promote-stable.yml` | daily, 19:30 UTC | fast-forwards `deploy-stable` to what `deploy` held 24h ago |
+| `package-update.yml` | Mondays, 03:00 UTC | runs each package's own updater, one PR per package |
+
+CI builds are pushed to a [Cachix](https://cachix.org) cache that the hosts substitute
+from, so a closure is built once rather than once per machine.
+
+Lock updates auto-merge when green. Package updates do not — they cross an upstream
+release boundary, where "it built" is the weakest form of evidence.
+
+## What happens when something breaks
+
+Deployment state is exported as node_exporter textfile metrics and alerted on through the
+existing Prometheus and Alertmanager stack:
+
+| Alert | Catches |
+| --- | --- |
+| `NixosDeployFailed` | the upgrade ran and failed |
+| `NixosDeployStale` | **no upgrade has run in 48 hours** |
+| `NixosRebootPending` | a generation is staged but never activated |
+
+The middle one is the point of the exercise. A host that stops upgrading raises nothing
+else — no unit fails, no probe drops, it simply falls behind in silence.
+
+The last one exists because `nixos-upgrade` runs `nixos-rebuild boot` and then reboots
+*only* if the kernel changed and the clock is still inside the reboot window. A build that
+runs long pushes it past that window, and the unit reports success while the new kernel
+never activates.
+
+Existing rules already cover services that fail to come back (`node_systemd_unit_state`)
+and endpoints that stop responding (`probe_success` via blackbox).
+
+## Working on it
 
 ```bash
+# Iterate on a server without a commit, a push, or a CI round-trip
+nixos-rebuild switch --flake .#homelab01 \
+  --target-host root@homelab01 --build-host root@homelab01
+
+# Pull the promoted revision now rather than waiting for 04:00
+ssh homelab01 sudo systemctl start nixos-upgrade.service
+
+# Local machine, from the working tree
 sudo nixos-rebuild switch --flake .#xps15
 ```
 
-### Update flake inputs
+`flake.lock` is CI's to move — running `nix flake update` by hand only creates a conflict
+with the nightly PR.
 
-```bash
-nix flake update
-```
+Direct pushes to `master` are rejected; changes go through a pull request. Never create a
+branch under `deploy/` or `deploy-stable/` — git stores refs as paths, so it would turn
+those refs into directories and break promotion. A ruleset blocks this.
 
-### Add a new host
+### Adding a host
 
-1. Create `hosts/hostname/` directory
-2. Copy and modify `default.nix`, `hardware.nix`, `home.nix` from an existing host
-3. Add to `flake.nix`:
+1. Create `hosts/<hostname>/` with `default.nix`, `hardware.nix` and `home.nix`
+2. Register it in `flake.nix` under `nixosConfigurations`
+3. Add it to the `build` matrix in `.github/workflows/ci.yml` — a host that CI does not
+   build is a host the gate does not protect
 
-   ```nix
-   nixosConfigurations.hostname = mkHost {
-     hostname = "hostname";
-     system = "x86_64-linux";
-   };
-   ```
+### Adding an auto-updating package
 
-## Module System
-
-### Enabling modules
-
-In `hosts/hostname/default.nix` (NixOS modules):
+Packages pinned to an upstream tag or an npm version do not move when the lock does.
+Declare an updater on the package itself:
 
 ```nix
+passthru = {
+  autoUpdate = true;
+  updateScript = [ "packages/<name>/update.sh" ];
+};
+```
+
+`updateScript` is an argv list run from the repository root. It mutates the working tree,
+prints **nothing** when already current, and on a change prints a one-line summary first.
+`package-update.yml` discovers anything with `autoUpdate` set, so adding a package means
+editing the package, not the workflow.
+
+Participation is an explicit flag rather than the presence of `updateScript` because
+nixpkgs' `buildPythonApplication` sets a default one of its own.
+
+## Repository layout
+
+```
+dotfiles/
+├── flake.nix              # Entry point: hosts, packages, checks, overlays
+├── hosts/                 # Per-machine configuration
+│   ├── homelab01/         # Compute + streaming
+│   ├── homelab02/         # Storage + download (ZFS, NFS export)
+│   └── xps15/             # Laptop
+├── modules/
+│   ├── nixos/             # System-level modules
+│   ├── services/          # Homelab service modules (auto-imported)
+│   └── home/              # Home-manager modules
+├── configs/               # Portable dotfiles, symlinked by home-manager
+├── overlays/              # Package overlays
+├── packages/              # Custom package definitions
+├── secrets/               # SOPS-encrypted secrets
+└── docs/adr/              # Architecture decision records
+```
+
+Modules follow a consistent shape and are toggled per host:
+
+```nix
+# hosts/<host>/default.nix
 cg = {
   hyprland.enable = true;
   nvidia.enable = true;
-  # ...
+};
+
+cg.service = {
+  monitoring.enable = true;
 };
 ```
-
-In `hosts/hostname/home.nix` (Home-manager modules):
-
-```nix
-cg.home = {
-  nvim.enable = true;
-  zellij.enable = true;
-  # ...
-};
-```
-
-### Creating a new module
-
-1. Create the module file in the appropriate directory
-2. Add to the relevant `default.nix` imports
-3. Follow the pattern:
 
 ```nix
 { config, lib, pkgs, ... }:
 let
-  cfg = config.cg.home.modulename;
-in {
-  options.cg.home.modulename.enable = lib.mkEnableOption "Module description";
+  cfg = config.cg.<name>;
+in
+{
+  options.cg.<name>.enable = lib.mkEnableOption "description";
 
   config = lib.mkIf cfg.enable {
-    # Configuration here
+    # ...
   };
 }
 ```
 
-## Portable Configurations
+Everything under `modules/services/` is imported automatically, so a new service module
+only needs the file.
 
-Configuration files in `configs/` are designed to work on non-NixOS systems.
-They are symlinked by home-manager using `xdg.configFile`.
+## Secrets
 
-To use on a non-NixOS system, simply copy or symlink the relevant directories
-to your `~/.config/`.
+[sops-nix](https://github.com/Mic92/sops-nix) with age keys derived from each host's SSH
+host key, so a host can decrypt only what it is granted.
 
-## Secrets Management (TODO)
+```bash
+age-keygen -o ~/.config/sops/age/keys.txt   # generate a key
+ssh-to-age < /etc/ssh/ssh_host_ed25519_key.pub   # derive a host's key
+sops secrets/homelab.yaml                   # edit
+```
 
-This configuration uses [sops-nix](https://github.com/Mic92/sops-nix) for secrets management.
-
-Setup:
-
-1. Generate an age key: `age-keygen -o ~/.config/sops/age/keys.txt`
-2. Add the public key to `secrets/.sops.yaml`
-3. Encrypt secrets: `sops secrets/secrets.yaml`
-4. Enable sops in your host configuration
-
-## Homelab Infrastructure
+## Homelab infrastructure
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -161,3 +229,21 @@ Setup:
 │  Storage: /srv/media (NFS mount from homelab02)                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
+
+## Known gaps
+
+Stated plainly, because a pipeline whose limits are undocumented invites more trust than
+it has earned:
+
+- **Building is the only pre-deploy gate, and building is not working.** A package that
+  compiles and then fails at runtime will auto-merge and deploy. The alert rules catch it
+  afterwards. NixOS VM tests are the intended fix — see
+  [the hardening plan](docs/plans/deployment-hardening.md).
+- **There is no automated rollback.** A bad deploy is recovered by fixing forward, or by
+  selecting an older generation at the boot menu. Options are sketched in the same plan.
+- **The `deploy-stable` lag is time-based, not health-based.** It establishes that
+  homelab01 has *had* a revision for 24 hours, not that homelab01 is well.
+- **The canary soak is weaker for host-specific packages.** A ZFS or qBittorrent
+  regression will not surface on homelab01, which runs neither. What it does exercise is
+  the shared base — kernel, systemd, nix, glibc — which is where an unattended update does
+  catastrophic rather than annoying damage.

--- a/docs/plans/deployment-hardening.md
+++ b/docs/plans/deployment-hardening.md
@@ -1,0 +1,225 @@
+# Plan: hardening the deployment pipeline
+
+Status: sketch, not yet started. Follows on from
+[ADR 0001](../adr/0001-gitops-deployment-with-a-promoted-ref.md), which built the pipeline
+and named these as its known gaps.
+
+Three pieces, in the order they are worth doing:
+
+1. **Behaviour tests** — turn the gate from "it builds" into "it works"
+2. **Rollback** — recover from a bad deploy without a keyboard in front of the machine
+3. **An operational writeup** — after the thing has run long enough to have a history
+
+---
+
+## 1. Behaviour tests
+
+### The problem
+
+The gate builds every host configuration and validates the Prometheus rules. That proves
+the Nix evaluates and the derivations realise. It proves nothing about whether Jellyfin
+starts, whether Caddy routes to it, or whether the NFS mount comes up.
+
+This is the single largest gap in the pipeline. Unattended nixpkgs-unstable bumps reach
+the servers with only a compile-time gate, and the first signal that something is broken
+is an alert firing after it has already deployed.
+
+### Approach
+
+`pkgs.testers.runNixOSTest` boots real VMs and asserts against them. Exposed as flake
+`checks`, so `nix flake check` runs them and the existing `nixos ci` gate picks them up
+with no workflow changes.
+
+**Test modules, not hosts.** A whole host configuration will not boot in a VM — disko
+expects real disks, ZFS expects a pool, sops expects host keys, homelab01 expects an NFS
+server. Instantiate the *service module* in a minimal machine instead, with secrets
+stubbed.
+
+```nix
+# checks/media-stack.nix (sketch)
+testers.runNixOSTest {
+  name = "media-stack";
+
+  nodes.machine = {
+    imports = [ ../modules/services/media-stack ];
+
+    cg.service.media-stack = {
+      enable = true;
+      # point at tmpfs rather than the NFS mount
+    };
+
+    # sops cannot decrypt in a VM; hand the modules plain files instead
+    cg.testing.stubSecrets = true;
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_unit("sonarr.service")
+    machine.wait_for_open_port(8989)
+    machine.succeed("curl -sf http://localhost:8989/ >/dev/null")
+  '';
+}
+```
+
+The secret stubbing is the part that needs designing rather than typing. Options:
+
+- a `cg.testing.stubSecrets` flag on the sops module that swaps
+  `config.sops.secrets.<x>.path` for a `pkgs.writeText` fixture — invasive, but keeps the
+  test honest about which secrets a module consumes;
+- per-test `sops.secrets` overrides pointing at fixtures — no production code changes, but
+  each test has to know the secret names;
+- `sops.age.keyFile` set to a committed throwaway key with a fixture secrets file — the
+  most realistic, and exercises the sops wiring itself.
+
+The third is the most faithful and the most work. Start with the second and see whether
+the duplication actually hurts.
+
+### Candidates, in order of value
+
+| Test | Asserts | Why it earns its place |
+| --- | --- | --- |
+| `reverse-proxy` | Caddy starts, routes to a stub backend, serves 200 | every public service depends on it; a routing regression is invisible to a build |
+| `monitoring` | Prometheus starts, loads rules, scrapes a target | rule and config errors only surface at activation |
+| `digital-garden` | quartz builds a vault and the result is served | the failure mode is a *successful* build and an empty site |
+| `media-stack` | the arr services reach their ports | the largest module, and the one with the most moving parts |
+
+`digital-garden` is the most valuable per line: it is the one place where the current gate
+is actively misleading, because a broken plugin index produces a build that succeeds.
+
+### Cost and risks
+
+- **KVM.** NixOS tests need it. GitHub's free runners have historically been inconsistent
+  here, though the `nix-installer-action` already in use enables KVM when available. Verify
+  early with a single trivial test — if it falls back to TCG emulation the tests still run,
+  just slowly enough to matter.
+- **Runtime.** Minutes per test, in parallel matrix jobs. Acceptable for a nightly gate;
+  worth watching if it starts delaying the lock PR's auto-merge.
+- **Maintenance.** A VM test that is flaky is worse than no test, because it trains you to
+  re-run the gate. Prefer few, sharp assertions over broad ones.
+
+---
+
+## 2. Rollback
+
+### The problem
+
+A bad deploy currently has no automated recovery. If a service breaks, the alert fires and
+you fix forward. If the machine does not boot, you need physical access to a box in a
+cupboard.
+
+Worth separating three distinct failure modes, because they need different answers:
+
+| Failure | Current recovery | Gap |
+| --- | --- | --- |
+| does not boot | boot menu, physically | needs a keyboard on the machine |
+| boots, service broken | alert, then fix forward | slow; degraded the whole time |
+| boots, network broken | physical access | no remote path at all |
+
+### Layer 0 — health-gate the canary (prevention, cheapest)
+
+`promote-stable.yml` currently advances `deploy-stable` on elapsed time alone. The
+deployment metrics from phase 4 already say whether homelab01 is well. Gate on them:
+
+- query Prometheus for `nixos_deploy_last_run_success{host="homelab01"}` and
+  `nixos_deploy_pending_reboot{host="homelab01"}` for the target revision
+- refuse to promote if homelab01 is unhealthy, and alert instead
+
+This is the highest value per unit of work in this document. It turns the canary from "has
+had it for 24h" into "has had it for 24h *and is fine*", which is what a canary is supposed
+to mean. It needs Prometheus reachable from CI, which is the real obstacle — either an
+authenticated endpoint through the existing Cloudflare tunnel, or a small pushed summary
+the workflow can read without inbound access.
+
+### Layer 1 — boot counting (does not boot)
+
+`boot.loader.systemd-boot.bootCounting` implements
+[systemd's Automatic Boot Assessment](https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/): a
+new entry is written with a counter, systemd-boot decrements it each attempt, and once the
+system reaches `boot-complete.target`, `systemd-bless-boot.service` marks the entry good.
+An entry that exhausts its tries is skipped in favour of an older generation.
+
+All three hosts already use systemd-boot, so this is close to free:
+
+```nix
+boot.loader.systemd-boot.bootCounting = {
+  enable = true;
+  tries = 3;
+};
+```
+
+This is the native answer to the unattended-kernel-bump risk that motivated the canary in
+the first place, and it works without anyone being present.
+
+Worth understanding before enabling: `boot-complete.target` is reached once the boot
+succeeds, *not* once services are healthy. It protects against a kernel that will not boot,
+not against one that boots into a broken userspace. Layer 2 covers that.
+
+### Layer 2 — health-gated activation (boots, service broken)
+
+After a switch, verify and revert if the system is unhealthy:
+
+```
+nixos-upgrade.service
+  └─ ExecStartPost: nixos-upgrade-verify
+       ├─ systemctl is-system-running --wait   (degraded ⇒ fail)
+       ├─ probe the host's own critical units
+       └─ on failure: nix-env -p /nix/var/nix/profiles/system --rollback
+                      && /run/current-system/bin/switch-to-configuration switch
+```
+
+Notes:
+
+- `systemctl is-system-running` returning `degraded` is a good, cheap, generic signal — it
+  is exactly what the existing `node_systemd_unit_state` alert keys off, evaluated
+  immediately instead of five minutes later.
+- The check must be *conservative*. A rollback loop caused by an over-eager health check is
+  worse than the degradation it is protecting against. Give services time to settle, and
+  roll back only on unambiguous failure.
+- A rollback must alert loudly. Silently reverting means the host stops tracking `deploy`
+  and then trips `NixosDeployStale` two days later with a confusing message.
+- This cannot recover a network-level mistake, since the verification runs on the host
+  itself and a machine that has lost its network still thinks it is fine.
+
+### Layer 3 — deploy-rs for the network case (optional)
+
+The one failure this does not cover is locking yourself out — a firewall or interface
+change that leaves the machine up but unreachable. `deploy-rs`'s magic rollback is the
+established answer: it activates, waits for a confirmation *over the new configuration*,
+and reverts if the confirmation never arrives.
+
+It was rejected as the primary mechanism in ADR 0001 because it is push-based and would
+reintroduce the dependency on an operator's machine being online. But it could be adopted
+narrowly, for exactly this case, without disturbing the pull model — for instance
+homelab01 deploying homelab02, since the two already have SSH between them and the
+storage node is the one worth protecting.
+
+That is a real increase in moving parts for one failure mode. Worth doing only after
+actually being locked out once, or before a change that is obviously risky.
+
+### Suggested order
+
+1. Boot counting — one option, native, covers the catastrophic case
+2. Health-gated activation — moderate work, covers the common case
+3. Health-gated canary promotion — highest value, blocked on Prometheus reachability
+4. deploy-rs — only if the network case bites
+
+---
+
+## 3. Operational writeup
+
+After the pipeline has run for a month or so, write up what actually happened: what broke,
+what the alerts caught, what they missed, what was tuned and why.
+
+The value is not the incidents themselves but the evidence of operating something over
+time rather than building it and walking away. `docs/recovery-2026-07-25-qbittorrent-reconciliation.md`
+is already an example of this done well — a real incident, a real root cause, and the
+reasoning about what to change.
+
+Candidate material already visible:
+
+- whether `NixosDeployStale` ever fired, and whether 48h was the right threshold
+- whether the reboot window is actually wide enough for a large nixpkgs bump, which is the
+  failure `NixosRebootPending` was written to catch
+- how often the lock update produced a genuinely empty closure diff, i.e. whether daily is
+  the right cadence
+- whether the 24h canary lag ever mattered


### PR DESCRIPTION
Two documents, no code.

## `README.md`

The reasoning behind the pipeline was spread across ADR 0001 and nine pull requests. Someone evaluating the repository — or me in six months — should not have to reconstruct it from git history.

Leads with **how a change reaches a machine** (mermaid diagram of branch → gate → `deploy` → hosts), then what runs unattended, then what happens when something breaks. Keeps the existing homelab topology diagram and module documentation.

Ends with **Known gaps**, stated plainly: build-only gate, no automated rollback, time-based rather than health-based canary lag, and the fact that the soak is weaker for host-specific packages than for the shared base. A pipeline whose limits are undocumented invites more trust than it has earned.

## `docs/plans/deployment-hardening.md`

Sketch — not started — for the three gaps ADR 0001 named.

**Behaviour tests.** `runNixOSTest` against *service modules*, not whole hosts: disko wants real disks, ZFS wants a pool, sops wants host keys, homelab01 wants an NFS server. Exposed as flake `checks` so the existing gate picks them up with no workflow change. Three options sketched for stubbing secrets, which is the part needing design rather than typing. `digital-garden` is flagged as the highest value per line, because it is the one place the current gate is actively misleading — a broken plugin index produces a build that *succeeds*.

**Rollback, layered by failure mode** rather than as a single mechanism:

| Failure | Answer |
|---|---|
| does not boot | `boot.loader.systemd-boot.bootCounting` — native automatic boot assessment, one option away, all three hosts already use systemd-boot |
| boots, service broken | post-switch health check that reverts and alerts |
| boots, network broken | `deploy-rs` magic rollback, narrowly — e.g. homelab01 deploying homelab02 |

`deploy-rs` is deliberately *not* proposed wholesale: adopting it as the primary mechanism would reintroduce the operator-machine dependency the pull model exists to avoid. The plan also warns that an over-eager health check causing a rollback loop is worse than the degradation it guards against.

**Health-gating the canary** is called out as the highest value per unit of work. The phase 4 metrics already say whether homelab01 is well, so the 24h lag could mean "and is fine" rather than merely "has had it". Blocked on Prometheus being reachable from CI, which is a real obstacle given the pull model deliberately avoids inbound access.

**Operational writeup** once there is a history worth reporting, with candidate material listed (was 48h the right staleness threshold; is the reboot window wide enough for a large nixpkgs bump; how often the lock diff was genuinely empty).

## Note

`bootCounting` and `boot-complete.target` were verified present in the pinned nixpkgs, and all three hosts confirmed on systemd-boot, before being recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)