### PR TITLE
fix(cross-seed): reach Prowlarr by address, not through the reverse proxy

### DIFF
--- a/modules/services/media-stack/cross-seed.nix
+++ b/modules/services/media-stack/cross-seed.nix
@@ -45,8 +45,10 @@
 #   qBittorrent also shares gluetun's network.
 # - When VPN disabled: cross-seed uses arr-network and accesses qBittorrent via
 #   its container hostname.
-# - Prowlarr is always accessed via the reverse proxy (prowlarr.gyarmathy.co)
-#   since it's on the arr-network and cross-seed needs a stable route to it.
+# - Prowlarr is accessed by address (see the prowlarrUrl option). It used to be
+#   accessed by its reverse-proxy hostname, which does not resolve inside
+#   Gluetun's namespace, so every Torznab request failed and every search ran
+#   with no indexers.
 #
 # MIGRATION NOTES (homelab02 NAS):
 # Cross-seed will MOVE to homelab02 alongside qBittorrent.
@@ -73,12 +75,14 @@ let
   # When VPN disabled: cross-seed is on arr-network, uses container hostname
   effectiveQbtHost = if qbt.vpn.enable then "localhost" else cfg.qbittorrentHost;
 
-  # Build Torznab URL list for config
-  # Always use the reverse proxy URL for Prowlarr since it's accessible from
-  # both VPN and non-VPN network configurations
+  # Build Torznab URL list for config.
+  # This used the reverse proxy hostname, on the stated grounds that it worked
+  # under both VPN and non-VPN configurations. It did not: under VPN this
+  # container has Gluetun's resolver, which cannot see the internal zone. See
+  # the prowlarrUrl option.
   torznabUrlList = lib.concatMapStringsSep ",\n    " (
     id:
-    ''"https://prowlarr.gyarmathy.co/${toString id}/api?apikey=${
+    ''"${cfg.prowlarrUrl}/${toString id}/api?apikey=${
       config.sops.placeholder."media-stack/prowlarr/api"
     }"''
   ) cfg.torznabIndexerIds;
@@ -104,7 +108,12 @@ let
       // TORRENT CLIENT CONNECTION
       // ========================================================================
       // Host is ${effectiveQbtHost} because:
-      // ${if qbt.vpn.enable then "VPN mode: cross-seed shares gluetun's network namespace with qBittorrent" else "Direct mode: cross-seed uses arr-network container hostname"}
+      // ${
+        if qbt.vpn.enable then
+          "VPN mode: cross-seed shares gluetun's network namespace with qBittorrent"
+        else
+          "Direct mode: cross-seed uses arr-network container hostname"
+      }
       torrentClients: [
         "qbittorrent:http://${config.sops.placeholder."media-stack/qbittorrent/username"}:${
           config.sops.placeholder."media-stack/qbittorrent/password"
@@ -182,6 +191,24 @@ in
       type = lib.types.port;
       default = 2468;
       description = "Port for cross-seed API";
+    };
+
+    prowlarrUrl = lib.mkOption {
+      type = lib.types.str;
+      default = "http://10.20.2.85:9696";
+      example = "http://prowlarr:9696";
+      description = ''
+        Base URL for Prowlarr's Torznab feeds. An address, not a hostname, and
+        deliberately not the reverse proxy.
+
+        Under VPN this container lives in Gluetun's network namespace, where
+        DNS is Gluetun's own DoT resolver pointed at a public upstream. The
+        internal zone does not exist there: prowlarr.gyarmathy.co resolves only
+        on AdGuard and has no public record, so every Torznab request failed to
+        resolve and every search silently skipped its indexers. Reaching
+        Prowlarr by address avoids resolution entirely, and Gluetun's
+        FIREWALL_OUTBOUND_SUBNETS already permits the LAN.
+      '';
     };
 
     torznabIndexerIds = lib.mkOption {

--- a/modules/services/media-stack/shelfmark.nix
+++ b/modules/services/media-stack/shelfmark.nix
@@ -9,8 +9,22 @@
 # 3. Configure sources under Settings. Nothing is enabled by default -- this
 #    module deliberately ships no source list; which ones to run is a decision
 #    for the operator, not for the Nix config.
-# 4. Add qBittorrent as a download client at http://localhost:8080 (see NETWORK)
-# 5. Leave the download destination at /books, which is the BookDrop folder
+# 4. Add qBittorrent as a download client at http://localhost:8080
+# 5. Point it at Prowlarr by address: http://10.20.2.85:9696
+# 6. Leave the download destination at /books, which is the BookDrop folder
+#
+# THOSE TWO ADDRESSES LOOK INCONSISTENT AND ARE NOT:
+# qBittorrent shares this container's network namespace, so it is genuinely on
+# localhost -- and it must be addressed that way, because WebUI
+# HostHeaderValidation rejects a Host header that is not one of its own names.
+# Giving it the LAN address returns 401 before the request reaches
+# authentication, so nothing appears in qBittorrent's failure log and the
+# client reports it as a wrong password.
+#
+# Prowlarr is on another machine and has to be reached by address for the
+# opposite reason: Gluetun's resolver serves this namespace and cannot see the
+# internal DNS zone, so prowlarr.gyarmathy.co does not resolve here at all.
+# Same symptom class, opposite fixes.
 #
 # WHAT THIS REPLACED, AND WHAT WAS DROPPED WITH IT:
 # LazyLibrarian did two jobs: search/grab, and monitor an author for future

--- a/secrets/secrets.yaml
+++ b/secrets/secrets.yaml
@@ -27,6 +27,7 @@ media-stack:
     qbittorrent:
         username: ENC[AES256_GCM,data:LG6ltVEwNOcqwUo=,iv:IbjNwTsGeiIr0vji9Aug9vnkDvsDOuRcLtlga43l5Po=,tag:7BD8xBLSvbUQIk5D/RpdFQ==,type:str]
         password: ENC[AES256_GCM,data:dA9YBEA4hniF4PU9v1FODd+f26ZvoaRnSTiiWQ+DT3ZPlQ==,iv:Kp6yaqAgpvpycsDZAnO2u3WIbU/RqDriWXuPYcFWuEg=,tag:Jl+8wAPViZrkKf2oNgBZFA==,type:str]
+        api: ENC[AES256_GCM,data:ukrmM314xErdfxQFFF/Gj0L/ASrZYylP3RdmgNwQrf0=,iv:vuBS9wlr5zIj2HAsI8BzvHBy6IctRnYq0brVvDTx6Sw=,tag:0S53vlqHXr/9+QXDbEM2MQ==,type:str]
     radarr:
         username: ENC[AES256_GCM,data:o4KUhU20,iv:nym+97ExK+p9AMYQjD88DxwTk+BQ48NYJnUvh6kPj8A=,tag:jSucgoZqTR+YYmlhaH3e0Q==,type:str]
         password: ENC[AES256_GCM,data:o4bl7Mg+18chqhWrn1qiLOo98tbUhaFXx3ZfvA59PejB4I8pwESIeMYS0c4LCkU=,iv:3f2AWsOxna8CXRPjFgMKgzH2rESux9iBs8hNMuwJMNQ=,tag:xEIWl3OQBZfa8W5GQyk21Q==,type:str]
@@ -99,7 +100,7 @@ sops:
             ZYE+oa15HgXtkwqJVu8QlZrpkuzSyn0mHDBGibaZX/mKLvZXIKzpiA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age15h2tcfx9dw5qeyx4cgg358wlzr489vvq272s6wm7gud6mrkmregsp9s6x6
-    lastmodified: "2026-08-15T13:14:08Z"
-    mac: ENC[AES256_GCM,data:q0CdjG3A24FADOFPoVBFHNIACR4hyG39kvvJ+X5EWUdnJqeXc9gtpSRP0ikzSsqlkGE5yGu0Vz9sL9CAKmJ9CefXLaGlfKe6Trf0PL3OIRjrifodufY6PiQk3kndJx+6TrdLvRWHR3cq/4PtJWlEcaGG3HZGoQCWynJgIdWtyKg=,iv:JYvmgLkp2vEdlFBk5xVDbcBzuzBgvzjE5qaIFSBT6zY=,tag:lqnQqX0uOZomtvkv5JG47A==,type:str]
+    lastmodified: "2026-08-15T15:20:30Z"
+    mac: ENC[AES256_GCM,data:H3QzSNkqXVQ2nGwhrnpz9UleJLW34jOacNRe6DD6CGPGnHlYFxSGltXS7nF3PR6CvCUP+KKWzXHJSR0rfWYWwfJO2VuPPPRfkOQUx/RPsnHypJncDavOQkb5Bzg5/r1fnACy8J9ilzpw1a6u2HEn5gT9REJP9nXmf6DjClotbIg=,iv:V4NzDJb2ItH61qKVYn3v0EI/fAg64oxnafNGI/AN0pQ=,tag:NqlbdabLZnCB5eg1NRJd8g==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.12.2
+    version: 3.13.3


### PR DESCRIPTION
Cross-seed has been running searches with **no indexers**, quietly. From its logs today:

```
error: https://prowlarr.gyarmathy.co/8/api failed to respond: fetch failed
error: [torznab] Indexer https://prowlarr.gyarmathy.co/8/api failed to fetch caps
info: [search] (1799/1895) Skipped searching on indexers for ...
```

## Cause

Under VPN, cross-seed runs in Gluetun's network namespace, where DNS is Gluetun's own DoT resolver pointed at a public upstream. The internal zone doesn't exist there — `prowlarr.gyarmathy.co` resolves only on AdGuard and has no public record (it's `localOnly`, so the tunnel never registered it). Every Torznab request failed to resolve before it left the container.

The existing comment asserted this hostname worked "in both VPN and non-VPN configurations". It didn't. And the failure was quiet: cross-seed logs the error per search then carries on with data-based matching, so the service looks healthy while the ratio work silently doesn't happen.

## Fix

New `prowlarrUrl` option, defaulting to `http://10.20.2.85:9696`. Gluetun's `FIREWALL_OUTBOUND_SUBNETS` already permits the LAN, so no firewall change.

Found while diagnosing why Shelfmark couldn't reach Prowlarr either — same namespace, same resolver, same failure.

## Also: documenting a trap in shelfmark.nix

The two correct answers there look inconsistent, so the header now explains why they aren't:

| Target | Correct address | Why |
|---|---|---|
| Prowlarr | `http://10.20.2.85:9696` | different machine; Gluetun's resolver can't see internal DNS |
| qBittorrent | `http://localhost:8080` | **same namespace**; the LAN IP trips `WebUI\HostHeaderValidation` |

qBittorrent's rejection is a 401 issued *before* authentication, so nothing appears in its failure log and the client reports it as a wrong password. Confirmed by hand with identical credentials:

```
Host: 10.20.2.130:8080  -> HTTP 401
Host: localhost:8080    -> HTTP 204
```

## Verification

- rendered `config.js` carries `"http://10.20.2.85:9696/8/api?apikey=<placeholder>"`, and the qBittorrent client line is still `@localhost:8080`
- all three hosts build; `nix flake check` passes; `nixfmt --check` clean

Not verified: cross-seed hasn't been restarted against the new config yet — that needs the deploy. Worth checking its logs afterwards to confirm the indexer caps fetch succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)