### PR TITLE
docs(deployment): retire the staged rollout, protect at activation (ADR 0002)

### DIFF
--- a/docs/adr/0001-gitops-deployment-with-a-promoted-ref.md
+++ b/docs/adr/0001-gitops-deployment-with-a-promoted-ref.md
@@ -1,8 +1,9 @@
 # ADR 0001: GitOps deployment with a promoted ref
 
-- **Status:** Accepted
+- **Status:** Accepted, except §1a - superseded by [ADR 0002](0002-protect-at-activation-not-in-the-rollout.md)
 - **Date:** 2026-08-15
 - **Related Artefacts:**
+  - Superseded in part by: ADR 0002 (§1a, the staged rollout)
   - Implemented by: `.github/workflows/ci.yml` (build gate + promotion), `.github/workflows/flake-update.yml` (lock updates), `system.autoUpgrade` on each host
   - Supersedes: the flake-update and apply logic in `packages/nixos-upgrade-scripts`
   - Depends on: the `protect-main` repository ruleset, the `corygyarmathy-dotfiles` Cachix cache
@@ -25,7 +26,7 @@ Keep the pull model - it is correct for hosts with no inbound access and no depe
 
 **1. Hosts follow a promoted ref, not `master`.** A `deploy` branch is fast-forwarded to `master` by CI, and only after every host configuration builds. `system.autoUpgrade` points at `github:corygyarmathy/dotfiles/deploy#hostname`. A host can therefore only ever fetch a revision proven to evaluate and build _for that host_. `master` stays the integration branch and may be red; `deploy` is the fleet's contract.
 
-**1a. The servers roll out in stages.** `homelab01` follows `deploy` and takes each promoted revision the night it lands. `homelab02` follows `deploy-stable`, which a scheduled job advances to whatever `deploy` pointed at 24 hours earlier. The two servers are not interchangeable: `homelab02` holds the ZFS pool and exports the NFS storage `homelab01` mounts, so it is the host whose failure cascades. Staging the rollout means a kernel or systemd bump that fails to boot takes out the compute node while the data node keeps serving.
+**1a. The servers roll out in stages.** _Superseded by ADR 0002: both servers now follow `deploy`, and the protection this section sought is provided at activation instead._ `homelab01` follows `deploy` and takes each promoted revision the night it lands. `homelab02` follows `deploy-stable`, which a scheduled job advances to whatever `deploy` pointed at 24 hours earlier. The two servers are not interchangeable: `homelab02` holds the ZFS pool and exports the NFS storage `homelab01` mounts, so it is the host whose failure cascades. Staging the rollout means a kernel or systemd bump that fails to boot takes out the compute node while the data node keeps serving.
 
 The soak is worth less than it looks for host-specific packages - a regression in ZFS or qBittorrent will not surface on `homelab01`, which runs neither - but the shared base (kernel, systemd, nix, glibc) is where an unattended update does catastrophic rather than annoying damage, and that is exactly what a day of uptime on another machine exercises.
 

--- a/docs/adr/0002-protect-at-activation-not-in-the-rollout.md
+++ b/docs/adr/0002-protect-at-activation-not-in-the-rollout.md
@@ -1,0 +1,62 @@
+# ADR 0002: Protect at activation, not in the rollout
+
+- **Status:** Accepted
+- **Date:** 2026-08-16
+- **Related Artefacts:**
+  - Supersedes: ADR 0001 §1a (staged rollout via `deploy-stable`)
+  - Retires: the `deploy-stable` branch and `.github/workflows/promote-stable.yml`
+  - Depends on: the deployment metrics in `modules/services/monitoring/deploy-metrics.nix` and the `NixosDeployStale` alert in `modules/services/monitoring/alert-rules.yml`
+  - Planned in: `docs/plans/deployment-hardening.md`
+
+## Context
+
+ADR 0001 staged the server rollout by time: `homelab01` follows `deploy` and takes each promoted revision the night it lands, while `homelab02` follows `deploy-stable`, which a scheduled job advances to whatever `deploy` pointed at 24 hours earlier. Two things have become clear since.
+
+The lag has a cost that was not anticipated. A change merged for `homelab02` reaches it a day late, and any deliberate deployment in the meantime is reverted at 04:15 and then re-applied 24 hours later - the reconciler behaving correctly against a ref that lags, but the effect is that the host holding the data is the host least able to receive a considered change. Every attempt to keep the lag and add an expedite path founders on the same fact: promotion is a fast-forward of a ref, so it is all-or-nothing over the whole range between `deploy-stable` and `deploy`, and with `flake.lock` bumps auto-merging nightly there is an unsoaked commit sitting in that range almost every time an expedite would be wanted.
+
+The lag also buys less than it appeared to. ADR 0001 already conceded that `homelab01` runs neither ZFS nor qBittorrent nor the VPN, so the soak only ever exercised the shared base. It measures elapsed time rather than health, and nothing reads the result: a revision was promoted at 03:30 whether or not `homelab01` had survived the night on it. Meanwhile the failure history contains no base-system regression at all. What has actually broken is service configuration - a service wiping a shared directory, a client reaching a peer through the reverse proxy instead of by address, a DNS record pointing at the wrong host. None of that would surface during a soak on a machine that does not run those services, and none of it would be undone by rolling back a generation: a reverted configuration does not restore deleted files.
+
+The pipeline is therefore carrying its most elaborate mechanism against the failure class it has never experienced, while the class it experiences repeatedly is gated only by "it builds".
+
+## Decision
+
+**1. Both servers follow `deploy`.** `deploy-stable` and `promote-stable.yml` are retired. `deploy` remains the fleet contract - CI fast-forwards it only after every host configuration builds - and both servers reconcile to it nightly. A merged change reaches every host the same night, and there is no longer a state in which a host is deliberately behind the ref it follows.
+
+**2. Protection moves from the rollout to activation, on the machine being changed.** Staging protected `homelab02` by delaying it. Instead, each host defends itself at the moment it switches, against three failure modes that need three different answers:
+
+- _Does not boot._ systemd's Automatic Boot Assessment, via `boot.loader.systemd-boot.bootCounting`. A new entry carries a counter, systemd-boot decrements it each attempt, and an entry that never reaches `boot-complete.target` is skipped in favour of an older generation. This is the native answer to the unattended kernel bump that motivated the staged rollout, it works with nobody present, and it protects the storage node directly rather than by proxy.
+- _Boots, services broken._ The upgrade verifies the system after switching and rolls back to the previous generation if it does not come up clean. This is the case the 24h soak was least able to catch and the one that occurs most often.
+- _Boots, network broken._ Not automated. An on-host check cannot detect that it has lost its own network, and the established remedy is push-based deployment with a remote confirmation, which would reintroduce the dependency on an operator's machine that the pull model exists to avoid. Accepted as a known gap, with the interactive path in decision 4 as its remedy.
+
+**3. The pre-deploy gate becomes behavioural, not only compilable.** NixOS VM tests per service module, exposed as flake `checks` so the existing gate picks them up without workflow changes. This is where new effort goes, because it is the only gate that stops a bad service configuration before it reaches any host, and service configuration is what actually breaks. ADR 0001 named this as its largest known weakness and deferred it; it is no longer deferred.
+
+**4. `deploy-rs` is adopted for interactive and recovery deployment only.** Iterating on a service, and recovering a host that the automated path cannot reach, both need a human-driven push. `deploy-rs` does that better than raw `nixos-rebuild --target-host` because its magic rollback covers exactly the network case decision 2 leaves open. It is explicitly _not_ the fleet mechanism: the servers keep pulling.
+
+The pull model, a gate, and a report - ADR 0001's own framing - all stand. The correction is that the gate belongs before the merge and at activation, not in the shape of the rollout.
+
+## Consequences
+
+**Positive**
+
+- A merged change reaches both servers the same night, so there is no window in which a deliberate configuration change is reverted and then reinstated.
+- Protection is exercised on the host that matters instead of inferred from a machine with a different workload. Boot counting tests the storage node's own kernel on its own hardware; the soak never did.
+- The fleet has one promoted ref again. `deploy-stable`, the promotion job, its 24h cutoff, its divergence guard, and the whole question of when a change deserves to skip the queue all disappear.
+- Effort moves to the failure class that has actually caused outages here.
+- Rollback becomes a real signal rather than a proxy: a host that reverts says so, instead of a promotion job silently not advancing.
+
+**Negative**
+
+- Both servers now take a bad revision on the same night. The blast radius of a base-system regression is the whole fleet rather than one node, and the mitigation is per-host recovery rather than an unaffected survivor. This is the deliberate trade: an automated check at activation in place of an unread day of elapsed time.
+- Nothing covers a host that boots and serves but has lost its network. It remains a trip to the machine, or a push deployment initiated by hand.
+- An over-eager health check can revert a good deployment. A rollback loop is worse than the degradation it protects against, so the verification must be conservative and must alert loudly when it fires.
+- VM tests are a standing maintenance cost, and a flaky one trains you to re-run the gate rather than read it.
+- Boot counting changes how boot loader entries are named on the ESP and migrates existing entries on the next `nixos-rebuild boot`. Low risk, but it touches the boot path of the host holding the pool.
+
+## Alternatives considered
+
+- **Keep the staged rollout and add an expedite path.** Either a manual promotion to a chosen revision, or a path-based fast-track that promotes immediately when the pending range touches only host or service configuration. Rejected because a ref advance carries everything before it: with nightly lock bumps auto-merging, the range is almost never clean, so the fast-track would rarely fire and the manual path would mean routinely pulling unsoaked base-system changes forward by hand while believing otherwise.
+- **Slow the `flake.lock` cadence to weekly so the fast-track could fire.** Rejected: it makes behaviour depend on the day of the week, delays security fixes by up to a week, and enlarges each batch so that attributing a regression gets harder. It changes when risk arrives without reducing it.
+- **Health-gate the promotion instead of retiring it** - advance `deploy-stable` only when the deployment metrics show `homelab01` well on the target revision. This was the previous plan's highest-value item. Rejected because it needs Prometheus reachable from CI, which reintroduces inbound access to the homelab, and because once activation-time verification exists the canary's remaining value is small - it never exercised the storage node's own workload in the first place.
+- **Mutual push with `deploy-rs`: each server deploys the other.** Genuinely attractive, because the deployer is then never the machine being changed, which is the condition magic rollback requires. Rejected as over-built for two hosts: it creates a control plane with no root of authority, two timers that can overlap with each other and with a manual deployment with no locking, and a credential cycle in which each host is effectively root on the other. Most of what it offers is available on-host, and it gives up the pull model's self-healing after downtime.
+- **`comin`.** A pull-mode GitOps operator for NixOS - polls git remotes, deploys by hostname, exports Prometheus metrics, supports testing branches. The closest thing to prior art for what this repository has built by hand, and worth tracking. Not adopted: it does not cover home-manager or unattended reboots, and it does not advertise rollback on a failed deployment, so it would replace a working mechanism without closing the gaps that motivated this ADR.
+- **Stop updating the storage node automatically.** The conservative option for a host with irreplaceable data. Rejected for now because `homelab02` is a second server that happens to hold storage rather than a dedicated appliance, the data on it is largely re-downloadable, and there is no parity disk to protect in the first place. Revisit if its role narrows or the array gains redundancy.

--- a/docs/plans/deployment-hardening.md
+++ b/docs/plans/deployment-hardening.md
@@ -1,28 +1,123 @@
 # Plan: hardening the deployment pipeline
 
-Status: sketch, not yet started. Follows on from [ADR 0001](../adr/0001-gitops-deployment-with-a-promoted-ref.md), which built the pipeline and named these as its known gaps.
+Status: revised 2026-08-16 to follow [ADR 0002](../adr/0002-protect-at-activation-not-in-the-rollout.md), which retires the staged rollout and moves protection to activation time. Supersedes the earlier version of this plan, whose "health-gate the canary promotion" item is dropped along with the canary itself.
 
-Three pieces, in the order they are worth doing:
+Already in place, and assumed by everything below: the deployment metrics in `modules/services/monitoring/deploy-metrics.nix` and the `NixosDeployFailed` / `NixosDeployStale` / `NixosRebootPending` rules in `modules/services/monitoring/alert-rules.yml`. No new monitoring work is required to start.
 
-1. **Behaviour tests** — turn the gate from "it builds" into "it works"
-2. **Rollback** — recover from a bad deploy without a keyboard in front of the machine
-3. **An operational writeup** — after the thing has run long enough to have a history
+Six pieces. The first two are small and independent; the rest can proceed in any order once they are in.
+
+| #   | Item                     | Size   | Blocks                            |
+| --- | ------------------------ | ------ | --------------------------------- |
+| 1   | Boot counting            | ~1 line | nothing - do first                |
+| 2   | Retire `deploy-stable`   | small  | nothing, once 1 is in             |
+| 3   | Health-gated activation  | medium | nothing                           |
+| 4   | Behaviour tests          | large  | nothing - grows incrementally     |
+| 5   | Service confinement      | medium | _proposed, not yet decided_       |
+| 6   | `deploy-rs` interactively | small  | nothing                           |
 
 ---
 
-## 1. Behaviour tests
+## 1. Boot counting
 
 ### The problem
 
-The gate builds every host configuration and validates the Prometheus rules. That proves the Nix evaluates and the derivations realise. It proves nothing about whether Jellyfin starts, whether Caddy routes to it, or whether the NFS mount comes up.
+An unattended kernel or initrd change that fails to boot leaves a host down until someone stands in front of it. `homelab02` reboots unattended inside a 04:00-05:00 window with `allowReboot = true`, and it is the host holding the pool.
 
-This is the single largest gap in the pipeline. Unattended nixpkgs-unstable bumps reach the servers with only a compile-time gate, and the first signal that something is broken is an alert firing after it has already deployed.
+### Approach
+
+[systemd's Automatic Boot Assessment](https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/), which `boot.loader.systemd-boot` gained in nixpkgs 26.11 - the release both servers run. A new entry is written with a boot counter in its filename, systemd-boot decrements it on each attempt, and `systemd-bless-boot.service` clears the counter once the system reaches `boot-complete.target`. An entry that exhausts its tries is skipped in favour of an older generation.
+
+```nix
+boot.loader.systemd-boot.bootCounting = {
+  enable = true;
+  tries = 3;
+};
+```
+
+Both servers already use systemd-boot (`hosts/homelab01/default.nix:731`, `hosts/homelab02/default.nix:428`), so this belongs in the shared module rather than per host. `xps15` should get it too - it costs nothing and the laptop is the machine most likely to see a half-finished configuration.
+
+### Risks
+
+- Boot loader entries on the ESP are renamed from `nixos-generation-<n>.conf` to `nixos-<content-hash>.conf`, and existing entries migrate on the next `nixos-rebuild boot`/`switch`. Low risk, but it touches the boot path of the storage node; take it on `homelab01` first and confirm the ESP looks sane before it reaches `homelab02`.
+- `boot-complete.target` means the boot succeeded, not that services are healthy. This layer covers a kernel that will not come up, nothing more. Item 3 covers the rest.
+
+### Done when
+
+Both servers have booted at least once with counting enabled, and `bootctl` shows entries blessed rather than counting down.
+
+---
+
+## 2. Retire `deploy-stable`
+
+### The problem
+
+`homelab02` follows a ref that trails `deploy` by 24 hours, so a change merged for it arrives a day late, and any deliberate deployment in the meantime is reverted overnight and reinstated the following night. ADR 0002 has the full reasoning.
+
+### Approach
+
+- Point `hosts/homelab02/default.nix` at `github:corygyarmathy/dotfiles/deploy#homelab02` and rewrite the comment above it, which currently explains the staging.
+- Delete `.github/workflows/promote-stable.yml`.
+- Delete the `origin/deploy-stable` branch, and drop `deploy-stable` from the `reserve-deploy-namespace` ruleset only if the ruleset names it explicitly - the `deploy/` namespace reservation itself must stay.
+- Update `.github/workflows/README.md` and the repository `README.md`, both of which describe the two-tier rollout.
+- Consider moving `homelab02`'s upgrade time back from 04:15 now that it is not waiting on a promotion job at 03:30. Keeping the offset from `homelab01` is still worth something: `homelab01` mounts NFS from `homelab02`, so the storage node should not be switching underneath it.
+
+### Ordering
+
+Strictly this should follow item 3, since it removes protection that health-gated activation replaces. In practice item 1 covers the catastrophic case and the observed failure history contains no base-system regression, so taking it directly after item 1 is defensible - it just means running for a while with no automated recovery from a revision that boots into broken services, which is the status quo today anyway.
+
+### Done when
+
+`homelab02` has taken a revision on the same night it was promoted, and no reference to `deploy-stable` remains in the repository.
+
+---
+
+## 3. Health-gated activation
+
+### The problem
+
+A revision that builds, boots, and then fails to bring its services up has no automated recovery. The alert fires and you fix forward, degraded the whole time. With item 2 in place, both servers take that revision on the same night.
+
+### Approach
+
+Verify after switching, and revert if the system does not come up clean:
+
+```
+nixos-upgrade.service
+  └─ ExecStartPost: nixos-upgrade-verify
+       ├─ systemctl is-system-running --wait   (degraded ⇒ fail)
+       ├─ probe the host's own critical units
+       └─ on failure: nix-env -p /nix/var/nix/profiles/system --rollback
+                      && /run/current-system/bin/switch-to-configuration switch
+```
+
+Notes carried over from the previous version of this plan, all still true:
+
+- `systemctl is-system-running` returning `degraded` is a cheap, generic signal - the same condition the existing `node_systemd_unit_state` alert keys off, evaluated immediately instead of at the next scrape.
+- The check must be _conservative_. A rollback loop is worse than the degradation it protects against. Give services time to settle and revert only on unambiguous failure.
+- A rollback must alert loudly. Silently reverting means the host stops tracking `deploy` and then trips `NixosDeployStale` two days later with a confusing message. Emit it through the existing textfile metrics so it rides the stack that already exists.
+- This cannot recover a network-level mistake: verification runs on the host, and a machine that has lost its network still believes it is fine. Item 6 is the remedy for that case.
+
+One addition worth considering: arm the rollback _before_ switching rather than after, as a transient timer (`systemd-run --on-active=…`) that reverts unless cancelled by a successful verification. That covers activation hanging, and partially covers the network case, since the timer fires locally whether or not anything can reach the host. Verify first that a transient timer survives `switch-to-configuration`.
+
+### Done when
+
+A deliberately broken service configuration, deployed to `homelab01`, reverts itself and raises an alert saying so.
+
+---
+
+## 4. Behaviour tests
+
+### The problem
+
+The gate builds every host configuration and validates the Prometheus rules. That proves the Nix evaluates and the derivations realise. It proves nothing about whether Jellyfin starts, whether Caddy routes to it, or whether cross-seed talks to Prowlarr by the address it was configured with.
+
+Per ADR 0002 this is now the primary pre-deploy gate, because service configuration is the failure class this homelab actually experiences.
 
 ### Approach
 
 `pkgs.testers.runNixOSTest` boots real VMs and asserts against them. Exposed as flake `checks`, so `nix flake check` runs them and the existing `nixos ci` gate picks them up with no workflow changes.
 
-**Test modules, not hosts.** A whole host configuration will not boot in a VM — disko expects real disks, ZFS expects a pool, sops expects host keys, homelab01 expects an NFS server. Instantiate the _service module_ in a minimal machine instead, with secrets stubbed.
+**Test modules, not hosts.** A whole host configuration will not boot in a VM - disko expects real disks, ZFS expects a pool, sops expects host keys, `homelab01` expects an NFS server. Instantiate the _service module_ in a minimal machine instead, with secrets stubbed.
 
 ```nix
 # checks/media-stack.nix (sketch)
@@ -52,117 +147,99 @@ testers.runNixOSTest {
 
 The secret stubbing is the part that needs designing rather than typing. Options:
 
-- a `cg.testing.stubSecrets` flag on the sops module that swaps `config.sops.secrets.<x>.path` for a `pkgs.writeText` fixture — invasive, but keeps the test honest about which secrets a module consumes;
-- per-test `sops.secrets` overrides pointing at fixtures — no production code changes, but each test has to know the secret names;
-- `sops.age.keyFile` set to a committed throwaway key with a fixture secrets file — the most realistic, and exercises the sops wiring itself.
+- a `cg.testing.stubSecrets` flag on the sops module that swaps `config.sops.secrets.<x>.path` for a `pkgs.writeText` fixture - invasive, but keeps the test honest about which secrets a module consumes;
+- per-test `sops.secrets` overrides pointing at fixtures - no production code changes, but each test has to know the secret names;
+- `sops.age.keyFile` set to a committed throwaway key with a fixture secrets file - the most realistic, and exercises the sops wiring itself.
 
 The third is the most faithful and the most work. Start with the second and see whether the duplication actually hurts.
 
 ### Candidates, in order of value
 
-| Test             | Asserts                                            | Why it earns its place                                                           |
-| ---------------- | -------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `reverse-proxy`  | Caddy starts, routes to a stub backend, serves 200 | every public service depends on it; a routing regression is invisible to a build |
-| `monitoring`     | Prometheus starts, loads rules, scrapes a target   | rule and config errors only surface at activation                                |
-| `digital-garden` | quartz builds a vault and the result is served     | the failure mode is a _successful_ build and an empty site                       |
-| `media-stack`    | the arr services reach their ports                 | the largest module, and the one with the most moving parts                       |
+| Test             | Asserts                                                             | Why it earns its place                                                           |
+| ---------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `data-safety`    | a canary file in the shared download root survives service startup  | models the LazyLibrarian incidents directly, and costs three lines per service    |
+| `reverse-proxy`  | Caddy starts, routes to a stub backend, serves 200                  | every public service depends on it; a routing regression is invisible to a build |
+| `monitoring`     | Prometheus starts, loads rules, scrapes a target                    | rule and config errors only surface at activation                                |
+| `digital-garden` | quartz builds a vault and the result is served                      | the failure mode is a _successful_ build and an empty site                       |
+| `media-stack`    | the arr services reach their ports                                  | the largest module, and the one with the most moving parts                       |
 
-`digital-garden` is the most valuable per line: it is the one place where the current gate is actively misleading, because a broken plugin index produces a build that succeeds.
+`data-safety` is new and first for a reason: two of the three recent incidents were a service touching data it had no business touching, and it is the cheapest assertion in the table.
+
+`digital-garden` remains the most valuable per line among the rest: it is the one place where the current gate is actively misleading, because a broken plugin index produces a build that succeeds.
 
 ### Cost and risks
 
-- **KVM.** NixOS tests need it. GitHub's free runners have historically been inconsistent here, though the `nix-installer-action` already in use enables KVM when available. Verify early with a single trivial test — if it falls back to TCG emulation the tests still run, just slowly enough to matter.
+- **KVM.** NixOS tests need it. GitHub's free runners have historically been inconsistent here, though the `nix-installer-action` already in use enables KVM when available. Verify early with a single trivial test - if it falls back to TCG emulation the tests still run, just slowly enough to matter.
 - **Runtime.** Minutes per test, in parallel matrix jobs. Acceptable for a nightly gate; worth watching if it starts delaying the lock PR's auto-merge.
-- **Maintenance.** A VM test that is flaky is worse than no test, because it trains you to re-run the gate. Prefer few, sharp assertions over broad ones.
+- **Maintenance.** A flaky VM test is worse than no test, because it trains you to re-run the gate. Prefer few, sharp assertions over broad ones.
+
+### Done when
+
+At least one test exists, the gate runs it, and a deliberately broken service configuration fails CI rather than merging.
 
 ---
 
-## 2. Rollback
+## 5. Service confinement _(proposed - not part of ADR 0002)_
 
 ### The problem
 
-A bad deploy currently has no automated recovery. If a service breaks, the alert fires and you fix forward. If the machine does not boot, you need physical access to a box in a cupboard.
+Two of the three recent incidents were a service damaging data outside its own scope. Detection after the fact is expensive; prevention is declarative and cheap. A service that cannot write to the shared download root cannot delete it.
 
-Worth separating three distinct failure modes, because they need different answers:
+### Approach
 
-| Failure               | Current recovery        | Gap                             |
-| --------------------- | ----------------------- | ------------------------------- |
-| does not boot         | boot menu, physically   | needs a keyboard on the machine |
-| boots, service broken | alert, then fix forward | slow; degraded the whole time   |
-| boots, network broken | physical access         | no remote path at all           |
+Tighten the systemd units the service modules generate - `ProtectSystem=strict`, `ProtectHome`, `PrivateTmp`, and an explicit `ReadWritePaths` naming only what the service legitimately writes. For the podman-hosted services the equivalent is narrowing the bind mounts rather than mounting the media tree wholesale.
 
-### Layer 0 — health-gate the canary (prevention, cheapest)
+Pairs naturally with the `data-safety` test in item 4: the test asserts the property, the confinement enforces it.
 
-`promote-stable.yml` currently advances `deploy-stable` on elapsed time alone. The deployment metrics from phase 4 already say whether homelab01 is well. Gate on them:
+### Risks
 
-- query Prometheus for `nixos_deploy_last_run_success{host="homelab01"}` and `nixos_deploy_pending_reboot{host="homelab01"}` for the target revision
-- refuse to promote if homelab01 is unhealthy, and alert instead
+- Several of these services legitimately need broad access - qBittorrent writes into the download root by design, unpackerr extracts across it, cross-seed reads the whole media tree. The win is narrowing _which_ tree, not eliminating access, and getting it wrong shows up as a service that starts and then silently fails on IO.
+- Worth doing one module at a time, behind the VM tests, rather than as a sweep.
 
-This is the highest value per unit of work in this document. It turns the canary from "has had it for 24h" into "has had it for 24h _and is fine_", which is what a canary is supposed to mean. It needs Prometheus reachable from CI, which is the real obstacle — either an authenticated endpoint through the existing Cloudflare tunnel, or a small pushed summary the workflow can read without inbound access.
+### Decide first
 
-### Layer 1 — boot counting (does not boot)
-
-`boot.loader.systemd-boot.bootCounting` implements [systemd's Automatic Boot Assessment](https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/): a new entry is written with a counter, systemd-boot decrements it each attempt, and once the system reaches `boot-complete.target`, `systemd-bless-boot.service` marks the entry good. An entry that exhausts its tries is skipped in favour of an older generation.
-
-All three hosts already use systemd-boot, so this is close to free:
-
-```nix
-boot.loader.systemd-boot.bootCounting = {
-  enable = true;
-  tries = 3;
-};
-```
-
-This is the native answer to the unattended-kernel-bump risk that motivated the canary in the first place, and it works without anyone being present.
-
-Worth understanding before enabling: `boot-complete.target` is reached once the boot succeeds, _not_ once services are healthy. It protects against a kernel that will not boot, not against one that boots into a broken userspace. Layer 2 covers that.
-
-### Layer 2 — health-gated activation (boots, service broken)
-
-After a switch, verify and revert if the system is unhealthy:
-
-```
-nixos-upgrade.service
-  └─ ExecStartPost: nixos-upgrade-verify
-       ├─ systemctl is-system-running --wait   (degraded ⇒ fail)
-       ├─ probe the host's own critical units
-       └─ on failure: nix-env -p /nix/var/nix/profiles/system --rollback
-                      && /run/current-system/bin/switch-to-configuration switch
-```
-
-Notes:
-
-- `systemctl is-system-running` returning `degraded` is a good, cheap, generic signal — it is exactly what the existing `node_systemd_unit_state` alert keys off, evaluated immediately instead of five minutes later.
-- The check must be _conservative_. A rollback loop caused by an over-eager health check is worse than the degradation it is protecting against. Give services time to settle, and roll back only on unambiguous failure.
-- A rollback must alert loudly. Silently reverting means the host stops tracking `deploy` and then trips `NixosDeployStale` two days later with a confusing message.
-- This cannot recover a network-level mistake, since the verification runs on the host itself and a machine that has lost its network still thinks it is fine.
-
-### Layer 3 — deploy-rs for the network case (optional)
-
-The one failure this does not cover is locking yourself out — a firewall or interface change that leaves the machine up but unreachable. `deploy-rs`'s magic rollback is the established answer: it activates, waits for a confirmation _over the new configuration_, and reverts if the confirmation never arrives.
-
-It was rejected as the primary mechanism in ADR 0001 because it is push-based and would reintroduce the dependency on an operator's machine being online. But it could be adopted narrowly, for exactly this case, without disturbing the pull model — for instance homelab01 deploying homelab02, since the two already have SSH between them and the storage node is the one worth protecting.
-
-That is a real increase in moving parts for one failure mode. Worth doing only after actually being locked out once, or before a change that is obviously risky.
-
-### Suggested order
-
-1. Boot counting — one option, native, covers the catastrophic case
-2. Health-gated activation — moderate work, covers the common case
-3. Health-gated canary promotion — highest value, blocked on Prometheus reachability
-4. deploy-rs — only if the network case bites
+Whether this belongs in this plan at all or as its own piece of work. It is prevention rather than deployment hardening, and it arrived late in the discussion that produced ADR 0002.
 
 ---
 
-## 3. Operational writeup
+## 6. `deploy-rs` for interactive and recovery deployment
+
+### The problem
+
+`nixos-rebuild switch --flake .#homelab02 --target-host coryg@homelab02 --elevate=sudo --ask-elevate-password` is the supported path for iterating on a service, and it is long enough to discourage use. It also offers no protection when the change under test is the one most likely to lock you out - firewall, interface, or sshd configuration on a headless box in a cupboard.
+
+### Approach
+
+Adopt `deploy-rs` narrowly: an input, a `deploy.nodes` block, and `deployChecks` in `checks`. Its `magicRollback` activates, waits for the deployer to reconnect over the new configuration, and reverts if the confirmation never arrives - which is precisely the failure mode item 3 cannot cover.
+
+Two things to settle:
+
+- **A dedicated deploy user** with `sshUser` set to it and `user = "root"`, rather than deploying as `coryg`. `modules/nixos/ssh-hardening.nix` hardcodes `AllowUsers = [ "coryg" ]` and puts `authorizedKeys` on `users.users.coryg`, so both need to grow. Be clear-eyed that this contains accidents and gives an audit trail; it is not a security boundary, since anything that can set the system profile can set it to a closure containing a root shell.
+- **`interactiveSudo`**, since `security.sudo.wheelNeedsPassword = true` and root SSH is disallowed. Confirm it works before building on it.
+
+While here, add the `Host homelab01 homelab02 { User = "coryg"; }` block to `modules/home/development/ssh.nix` - it shortens plain `ssh` too.
+
+### Explicitly not
+
+The fleet mechanism. The servers keep pulling. Mutual push - each server deploying the other - was considered and rejected in ADR 0002.
+
+### Done when
+
+`deploy homelab02` from the laptop is one short command, and a deliberately broken firewall rule reverts itself instead of requiring a trip to the cupboard.
+
+---
+
+## 7. Operational writeup
 
 After the pipeline has run for a month or so, write up what actually happened: what broke, what the alerts caught, what they missed, what was tuned and why.
 
-The value is not the incidents themselves but the evidence of operating something over time rather than building it and walking away. `docs/recovery-2026-07-25-qbittorrent-reconciliation.md` is already an example of this done well — a real incident, a real root cause, and the reasoning about what to change.
+The value is not the incidents themselves but the evidence of operating something over time rather than building it and walking away. `docs/recovery-2026-07-25-qbittorrent-reconciliation.md` is already an example of this done well - a real incident, a real root cause, and the reasoning about what to change.
 
-Candidate material already visible:
+Candidate material:
 
 - whether `NixosDeployStale` ever fired, and whether 48h was the right threshold
-- whether the reboot window is actually wide enough for a large nixpkgs bump, which is the failure `NixosRebootPending` was written to catch
+- whether the reboot window is wide enough for a large nixpkgs bump, which is the failure `NixosRebootPending` was written to catch
 - how often the lock update produced a genuinely empty closure diff, i.e. whether daily is the right cadence
-- whether the 24h canary lag ever mattered
+- whether health-gated activation ever rolled back, and whether it was right to
+- whether boot counting ever caught a generation, and whether three tries was the right number
+- whether retiring the staged rollout was vindicated or regretted - ADR 0002 makes a falsifiable bet that base-system regressions are not this homelab's problem


### PR DESCRIPTION
Docs only. No configuration changes, no workflow changes — `deploy-stable` and `promote-stable.yml` are still live until the implementation PRs land.

## Why

`homelab02` follows `deploy-stable`, which trails `deploy` by 24h. A change merged for it arrives a day late, and a deliberate deployment in the meantime is reverted overnight and reinstated the following night.

Every way of keeping the lag and adding an expedite path founders on the same fact: promotion is a fast-forward, so it is all-or-nothing over the whole range between the two refs, and with nightly lock bumps auto-merging there is an unsoaked commit in that range almost whenever an expedite would be wanted.

The lag buys less than it looked, too. ADR 0001 already conceded `homelab01` runs neither ZFS nor qBittorrent nor the VPN, so the soak only exercised the shared base; it measured elapsed time rather than health, and nothing read the result. Meanwhile the failure history holds no base-system regression — what breaks here is service configuration, which a soak on a machine that does not run those services cannot surface, and which a generation rollback would not undo anyway.

## What changes

**`docs/adr/0002-protect-at-activation-not-in-the-rollout.md`** (new) — four decisions: both servers follow `deploy`; protection moves to activation (boot assessment, health-gated activation, the network case named as an accepted gap); the pre-deploy gate becomes behavioural via NixOS VM tests; `deploy-rs` adopted narrowly for interactive and recovery deployment, explicitly not as the fleet mechanism.

The Alternatives section carries the rejected options with reasons — manual and path-based expedite paths, a weekly lock cadence, health-gated promotion, mutual push with `deploy-rs`, `comin`, and not auto-updating the storage node.

**`docs/adr/0001-…md`** — status now "Accepted, except §1a", with a supersession note inline at §1a.

**`docs/plans/deployment-hardening.md`** — revised, not replaced. The health-gated canary promotion item is dropped along with the canary. Boot counting and the `deploy-stable` retirement move to items 1 and 2. VM test material carried over intact, plus a new `data-safety` canary-file test. Item 5 (service confinement) is flagged as **proposed, not part of ADR 0002** and needs a decision.

## Notes for the implementation PRs

- `boot.loader.systemd-boot.bootCounting` exists in nixpkgs 26.11 and all three hosts use systemd-boot. Take it on `homelab01` first — it renames ESP entries, and `homelab02` reboots unattended.
- The deployment metrics and `NixosDeployStale` alert already exist, so no monitoring prerequisite work.
- ADR 0002 makes a falsifiable bet: that base-system regressions are not this homelab's problem. Item 7 in the plan revisits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
