### PR TITLE
feat(acquisition): add Shelfmark for book and audiobook search

### DIFF
--- a/hosts/homelab02/default.nix
+++ b/hosts/homelab02/default.nix
@@ -286,6 +286,14 @@
           localOnly = true;
         };
 
+        # Shelfmark. Published by the gluetun container on this host, so from
+        # Caddy's point of view it is just another local port.
+        shelfmark = {
+          subdomain = "shelfmark";
+          port = 8084;
+          localOnly = true; # acquisition tooling, same as lazylibrarian/mylar3
+        };
+
         # Future NAS-related services would go here
         # e.g., syncthing, nextcloud, etc.
       };
@@ -351,6 +359,17 @@
       enable = true;
       diskType = "LOCAL"; # /srv/media is the local ZFS pool on this host
     };
+
+    # Search-and-grab for books and audiobooks, feeding Grimmory's BookDrop.
+    # It lives here rather than beside LazyLibrarian on homelab01 because
+    # BookDrop watches with inotify, which does not fire for writes arriving
+    # over NFS from another machine. It shares Gluetun's network namespace, so
+    # its UI is published by the gluetun container, not by this one.
+    #
+    # This does NOT retire LazyLibrarian. Shelfmark replaces the search half of
+    # it and has no equivalent of monitoring an author for future releases, so
+    # both run until that gap is either filled or decided against.
+    shelfmark.enable = true;
 
     # -------------------------------------------------------------------------
     # Services that stay on homelab01

--- a/modules/services/media-stack/qbittorrent.nix
+++ b/modules/services/media-stack/qbittorrent.nix
@@ -116,6 +116,11 @@ in
         ]
         ++ lib.optionals config.cg.service.cross-seed.enable [
           "${toString config.cg.service.cross-seed.port}:2468"
+        ]
+        # Shelfmark shares this namespace too, so its UI is published here for
+        # the same reason cross-seed's is.
+        ++ lib.optionals config.cg.service.shelfmark.enable [
+          "${toString config.cg.service.shelfmark.port}:${toString config.cg.service.shelfmark.port}"
         ];
         extraOptions = [
           "--pull=newer"

--- a/modules/services/media-stack/shelfmark.nix
+++ b/modules/services/media-stack/shelfmark.nix
@@ -1,0 +1,156 @@
+# Shelfmark - Book & Audiobook Search and Request Hub
+# One interface to search configured sources (web, torrent, usenet, IRC), pick
+# the release you actually want, and watch a unified download queue. Metadata
+# comes from Hardcover, Open Library or Google Books.
+#
+# SETUP AFTER DEPLOYMENT:
+# 1. Access web UI at http://homelab02:8084 (or https://shelfmark.gyarmathy.co)
+# 2. Create an account on first launch
+# 3. Configure sources under Settings. Nothing is enabled by default -- this
+#    module deliberately ships no source list; which ones to run is a decision
+#    for the operator, not for the Nix config.
+# 4. Add qBittorrent as a download client at http://localhost:8080 (see NETWORK)
+# 5. Leave the download destination at /books, which is the BookDrop folder
+#
+# WHY THIS REPLACES THE SEARCH HALF OF LAZYLIBRARIAN, NOT ALL OF IT:
+# LazyLibrarian does two jobs: search/grab, and monitor an author for future
+# releases. Shelfmark does the first well and does not do the second at all.
+# So this module does not retire anything -- see the note in hosts/homelab02.
+#
+# NETWORK -- SHARES THE GLUETUN NAMESPACE:
+# Shelfmark makes direct HTTP requests to book sources, which would otherwise
+# egress on the home IP while qBittorrent's traffic is tunnelled. Rather than a
+# second Gluetun, it joins the existing one the same way cross-seed does
+# (--network=container:gluetun), so:
+# - all of its egress is tunnelled and dies with the tunnel
+# - qBittorrent is reachable at localhost:8080, not a container hostname
+# - its web UI must be published on the *gluetun* container, since Shelfmark
+#   has no network namespace of its own. That happens in qbittorrent.nix, next
+#   to the identical arrangement for cross-seed.
+# Falls back to arr-network when the VPN is off, matching cross-seed.
+#
+# WHY THIS RUNS ON homelab02:
+# Grimmory's BookDrop watcher uses inotify, which does not fire for writes made
+# by a remote NFS client. Shelfmark has to write into /srv/media/bookdrop on the
+# machine that hosts it, or imports would only ever happen on Grimmory's next
+# full scan. homelab02 also holds qBittorrent and the downloads tree.
+#
+# DOWNLOAD PATH MUST MATCH qBITTORRENT EXACTLY:
+# For torrent grabs, Shelfmark hands a path to qBittorrent and then looks for
+# the result at that same path. Both containers therefore mount the downloads
+# tree at /data/downloads. Changing one without the other silently breaks
+# torrent imports while direct downloads keep working.
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.cg.service.shelfmark;
+  stack = config.cg.service.media-stack;
+  qbt = config.cg.service.qbittorrent;
+in
+{
+  options.cg.service.shelfmark = {
+    enable = lib.mkEnableOption "Shelfmark book search and request hub";
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8084;
+      description = ''
+        Host port for the Shelfmark web UI. Published on the Gluetun container
+        when the VPN is enabled, because Shelfmark shares its namespace.
+      '';
+    };
+
+    ingestPath = lib.mkOption {
+      type = lib.types.str;
+      default = "${stack.dataPath}/bookdrop";
+      description = ''
+        Where finished downloads land. Defaults to Grimmory's BookDrop folder,
+        so anything Shelfmark fetches is imported without a manual scan.
+      '';
+    };
+
+    searchMode = lib.mkOption {
+      type = lib.types.enum [
+        "universal"
+        "direct"
+      ];
+      default = "universal";
+      description = ''
+        universal searches metadata providers and aggregates releases across
+        sources; direct queries the configured sources only. Upstream
+        recommends universal, and audiobook support depends on it.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = stack.enable;
+        message = "shelfmark requires media-stack to be enabled (cg.service.media-stack.enable = true)";
+      }
+      {
+        # Sharing a namespace with a container that does not exist yields a
+        # container that cannot start, with an error that does not say why.
+        assertion = !qbt.vpn.enable || qbt.enable;
+        message = "shelfmark: qbittorrent.vpn is enabled but qbittorrent is not, so there is no gluetun container to share a namespace with";
+      }
+    ];
+
+    systemd.tmpfiles.rules = [
+      "d ${stack.configPath}/shelfmark 0775 ${stack.user} ${stack.group} -"
+    ];
+
+    virtualisation.oci-containers.containers.shelfmark = {
+      image = "ghcr.io/calibrain/shelfmark:latest";
+      environment = {
+        PUID = toString config.users.users.${stack.user}.uid;
+        PGID = toString config.users.groups.${stack.group}.gid;
+        TZ = config.time.timeZone;
+        FLASK_PORT = toString cfg.port;
+        INGEST_DIR = "/books";
+        SEARCH_MODE = cfg.searchMode;
+        # Shelfmark can manage its own WireGuard tunnel. It must not here: it
+        # is already inside Gluetun's namespace, and a second kill-switch
+        # installing its own iptables rules in that namespace would fight the
+        # one Gluetun put there.
+        USING_WIREGUARD = "false";
+        USING_TOR = "false";
+      };
+      volumes = [
+        "${stack.configPath}/shelfmark:/config"
+        "${cfg.ingestPath}:/books"
+        # Identical to qBittorrent's mapping -- see the header.
+        "${stack.dataPath}/downloads:/data/downloads"
+      ];
+      # Published on gluetun instead when sharing its namespace, since a
+      # container without its own namespace cannot publish anything.
+      ports = lib.optionals (!qbt.vpn.enable) [ "${toString cfg.port}:${toString cfg.port}" ];
+      dependsOn = lib.optionals qbt.vpn.enable [ "gluetun" ];
+      extraOptions = [
+        "--pull=newer"
+      ]
+      ++ (if qbt.vpn.enable then [ "--network=container:gluetun" ] else [ "--network=arr-network" ]);
+    };
+
+    systemd.services.podman-shelfmark = {
+      after = [
+        "podman-network-arr.service"
+      ]
+      # Writes into the BookDrop folder, which nas-directory-setup creates and
+      # which is ordered only against zfs.target -- the same race that broke
+      # podman-grimmory before it required this.
+      ++ lib.optional config.cg.service.nas-storage.enable "nas-directory-setup.service";
+      requires = [
+        "podman-network-arr.service"
+      ]
+      ++ lib.optional config.cg.service.nas-storage.enable "nas-directory-setup.service";
+    };
+
+    networking.firewall.allowedTCPPorts = [ cfg.port ];
+  };
+}


### PR DESCRIPTION
Phase 2 of the reading-stack work. Adds [Shelfmark](https://github.com/calibrain/shelfmark) on homelab02, feeding Grimmory's BookDrop.

## Why

LazyLibrarian's UI locks up mid-search. That's architectural, not configuration — it's a CherryPy app making synchronous provider calls from a small thread pool and rendering the whole author/book list into the page, so one provider that hangs instead of failing fast takes the interface with it.

Shelfmark is built for the workflow that was already working better by hand: search across sources, look at the actual releases, pick one, watch a queue. Metadata comes from Hardcover / Open Library / Google Books, and finished downloads land in BookDrop so they're imported without a manual scan.

**It ships no source list.** Which sources to run is an operator decision; encoding one here would make it a default nobody revisits.

## The plan got simpler

This phase was scoped to need a second Gluetun instance and a refactor of the one embedded in `qbittorrent.nix`. That's no longer true. Once Grimmory moved to homelab02, the downloader landed on the machine already running Gluetun, so Shelfmark just joins that namespace the way `cross-seed` does:

- egress is tunnelled and dies with the tunnel
- qBittorrent is reachable at `localhost:8080`
- the UI is published by the **gluetun** container, since a container sharing a namespace can't publish anything itself

Shelfmark's own WireGuard support is explicitly disabled — a second kill-switch writing iptables rules into that namespace would fight the ones Gluetun already put there.

## Why homelab02 specifically

Not convenience — BookDrop. That watcher uses inotify, which **does not fire for writes arriving from a remote NFS client**. Hosting Shelfmark on homelab01 beside LazyLibrarian would mean imports only ever happened on Grimmory's next full scan.

## Nothing is retired

LazyLibrarian does two jobs and this replaces one. It has no equivalent of **monitoring an author for future releases**. Whether to drop it is a separate decision about whether that job still needs doing — see the question below.

## Verification

Rendered units inspected, not just built:

| Check | Result |
|---|---|
| gluetun publishes | `8000` (api), `8080` (qbt), `2468` (cross-seed), **`8084` (shelfmark)** |
| shelfmark network | `--network=container:gluetun`, publishes nothing itself |
| downloads mount parity | shelfmark `/srv/media/downloads:/data/downloads` — identical to qBittorrent |
| ordering | `After=`/`Requires=` `podman-gluetun`, `podman-network-arr`, `nas-directory-setup` |
| hosts | all three build; `nix flake check` passes; `nixfmt --check` clean |

Ordered after `nas-directory-setup` because it writes into the BookDrop folder that service creates — the same race that broke `podman-grimmory` in #15.

Not verified: nothing deployed. First run needs an account plus source and download-client configuration per the module header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)