### PR TITLE
feat(reading): serve books, comics and audiobooks from Grimmory

### DIFF
--- a/hosts/homelab01/default.nix
+++ b/hosts/homelab01/default.nix
@@ -462,6 +462,16 @@
           localOnly = false; # listeners need external access for mobile apps
           rateLimitProfile = "media";
         };
+        # Runs on homelab02, where the library is on local disk rather than the
+        # NFS mount -- see the header of modules/services/media-stack/grimmory.nix.
+        # Proxied from here because homelab01 owns the Cloudflare tunnel.
+        grimmory = {
+          subdomain = "grimmory";
+          port = 6060;
+          upstream = "10.20.2.130"; # homelab02
+          localOnly = false; # readers need external access
+          rateLimitProfile = "media";
+        };
       };
     };
 
@@ -672,6 +682,7 @@
       services = lib.mapAttrs (name: svc: {
         subdomain = svc.subdomain;
         port = svc.port;
+        upstream = svc.upstream;
         localOnly = svc.localOnly;
       }) config.cg.service.reverse-proxy.services;
     };

--- a/hosts/homelab02/default.nix
+++ b/hosts/homelab02/default.nix
@@ -104,6 +104,12 @@
       extraExclude = [
         # cross-seed logs are ~1GB
         "/srv/arr/cross-seed/logs/**"
+
+        # Grimmory's live MariaDB datadir. Restic snapshots of a running
+        # database are torn and may not restore; grimmory-db-backup.timer
+        # writes a consistent dump to /srv/arr/grimmory/db-dump at 02:00,
+        # half an hour before the restic window, and that is what gets backed up.
+        "/srv/arr/grimmory/mariadb/databases/**"
       ];
 
       repositories = {
@@ -333,6 +339,18 @@
     };
 
     unpackerr.enable = true;
+
+    # -------------------------------------------------------------------------
+    # Reading Stack
+    # -------------------------------------------------------------------------
+    # Grimmory lives here rather than with the other reading services on
+    # homelab01, because it needs the library on local disk: over NFS it loses
+    # UI file operations and its BookDrop watcher stops firing. Caddy and the
+    # Cloudflare tunnel on homelab01 proxy across to it.
+    grimmory = {
+      enable = true;
+      diskType = "LOCAL"; # /srv/media is the local ZFS pool on this host
+    };
 
     # -------------------------------------------------------------------------
     # Services that stay on homelab01

--- a/modules/services/cloudflare-tunnel.nix
+++ b/modules/services/cloudflare-tunnel.nix
@@ -60,7 +60,17 @@ in
             };
             port = lib.mkOption {
               type = lib.types.port;
-              description = "Local port the service listens on";
+              description = "Port the service listens on";
+            };
+            upstream = lib.mkOption {
+              type = lib.types.str;
+              default = "localhost";
+              example = "homelab02";
+              description = ''
+                Host the service runs on. Defaults to this machine -- cloudflared
+                bypasses Caddy and connects to the origin directly, so a service
+                living on another node needs its hostname here too.
+              '';
             };
             localOnly = lib.mkOption {
               type = lib.types.bool;
@@ -114,7 +124,7 @@ in
             # Public services only (where localOnly = false)
             (lib.mapAttrsToList (name: svc: {
               hostname = "${svc.subdomain}.${cfg.domain}";
-              service = "http://localhost:${toString svc.port}";
+              service = "http://${svc.upstream}:${toString svc.port}";
               originRequest = {
                 httpHostHeader = "${svc.subdomain}.${cfg.domain}";
                 noTLSVerify = true;

--- a/modules/services/media-stack/grimmory.nix
+++ b/modules/services/media-stack/grimmory.nix
@@ -1,0 +1,322 @@
+# Grimmory - Unified Reading Server (ebooks, comics, audiobooks)
+# Serves EPUB/MOBI/AZW3/FB2, PDF, CBZ/CBR/CB7 and M4B/MP3 from one library,
+# with a browser reader, Kobo sync, KOReader progress sync and OPDS.
+#
+# SETUP AFTER DEPLOYMENT:
+# 1. Access web UI at http://homelab02:6060 (or https://grimmory.gyarmathy.co)
+# 2. Create an admin account on first launch
+# 3. Add libraries pointing at the in-container paths:
+#    - /books/books       (ebooks)
+#    - /books/comics      (comics)
+#    - /books/manga       (manga)
+#    - /books/audiobooks  (audiobooks)
+# 4. Point acquisition tooling at /srv/media/bookdrop for automatic import
+#
+# WHY THIS RUNS ON homelab02, NOT homelab01:
+# Grimmory disables all UI-initiated file operations (delete, move, rename) when
+# DISK_TYPE=NETWORK, and its BookDrop watcher relies on filesystem notifications
+# that do not fire reliably over NFS. homelab01 mounts /srv/media over NFS from
+# homelab02 (hosts/homelab01/default.nix, storage.type = "nfs"), so running it
+# there would cost both. On homelab02 the ZFS pool is local, so DISK_TYPE stays
+# LOCAL and inotify works. Caddy on homelab01 proxies across for external access.
+#
+# SCHEMA MIGRATIONS AND :latest:
+# Grimmory runs schema migrations against MariaDB on startup, so a new image can
+# change the database on first boot. That is not a reason to pin the tag: the
+# migration is one-way whenever it happens, so recovery means restoring a dump
+# either way, and a pinned tag only chooses the moment -- at the cost of never
+# actually updating. wallabag.nix runs Doctrine migrations on :latest for the
+# same reason. What does help is a *fresh* restore point, so grimmory-db-backup
+# runs before every start of the app, not just nightly. See BACKUPS below.
+#
+# WHY MARIADB IS A SIDECAR RATHER THAN A HOST SERVICE:
+# wallabag.nix shares homelab01's PostgreSQL because that server already exists
+# and serves several apps. homelab02 has no MySQL at all, so a host MariaDB would
+# exist solely for this one app -- no consolidation to gain, and it would need the
+# podman0 bridge plumbing wallabag needs. Upstream ships and tests this exact
+# image pairing, and keeping the pair together makes backup/restore one unit.
+#
+# BACKUPS:
+# Restic snapshots of a live MariaDB datadir are torn and may not restore. This
+# module therefore dumps the database to ${configPath}/grimmory/db-dump ahead of
+# the nightly backup window, and homelab02 excludes the raw datadir from restic.
+# The same dump also runs immediately before the app starts, so an image that
+# migrates the schema is always preceded by a restore point minutes old rather
+# than up to a day old.
+#
+# COEXISTENCE WITH KAVITA AND AUDIOBOOKSHELF:
+# All three are read-only consumers of the same directories, so they can run in
+# parallel indefinitely. Nothing here retires them.
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.cg.service.grimmory;
+  stack = config.cg.service.media-stack;
+in
+{
+  options.cg.service.grimmory = {
+    enable = lib.mkEnableOption "Grimmory reading server";
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 6060;
+      description = "Port for the Grimmory web UI";
+    };
+
+    mariadbTag = lib.mkOption {
+      type = lib.types.str;
+      default = "11.4.8";
+      description = ''
+        MariaDB image tag. Pinned on purpose -- see the comment on the container
+        below. Bump one major at a time, and read MariaDB's upgrade notes first.
+      '';
+    };
+
+    heapSize = lib.mkOption {
+      type = lib.types.str;
+      default = "1g";
+      description = ''
+        JVM maximum heap. The image defaults to roughly 512 MB, which is tight
+        once a large library's metadata is cached. homelab02 has 16 GB total and
+        already runs qBittorrent, Gluetun and cross-seed, so this is not free.
+      '';
+    };
+
+    diskType = lib.mkOption {
+      type = lib.types.enum [
+        "LOCAL"
+        "NETWORK"
+      ];
+      default = "LOCAL";
+      description = ''
+        Storage mode. NETWORK disables UI-initiated file operations (delete,
+        move, rename) to avoid destructive changes on shared mounts; reading,
+        metadata and sync are unaffected. Must be NETWORK if the library is on
+        an NFS/SMB mount rather than local disk.
+      '';
+    };
+
+    dbBackupTime = lib.mkOption {
+      type = lib.types.str;
+      default = "02:00";
+      description = ''
+        When to dump the database. Must land before the restic window
+        (cg.service.backup.repositories.*.schedule, 02:30) so the nightly
+        snapshot picks up a consistent dump.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = stack.enable;
+        message = "grimmory requires media-stack to be enabled (cg.service.media-stack.enable = true)";
+      }
+      {
+        # Catches the homelab01 footgun described in the header: pointing
+        # Grimmory at an NFS-mounted library while claiming it is local.
+        assertion = stack.storage.type != "nfs" || cfg.diskType == "NETWORK";
+        message = ''
+          grimmory: media-stack storage is NFS, so cg.service.grimmory.diskType
+          must be "NETWORK". Grimmory's file operations and BookDrop watcher are
+          not safe over a network mount.
+        '';
+      }
+    ];
+
+    sops.secrets = {
+      "media-stack/grimmory/db-password" = { };
+      "media-stack/grimmory/db-root-password" = { };
+    };
+
+    # Rendered at activation so the passwords never enter the Nix store, and
+    # passed to Podman via --env-file rather than into the container filesystem.
+    sops.templates = {
+      "grimmory-db-env" = {
+        content = ''
+          MYSQL_ROOT_PASSWORD=${config.sops.placeholder."media-stack/grimmory/db-root-password"}
+          MYSQL_DATABASE=grimmory
+          MYSQL_USER=grimmory
+          MYSQL_PASSWORD=${config.sops.placeholder."media-stack/grimmory/db-password"}
+        '';
+        mode = "0400";
+        restartUnits = [ "podman-grimmory-mariadb.service" ];
+      };
+
+      "grimmory-env" = {
+        content = ''
+          DATABASE_PASSWORD=${config.sops.placeholder."media-stack/grimmory/db-password"}
+        '';
+        mode = "0400";
+        restartUnits = [ "podman-grimmory.service" ];
+      };
+    };
+
+    systemd.tmpfiles.rules = [
+      "d ${stack.configPath}/grimmory 0775 ${stack.user} ${stack.group} -"
+      "d ${stack.configPath}/grimmory/data 0775 ${stack.user} ${stack.group} -"
+      "d ${stack.configPath}/grimmory/mariadb 0775 ${stack.user} ${stack.group} -"
+      # Dumps contain the whole database; keep them off the group-readable path.
+      "d ${stack.configPath}/grimmory/db-dump 0700 root root -"
+    ];
+
+    virtualisation.oci-containers.containers = {
+      grimmory-mariadb = {
+        # The database engine stays pinned even though the app tracks :latest.
+        # This is a different risk: MariaDB rewrites its datadir on a major
+        # upgrade and will not read it again on the older version, and majors
+        # must be crossed one at a time with mariadb-upgrade. A :latest that
+        # jumps 11.4 to 12.x is unrecoverable by restarting the old image,
+        # whereas an app migration is just a restore. Upstream pins it too.
+        image = "lscr.io/linuxserver/mariadb:${cfg.mariadbTag}";
+        environment = {
+          PUID = toString config.users.users.${stack.user}.uid;
+          PGID = toString config.users.groups.${stack.group}.gid;
+          TZ = config.time.timeZone;
+        };
+        environmentFiles = [ config.sops.templates."grimmory-db-env".path ];
+        volumes = [
+          "${stack.configPath}/grimmory/mariadb:/config"
+        ];
+        # No ports: reachable only as `grimmory-mariadb` on arr-network.
+        extraOptions = [
+          "--network=arr-network"
+        ];
+      };
+
+      grimmory = {
+        image = "ghcr.io/grimmory-tools/grimmory:latest";
+        environment = {
+          USER_ID = toString config.users.users.${stack.user}.uid;
+          GROUP_ID = toString config.users.groups.${stack.group}.gid;
+          TZ = config.time.timeZone;
+          DATABASE_URL = "jdbc:mariadb://grimmory-mariadb:3306/grimmory";
+          DATABASE_USERNAME = "grimmory";
+          DISK_TYPE = cfg.diskType;
+          SWAGGER_ENABLED = "false";
+          JDK_JAVA_OPTIONS = "-Xmx${cfg.heapSize}";
+        };
+        environmentFiles = [ config.sops.templates."grimmory-env".path ];
+        # Mounted per-library rather than handing over all of dataPath, so a
+        # reading server has no path to the movie and TV trees.
+        volumes = [
+          "${stack.configPath}/grimmory/data:/app/data"
+          "${stack.dataPath}/books:/books/books"
+          "${stack.dataPath}/comics:/books/comics"
+          "${stack.dataPath}/manga:/books/manga"
+          "${stack.dataPath}/lightnovels:/books/lightnovels"
+          "${stack.dataPath}/audiobooks:/books/audiobooks"
+          "${stack.dataPath}/bookdrop:/bookdrop"
+        ];
+        ports = [ "${toString cfg.port}:6060" ];
+        dependsOn = [ "grimmory-mariadb" ];
+        extraOptions = [
+          "--pull=newer"
+          "--network=arr-network"
+        ];
+      };
+    };
+
+    systemd.services = {
+      podman-grimmory-mariadb = {
+        after = [ "podman-network-arr.service" ];
+        requires = [ "podman-network-arr.service" ];
+      };
+
+      podman-grimmory = {
+        after = [ "podman-network-arr.service" ];
+        requires = [ "podman-network-arr.service" ];
+      };
+
+      # Consistent dump for restic to pick up -- see BACKUPS above.
+      #
+      # Ordered before the app as well as run nightly, so the dump also acts as
+      # the restore point for whatever schema migration the next :latest image
+      # brings. Wanted rather than required by podman-grimmory: a dump that
+      # cannot run is worth an alert, never a reason to keep the app down.
+      grimmory-db-backup = {
+        description = "Dump the Grimmory MariaDB database for backup";
+        after = [ "podman-grimmory-mariadb.service" ];
+        requires = [ "podman-grimmory-mariadb.service" ];
+        before = [ "podman-grimmory.service" ];
+        wantedBy = [ "podman-grimmory.service" ];
+
+        path = [
+          pkgs.podman
+          pkgs.gzip
+        ];
+
+        serviceConfig = {
+          Type = "oneshot";
+          # Deliberately no RemainAfterExit: this must run again on every
+          # restart of the app, not once per boot.
+          TimeoutStartSec = "5min";
+          LoadCredential = [
+            "db-password:${config.sops.secrets."media-stack/grimmory/db-password".path}"
+          ];
+        };
+
+        script = ''
+          set -euo pipefail
+
+          DEST=${stack.configPath}/grimmory/db-dump
+          DB_PASSWORD=$(cat "$CREDENTIALS_DIRECTORY/db-password")
+
+          # Podman reports the container started well before MariaDB accepts
+          # connections, and on the pre-start path it may have only just come
+          # up. Nothing to dump is also the normal state on a first ever boot.
+          for attempt in $(seq 60); do
+            if podman exec --env "MYSQL_PWD=$DB_PASSWORD" grimmory-mariadb \
+                 mariadb-admin --user=grimmory ping >/dev/null 2>&1; then
+              break
+            fi
+            if [ "$attempt" = 60 ]; then
+              echo "MariaDB did not accept connections within 120s; no dump taken"
+              exit 1
+            fi
+            sleep 2
+          done
+
+          # A crash-looping app would otherwise re-dump on every restart. Any
+          # dump taken in the last five minutes still predates the migration
+          # being guarded against, so it is just as good a restore point.
+          if [ -f "$DEST/grimmory.sql.gz" ] \
+             && [ -z "$(find "$DEST/grimmory.sql.gz" -mmin +5)" ]; then
+            echo "Dump from the last 5 minutes already exists, skipping"
+            exit 0
+          fi
+
+          # Write to a temporary file and rename, so restic can never snapshot a
+          # dump that is still being written.
+          podman exec -i \
+            --env "MYSQL_PWD=$DB_PASSWORD" \
+            grimmory-mariadb \
+            mariadb-dump --user=grimmory --single-transaction --quick grimmory \
+            | gzip > "$DEST/grimmory.sql.gz.tmp"
+
+          mv "$DEST/grimmory.sql.gz.tmp" "$DEST/grimmory.sql.gz"
+          echo "Dumped Grimmory database to $DEST/grimmory.sql.gz"
+        '';
+      };
+    };
+
+    systemd.timers.grimmory-db-backup = {
+      description = "Timer for the Grimmory database dump";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.dbBackupTime;
+        Persistent = true;
+        Unit = "grimmory-db-backup.service";
+      };
+    };
+
+    # Caddy and cloudflared on homelab01 proxy to this port across the LAN.
+    networking.firewall.allowedTCPPorts = [ cfg.port ];
+  };
+}

--- a/modules/services/media-stack/media-stack.nix
+++ b/modules/services/media-stack/media-stack.nix
@@ -46,7 +46,9 @@ in
           ├── books/
           ├── manga/
           ├── lightnovels/
-          └── comics/
+          ├── comics/
+          ├── audiobooks/
+          └── bookdrop/
       '';
     };
 
@@ -161,6 +163,11 @@ in
       "d ${cfg.dataPath}/comics 2775 ${cfg.user} ${cfg.group} -"
       "d ${cfg.dataPath}/manga 2775 ${cfg.user} ${cfg.group} -"
       "d ${cfg.dataPath}/lightnovels 2775 ${cfg.user} ${cfg.group} -"
+      # Audiobookshelf has always read this, but it was never declared here --
+      # it existed only because someone created it by hand.
+      "d ${cfg.dataPath}/audiobooks 2775 ${cfg.user} ${cfg.group} -"
+      # Watched ingest folder: drop a file here and Grimmory imports it.
+      "d ${cfg.dataPath}/bookdrop 2775 ${cfg.user} ${cfg.group} -"
       "d ${cfg.dataPath}/whisparr 2775 ${cfg.user} ${cfg.group} -"
     ];
 

--- a/modules/services/reverse-proxy.nix
+++ b/modules/services/reverse-proxy.nix
@@ -121,6 +121,9 @@ let
     {
       subdomain,
       port,
+      # Optional: host the service actually runs on. Defaults to this machine;
+      # set it to proxy a service hosted on another homelab node.
+      upstream ? "localhost",
       # Optional: restrict to local network only
       localOnly ? false,
       # Optional: rate limiting profile ("media", "admin", "none")
@@ -153,7 +156,7 @@ let
             respond @denied "Access denied" 403
           ''}
 
-          reverse_proxy localhost:${toString port} {
+          reverse_proxy ${upstream}:${toString port} {
             header_up Host {host}
             header_up X-Real-IP {remote_host}
             header_up X-Forwarded-For {remote_host}
@@ -197,7 +200,18 @@ in
             };
             port = lib.mkOption {
               type = lib.types.port;
-              description = "Local port the service listens on";
+              description = "Port the service listens on";
+            };
+            upstream = lib.mkOption {
+              type = lib.types.str;
+              default = "localhost";
+              example = "homelab02";
+              description = ''
+                Host the service runs on. Defaults to this machine. Set it to
+                another node's hostname or IP to proxy a service hosted there --
+                the traffic crosses the LAN in the clear, so only use it for
+                links inside the trusted network.
+              '';
             };
             localOnly = lib.mkOption {
               type = lib.types.bool;

--- a/secrets/secrets.yaml
+++ b/secrets/secrets.yaml
@@ -58,10 +58,12 @@ media-stack:
         username: ENC[AES256_GCM,data:5ZD1mJuc,iv:oGhy2ARMMsKUya2ubLZycm1Tz03lasQVSOi1EhhAiLA=,tag:gsNMD+7WX8PRwyDVgxthgw==,type:str]
         password: ENC[AES256_GCM,data:RzGwzYJIN2Zo9Y2spgPBScaoKOx7IZ0hdC4YAZwpKyNcVA==,iv:q/svrw8MJUNqHLMLmHYc0prCFWAPjVa0Onv8e2lYXZg=,tag:YQe29fuoGaKW6fWZklZyog==,type:str]
         token-key: ENC[AES256_GCM,data:C1s4/GvsdxWHwjtJafFK4j9XGZ4Z45vKLLZUwxg8zfY/I0wRpZ43qhHnssgmvaM+hING+Fsdw+67Hq+OKq4w3WIpEouBXnc4CVxP6Z/JFcI1ebk8IVAVnw==,iv:gljLE+Q1eVFRqYtO6eKasR4tpcgDcBfObHy3oHznQdE=,tag:tnvHXffGD8+qKF/c5zP4zQ==,type:str]
+    grimmory:
+        db-password: ENC[AES256_GCM,data:ibRUlurYTqpkSu07adU7/c6/h/YkoSnfYLbXvRfcxvs=,iv:75GyAM4wL97zv9xXO4FRtTWy0LKG/09ivb6Qob6KDsc=,tag:UmdtSvn5sFcxz+6JcDMq7A==,type:str]
+        db-root-password: ENC[AES256_GCM,data:o1UlTV9TSbOF5AD0A1DhwdOJsbOVTMSiZGMW3K+12v0=,iv:XNveOMo7mnRzS5Z86zYymjrhBe5/d9LHtxCU/BH5XKQ=,tag:e5HuXwpM1cNx9R+joGrqrA==,type:str]
 sops:
     age:
-        - recipient: age1emdtpejkq68k5zpp09fy6ak4wrkjmhuz4yxx9pmkk7r4h56tgppsqf9tuh
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzL2poL3FRUVpTRSt6dDdx
             MW9kcGxZanR5eUhEV3IzQTJzeVNIbDRxempBCmorY3dXM1dkaE1ocmNHMmJzbXhr
@@ -69,8 +71,8 @@ sops:
             cjlraU1FLzF6WjJkdkR3aEhnc0RwVTQKnAMNKIysxvLjvy/+gRl4gkpqCwkKcY8G
             72/VMuXNa1qn89+TLf0SR+4bZO2VSKJ+srpspUqsQu8qS3A+l/3YkQ==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1lp2gnrprq0nhz55mq58p54e28f5zxr6ps7swzz5qpud2ldynjqxqvfc2px
-          enc: |
+          recipient: age1emdtpejkq68k5zpp09fy6ak4wrkjmhuz4yxx9pmkk7r4h56tgppsqf9tuh
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6cnI5U2ZuOTlTMFFnQm84
             cjYydUZvazcyb1Zsd0wzWWVveWE2SjgzVVdjCno1SXkzVzloa0ZKeUlPa1pmaFRQ
@@ -78,8 +80,8 @@ sops:
             alNZYzM2NmVFR3FMVng1SEowaHVGRHMKJvBNN90PW2uRMNKB0w5juLGhAr0/hNIy
             0VYWq8PhvFzOatu7vqe41jtVbxYP9H9f37H1MkDobuXitRqM2s4W1g==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1xg2cx4mzsfh62nqfga04q0l0ahqdcqe42t46zt69cejlg7ws3azsf0gzh2
-          enc: |
+          recipient: age1lp2gnrprq0nhz55mq58p54e28f5zxr6ps7swzz5qpud2ldynjqxqvfc2px
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnSVQxa0ZkcUhmR2hPVEVD
             cE1uWnlkZ05WUW1pVE9SWjlBcmhWaS9jdFY4CkhyV1VSNGh6M1lwZWcxbDRPbkpI
@@ -87,8 +89,8 @@ sops:
             UDNCYjZDdGNNN3RPeXBMRkhTc0JkWU0KUecnAFdt6xlVUrzOC6Tm5RAORm2ml36L
             9EawCVfVuAVlY1JFzoY8LQhm+32/jPqp/O/2NsXr21bhHm1jqrG55A==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age15h2tcfx9dw5qeyx4cgg358wlzr489vvq272s6wm7gud6mrkmregsp9s6x6
-          enc: |
+          recipient: age1xg2cx4mzsfh62nqfga04q0l0ahqdcqe42t46zt69cejlg7ws3azsf0gzh2
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSMkQ5SHNYaGVqNU1SQml5
             VFZiYjRUUDVqZFRhcVdNYlV0SFRkdVoxSUFzClJsUWhlemkzT0pkaXZaYktRZ3hZ
@@ -96,7 +98,8 @@ sops:
             RE9FblN6UWtGMEU3YnhtdTNtNmN1Z0UKF15jQFlXkBr3XpizVfVapb8dcJ6pkxiq
             ZYE+oa15HgXtkwqJVu8QlZrpkuzSyn0mHDBGibaZX/mKLvZXIKzpiA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-10T12:16:27Z"
-    mac: ENC[AES256_GCM,data:11NPZe/0rLEgELTTgULncTk2nUfDOAZhsEVwYPCtSbegdiRlMpNqpGq1ki9vM5f3j4XDaWzgfWXta8b28aqRjEeHOCJDbC3bIrxf4CquW3HG3PgN0CliCGlu7f/5EOh62eX82ctC+6rY7takGc9aOfjsx6JW0zjtKoKXq7NatJY=,iv:kAyJ/Vjp4WYLao15cB1FDjIeltkDyMxBGhAKZrlF9hc=,tag:/CFEHtpiwzltPE74ikNBsA==,type:str]
+          recipient: age15h2tcfx9dw5qeyx4cgg358wlzr489vvq272s6wm7gud6mrkmregsp9s6x6
+    lastmodified: "2026-08-15T13:14:08Z"
+    mac: ENC[AES256_GCM,data:q0CdjG3A24FADOFPoVBFHNIACR4hyG39kvvJ+X5EWUdnJqeXc9gtpSRP0ikzSsqlkGE5yGu0Vz9sL9CAKmJ9CefXLaGlfKe6Trf0PL3OIRjrifodufY6PiQk3kndJx+6TrdLvRWHR3cq/4PtJWlEcaGG3HZGoQCWynJgIdWtyKg=,iv:JYvmgLkp2vEdlFBk5xVDbcBzuzBgvzjE5qaIFSBT6zY=,tag:lqnQqX0uOZomtvkv5JG47A==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Adds [Grimmory](https://github.com/grimmory-tools/grimmory) as a unified reading server on homelab02, alongside the existing stack rather than replacing any of it.

## Why

Kavita is a manga reader that also opens EPUBs. Its ebook reader renders each spine item as one continuously scrolling page — a design choice rather than a setting — so the books half of the reading stack has never been good. Grimmory covers EPUB/MOBI/AZW3/FB2, PDF, CBZ/CBR/CB7 and M4B in one library, with a paginated reader, Kobo sync, KOReader progress sync and OPDS.

**Nothing is retired.** Kavita and Audiobookshelf are read-only consumers of the same directories, so all three run in parallel until Grimmory has earned the replacement. Its audiobook support is the newest and least proven part, and Audiobookshelf's mobile apps are hard to beat.

## Why homelab02, and why that touches the proxy modules

Grimmory disables UI-initiated file operations under `DISK_TYPE=NETWORK`, and its BookDrop watcher needs filesystem notifications that don't fire over NFS. homelab01 mounts `/srv/media` over NFS from homelab02, so hosting it there would cost both; on homelab02 the ZFS pool is local. An assertion enforces this, so enabling it against an NFS `media-stack` fails the build rather than silently degrading.

That means the app lives on a node that owns neither the Cloudflare tunnel nor the public Caddy. Both hardcoded `localhost` as the origin, so both now take an `upstream` per service, defaulting to `localhost`. cloudflared needs it as well as Caddy because it bypasses the proxy and dials the origin directly. Every existing entry renders byte-identically — verified below.

## Notes on the choices

- **MariaDB is a sidecar, not a shared host service.** `wallabag.nix` borrows homelab01's PostgreSQL because that server already serves several apps. homelab02 has no MySQL at all, so a host instance would exist for this one app and would need the `podman0` bridge plumbing wallabag needs.
- **The app tracks `:latest`; the database engine doesn't.** Grimmory runs schema migrations on startup, but pinning wouldn't make those reversible — the migration is one-way whenever it happens, so recovery means restoring a dump either way, and a pin only chooses the moment at the cost of never updating. wallabag already runs Doctrine migrations on `:latest`. MariaDB is a different risk: it rewrites its datadir on a major upgrade and won't read it back on the older version, so an unattended jump isn't recoverable by restarting the previous image.
- **Libraries are mounted individually** rather than handing over all of `dataPath`, so a reading server has no path to the movie and TV trees.

## Backups

Restic snapshots of a live datadir are torn and may not restore, so the raw MariaDB directory is excluded and a dump is taken instead — nightly at 02:00, half an hour ahead of the backup window, **and before every start of the app**, so an image that migrates the schema is preceded by a restore point minutes old rather than up to a day old.

The dump service is `Wants=`, not `Requires=`, of the app: a dump that can't run deserves an alert, never a service that stays down. It waits for MariaDB to actually accept connections, skips if a dump under five minutes old exists so a crash loop can't thrash it, and writes to a temporary name before renaming so restic can't catch one mid-write.

## Drive-by

Declares two directories the tree had been relying on without saying so: `audiobooks`, which Audiobookshelf has always read but which only existed because someone made it by hand, and `bookdrop`, the new watched ingest folder.

## Verification

- `nix flake check` passes
- all three hosts build (`homelab01`, `homelab02`, `xps15`) — the full CI matrix, run locally post-rebase
- `nixfmt --check` clean on every touched file
- Caddy renders `reverse_proxy 10.20.2.130:6060` for `grimmory.gyarmathy.co`
- tunnel ingress renders `http://10.20.2.130:6060` for Grimmory, with all nine other entries still on `localhost`
- generated units confirmed: `grimmory-db-backup` is `After=podman-grimmory-mariadb`, `Before=podman-grimmory`, `WantedBy=podman-grimmory`, `Type=oneshot` with no `RemainAfterExit` so it re-runs on every restart; timer is `OnCalendar=02:00 Persistent=true`

Not verified: nothing has been deployed. First activation still needs the post-deploy library setup in the module header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)