### PR TITLE
feat(boot): give a generation three tries before falling back

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ sops secrets/homelab.yaml                   # edit
 Stated plainly, because a pipeline whose limits are undocumented invites more trust than it has earned:
 
 - **Building is the only pre-deploy gate, and building is not working.** A package that compiles and then fails at runtime will auto-merge and deploy. The alert rules catch it afterwards. NixOS VM tests are the intended fix.
-- **There is no automated rollback.** A bad deploy is recovered by fixing forward, or by selecting an older generation at the boot menu.
+- **Automated rollback covers only a generation that will not boot, and only on homelab01 so far.** systemd's boot assessment gives a new generation three attempts to reach `boot-complete.target`; one that never does is skipped in favour of an older entry, without anyone standing in front of the machine. A generation that boots and then fails to bring its services up is still recovered by fixing forward.
 - **The `deploy-stable` lag is time-based, not health-based.** It establishes that homelab01 has _had_ a revision for 24 hours, not that homelab01 is well.
 - **The canary soak is weaker for host-specific packages.** A ZFS or qBittorrent regression will not surface on homelab01, which runs neither. What it does exercise is the shared base — kernel, systemd, nix, glibc — which is where an unattended update does catastrophic rather than annoying damage.
 

--- a/docs/plans/deployment-hardening.md
+++ b/docs/plans/deployment-hardening.md
@@ -38,7 +38,7 @@ Both servers already use systemd-boot (`hosts/homelab01/default.nix:731`, `hosts
 
 ### Risks
 
-- Boot loader entries on the ESP are renamed from `nixos-generation-<n>.conf` to `nixos-<content-hash>.conf`, and existing entries migrate on the next `nixos-rebuild boot`/`switch`. Low risk, but it touches the boot path of the storage node; take it on `homelab01` first and confirm the ESP looks sane before it reaches `homelab02`.
+- ~~Boot loader entries on the ESP are renamed from `nixos-generation-<n>.conf` to `nixos-<content-hash>.conf`, and existing entries migrate on the next `nixos-rebuild boot`/`switch`.~~ Checked against the pinned nixpkgs while implementing: content-hash naming is unconditional in `systemd-boot-builder.py`, so the hosts already write `nixos-<hash>.conf` and boot counting does not cause that migration. What it does change is narrower - a `+<tries>` suffix on the entry filename, and `preferred <entry>` plus `default nixos-*` in `loader.conf` in place of a single `default`. Still worth taking on `homelab01` first, since it is the boot path of the storage node that is not worth proving things on.
 - `boot-complete.target` means the boot succeeded, not that services are healthy. This layer covers a kernel that will not come up, nothing more. Item 3 covers the rest.
 
 ### Done when

--- a/hosts/homelab01/default.nix
+++ b/hosts/homelab01/default.nix
@@ -68,6 +68,12 @@
       # Service ports are opened by individual service modules
     };
     user-security.enable = true;
+
+    # This host reboots unattended after an upgrade, so a kernel or initrd that
+    # will not come up would otherwise need someone in front of it. Enabled
+    # here first, ahead of homelab02, because homelab02 holds the pool and its
+    # ESP should not be the one this is proven on.
+    boot-counting.enable = true;
   };
 
   # ============================================================================

--- a/modules/nixos/boot-counting.nix
+++ b/modules/nixos/boot-counting.nix
@@ -1,0 +1,72 @@
+# modules/nixos/boot-counting.nix
+#
+# systemd's Automatic Boot Assessment, so a generation that will not boot is
+# abandoned in favour of an older one instead of leaving the host down.
+#
+# https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/
+#
+# The mechanism, end to end:
+#
+#   1. `nixos-rebuild boot`/`switch` writes the entry as
+#      `nixos-<hash>+<tries>.conf` on the ESP.
+#   2. systemd-boot decrements that counter before handing off to the kernel,
+#      renaming the file to `+<left>-<done>`.
+#   3. `systemd-bless-boot-generator` sees the counter in the EFI variables and
+#      pulls `systemd-bless-boot.service` into the boot, which strips the
+#      counter once `boot-complete.target` is reached.
+#   4. An entry that reaches zero tries is sorted last, and systemd-boot's
+#      `default nixos-*` glob then resolves to the newest entry that is not
+#      bad. Both this and the `preferred` directive that pairs with it need
+#      systemd-boot >= 260; the servers are on 261.
+#
+# What this does not cover: `boot-complete.target` requires only
+# `sysinit.target`, so it means the kernel came up and the filesystems mounted,
+# not that anything useful is running. A revision that boots into broken
+# services blesses itself quite happily. Health-gated activation - item 3 of
+# docs/plans/deployment-hardening.md - is the layer that catches that; this one
+# only catches a kernel or initrd that cannot come up at all, which is the
+# failure that otherwise needs someone standing in front of the machine.
+#
+# Only meaningful with `boot.loader.systemd-boot`; the assertion below says so
+# rather than letting the setting be silently inert.
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.cg.boot-counting;
+in
+{
+  options.cg.boot-counting = {
+    enable = lib.mkEnableOption "systemd-boot Automatic Boot Assessment";
+
+    tries = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 3;
+      description = ''
+        Boot attempts a freshly written generation is given before it is
+        considered bad. Each unattended reboot spends one, so this is also the
+        number of power cycles a wobbly-but-working generation survives.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.boot.loader.systemd-boot.enable;
+        message = ''
+          cg.boot-counting requires boot.loader.systemd-boot.enable. Boot
+          assessment is implemented by the boot loader, so it does nothing
+          under GRUB or any other loader.
+        '';
+      }
+    ];
+
+    boot.loader.systemd-boot.bootCounting = {
+      enable = true;
+      inherit (cfg) tries;
+    };
+  };
+}


### PR DESCRIPTION
Item 1 of [the deployment hardening plan](docs/plans/deployment-hardening.md).

## Why

An unattended kernel or initrd change that fails to boot leaves a host down until someone stands in front of it. Both servers reboot inside a 04:00-05:00 window with `allowReboot = true`, and `homelab02` is the one holding the pool.

## What

`cg.boot-counting`, a thin wrapper over `boot.loader.systemd-boot.bootCounting`. New entries are written with a counter, systemd-boot decrements it on each attempt, and `systemd-bless-boot.service` clears it once the system reaches `boot-complete.target`. An entry that exhausts its tries sorts last, and the loader falls through to an older generation.

The module carries an assertion that `systemd-boot` is enabled, since boot assessment is implemented by the loader and would otherwise be silently inert.

## Rollout

**homelab01 only.** The plan called for it fleet-wide, but this touches the boot path, and `homelab02`'s ESP is not where that should be proven. A follow-up enables `homelab02` and `xps15` once `bootctl` shows entries blessed here.

## A risk in the plan that turns out not to exist

The plan expected ESP entries to migrate from `nixos-generation-<n>.conf` to `nixos-<content-hash>.conf` as a consequence of this change. Content-hash naming is unconditional in `systemd-boot-builder.py` in the pinned nixpkgs, so the hosts already write that form. What actually changes is narrower: a `+<tries>` suffix on the entry filename, and `preferred <entry>` plus `default nixos-*` in `loader.conf` in place of a single `default`. The plan is corrected in place.

## Scope

This is the won't-come-up layer only. `boot-complete.target` requires just `sysinit.target`, so a revision that boots into broken services blesses itself quite happily — item 3 is the layer that catches that.

## Verification

- `nix build .#nixosConfigurations.homelab01.config.system.build.toplevel` succeeds
- the built system's bootloader installer carries `BOOT_COUNTING = True` and `BOOT_COUNTING_TRIES = "3"`
- `homelab02` and `xps15` evaluate with `bootCounting.enable = false`, unchanged
- systemd is 261, so the `preferred` directive the builder emits is supported (needs >= 260)

Not yet verified on hardware — worth a `nixos-rebuild switch --target-host homelab01` and a look at `bootctl` before merging, since the merge is what schedules the reboot.

## Done when

Both servers have booted at least once with counting enabled and `bootctl` shows entries blessed rather than counting down. This PR is the first half of that.
