### PR TITLE
fix(media-stack): create bookdrop on the host that actually needs it

### DIFF
--- a/modules/services/media-stack/grimmory.nix
+++ b/modules/services/media-stack/grimmory.nix
@@ -230,8 +230,18 @@ in
       };
 
       podman-grimmory = {
-        after = [ "podman-network-arr.service" ];
-        requires = [ "podman-network-arr.service" ];
+        # nas-directory-setup builds the media tree but is only ordered against
+        # zfs.target, so without this the container can be started before
+        # /srv/media/bookdrop exists and Podman fails the mount outright
+        # ("statfs ...: no such file or directory") rather than waiting.
+        after = [
+          "podman-network-arr.service"
+        ]
+        ++ lib.optional config.cg.service.nas-storage.enable "nas-directory-setup.service";
+        requires = [
+          "podman-network-arr.service"
+        ]
+        ++ lib.optional config.cg.service.nas-storage.enable "nas-directory-setup.service";
       };
 
       # Consistent dump for restic to pick up -- see BACKUPS above.

--- a/modules/services/media-stack/media-stack.nix
+++ b/modules/services/media-stack/media-stack.nix
@@ -70,6 +70,37 @@ in
       description = "Group for container PGID and file ownership";
     };
 
+    directories = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "downloads"
+        "downloads/complete"
+        "downloads/incomplete"
+        "downloads/cross-seed"
+        "movies"
+        "tv"
+        "music"
+        "livetv"
+        "books"
+        "comics"
+        "manga"
+        "doujin"
+        "lightnovels"
+        "audiobooks"
+        "podcasts"
+        "bookdrop"
+        "whisparr"
+      ];
+      description = ''
+        The media tree, relative to dataPath. This is the single definition of
+        it: nas-storage creates these on the pool it owns, and the tmpfiles
+        rules below create them on a host that stores media locally without
+        nas-storage. Both used to carry their own copy and had already drifted
+        apart, which is how bookdrop came to exist on one path and not the
+        other. Add a directory here and both agree.
+      '';
+    };
+
     storage = {
       type = lib.mkOption {
         type = lib.types.enum [
@@ -149,27 +180,18 @@ in
       # Config directory (always local, even with NFS storage)
       "d ${cfg.configPath} 0775 root ${cfg.group} -"
     ]
-    ++ lib.optionals (cfg.storage.type == "local" && !config.cg.service.nas-storage.enable) [
-      # Data directories (only when using local storage AND nas-storage isn't managing them)
-      # setgid (2xxx) for group inheritance
-      "d ${cfg.dataPath} 2775 ${cfg.user} ${cfg.group} -"
-      "d ${cfg.dataPath}/downloads 2775 ${cfg.user} ${cfg.group} -"
-      "d ${cfg.dataPath}/downloads/complete 2775 ${cfg.user} ${cfg.group} -"
-      "d ${cfg.dataPath}/downloads/incomplete 2775 ${cfg.user} ${cfg.group} -"
-      "d ${cfg.dataPath}/movies 2775 ${cfg.user} ${cfg.group} -"
-      "d ${cfg.dataPath}/tv 2775 ${cfg.user} ${cfg.group} -"
-      "d ${cfg.dataPath}/music 2775 ${cfg.user} ${cfg.group} -"
-      "d ${cfg.dataPath}/books 2775 ${cfg.user} ${cfg.group} -"
-      "d ${cfg.dataPath}/comics 2775 ${cfg.user} ${cfg.group} -"
-      "d ${cfg.dataPath}/manga 2775 ${cfg.user} ${cfg.group} -"
-      "d ${cfg.dataPath}/lightnovels 2775 ${cfg.user} ${cfg.group} -"
-      # Audiobookshelf has always read this, but it was never declared here --
-      # it existed only because someone created it by hand.
-      "d ${cfg.dataPath}/audiobooks 2775 ${cfg.user} ${cfg.group} -"
-      # Watched ingest folder: drop a file here and Grimmory imports it.
-      "d ${cfg.dataPath}/bookdrop 2775 ${cfg.user} ${cfg.group} -"
-      "d ${cfg.dataPath}/whisparr 2775 ${cfg.user} ${cfg.group} -"
-    ];
+    ++ lib.optionals (cfg.storage.type == "local" && !config.cg.service.nas-storage.enable) (
+      # Data directories, only when this host stores media locally AND
+      # nas-storage is not already managing them. Neither homelab currently
+      # meets that: homelab01 is an NFS client and homelab02 runs nas-storage,
+      # so on the present fleet this branch is unreachable. It is kept for a
+      # single-box deployment -- but that is exactly why it must not carry its
+      # own copy of the directory list, since nothing here would notice it
+      # going stale.
+      # setgid (2xxx) for group inheritance.
+      [ "d ${cfg.dataPath} 2775 ${cfg.user} ${cfg.group} -" ]
+      ++ map (dir: "d ${cfg.dataPath}/${dir} 2775 ${cfg.user} ${cfg.group} -") cfg.directories
+    );
 
     # Create the arr-network before any containers start
     systemd.services.podman-network-arr = {

--- a/modules/services/nas-storage.nix
+++ b/modules/services/nas-storage.nix
@@ -92,24 +92,10 @@ in
         let
           uid = toString config.users.users.${cfg.user}.uid;
           gid = toString config.users.groups.${cfg.group}.gid;
-          dirs = [
-            "downloads"
-            "downloads/complete"
-            "downloads/incomplete"
-            "downloads/cross-seed"
-            "movies"
-            "tv"
-            "music"
-            "livetv"
-            "books"
-            "comics"
-            "manga"
-            "doujin"
-            "lightnovels"
-            "audiobooks"
-            "podcasts"
-            "whisparr"
-          ];
+          # Defined by media-stack so the two modules cannot disagree about
+          # what the tree contains. Read from the options rather than the
+          # enabled config, since nas-storage does not require media-stack.
+          dirs = config.cg.service.media-stack.directories;
         in
         ''
           # Wait for ZFS to fully settle


### PR DESCRIPTION
Fixes the `podman-grimmory` start failure from #14 on homelab02:

```
Error: statfs /srv/media/bookdrop: no such file or directory
podman-grimmory.service: Main process exited, code=exited, status=125/n/a
```

## What went wrong

`bookdrop` was declared in `media-stack`'s tmpfiles rules, which are guarded by `storage.type == "local" && !nas-storage.enable`. homelab02 runs `nas-storage`, so that branch never fires there; homelab01 is an NFS client, so it doesn't fire there either. **On the current fleet those rules are unreachable on both machines** — which is why the drift below went unnoticed for so long.

The tree on homelab02 is actually built by `nas-directory-setup`, which carried a *second* copy of the directory list. Two lists meant they could disagree, and they already did:

| | `media-stack` | `nas-storage` |
|---|---|---|
| `livetv`, `doujin`, `podcasts`, `downloads/cross-seed` | ✗ | ✓ |
| `bookdrop` (added in #14) | ✓ | ✗ |

So adding `bookdrop` in one place looked complete and wasn't.

## The fix

The list moves to `cg.service.media-stack.directories`, and both consumers read it. `nas-storage` reads the *option* rather than the enabled config, since it doesn't require `media-stack`. The unreachable tmpfiles branch stays for a single-box deployment but no longer holds a copy that nothing would notice going stale.

**The rendered list is the previous `nas-storage` set plus `bookdrop`** — no other directory changes on either host.

## A second, latent bug

`nas-directory-setup` is ordered only against `zfs.target`, so nothing stopped a container that mounts the media tree from starting before the tree existed. The failure above would have been a boot-order race even with the directory correctly declared. `podman-grimmory` now `Requires=` it where `nas-storage` is enabled.

## Verification

- `nix flake check` passes; all three hosts build
- `nixfmt --check` clean
- generated `nas-directory-setup` script renders `for dir in downloads downloads/complete downloads/incomplete downloads/cross-seed movies tv music livetv books comics manga doujin lightnovels audiobooks podcasts bookdrop whisparr` — the original 16 plus `bookdrop`, nothing dropped
- `podman-grimmory.service` renders `After=` and `Requires=` including `nas-directory-setup.service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)