### PR TITLE
feat(nix): let wheel push a locally built closure to a server

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ flowchart LR
 ```bash
 # Iterate on a server without a commit, a push, or a CI round-trip
 nixos-rebuild switch --flake .#homelab01 \
-  --target-host root@homelab01 --build-host root@homelab01
+  --target-host coryg@homelab01 --elevate=sudo --ask-elevate-password
 
 # Pull the promoted revision now rather than waiting for 04:00
 ssh homelab01 sudo systemctl start nixos-upgrade.service
@@ -42,6 +42,8 @@ ssh homelab01 sudo systemctl start nixos-upgrade.service
 # Local machine, from the working tree
 sudo nixos-rebuild switch --flake .#xps15
 ```
+
+`coryg@`, not `root@` — `cg.ssh-hardening` sets `PermitRootLogin = "no"` and `AllowUsers = [ "coryg" ]`, so root SSH is refused on both servers. `--elevate=sudo` is what then runs the activation as root, and `--ask-elevate-password` is needed because `wheelNeedsPassword` is on. That command is long enough to discourage the iteration it exists for, which is [item 6](docs/plans/deployment-hardening.md) of the hardening plan.
 
 `flake.lock` is CI's to move — running `nix flake update` by hand only creates a conflict with the nightly PR.
 

--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,25 @@
                     "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
                     "corygyarmathy-dotfiles.cachix.org-1:/DMVcdDI+4GCAzS6iDTtiwERF1py+MD+w1Z/NTAd2oU="
                   ];
+                  # Without this, `nixos-rebuild --target-host` only works for
+                  # a closure the target can substitute from Cachix. Anything
+                  # built locally - which is every change not yet through CI,
+                  # i.e. exactly what interactive iteration is for - is
+                  # unsigned, and the remote daemon rejects it for an untrusted
+                  # user with "lacks a signature by a trusted key".
+                  #
+                  # Be clear-eyed about what this grants: a trusted user can
+                  # add arbitrary paths to the store and name its own
+                  # substituters, which is root-equivalent in practice. It is
+                  # not much of a widening here, since wheel already has sudo
+                  # and anything that can set the system profile can point it
+                  # at a closure containing a root shell - but it is a real
+                  # one, and it is the reason this is `@wheel` rather than
+                  # `*`.
+                  #
+                  # `@wheel` alone: the option is a merged list and nixpkgs
+                  # already contributes `root`.
+                  trusted-users = [ "@wheel" ];
                 };
                 # Automatic garbage collection
                 gc = {
@@ -217,11 +236,10 @@
         {
           alert-rules =
             # promtool lives in the `cli` output, not `out`.
-            pkgs.runCommand "check-alert-rules" { nativeBuildInputs = [ pkgs.prometheus.cli ]; }
-              ''
-                promtool check rules ${./modules/services/monitoring/alert-rules.yml}
-                touch $out
-              '';
+            pkgs.runCommand "check-alert-rules" { nativeBuildInputs = [ pkgs.prometheus.cli ]; } ''
+              promtool check rules ${./modules/services/monitoring/alert-rules.yml}
+              touch $out
+            '';
         }
       );
 


### PR DESCRIPTION
Not part of the hardening plan's numbered items — this is the thing that makes iterating on a server possible at all, and it turned up while trying to test #22 on hardware.

## The failure

```
nixos-rebuild switch --flake .#homelab01 --target-host coryg@homelab01 --ask-elevate-password
...
copying path '/nix/store/...-nixos-tmpfiles.d' to 'ssh://coryg@homelab01'...
error: cannot add path '/nix/store/...-nixos-tmpfiles.d' because it lacks a signature by a trusted key
```

Everything printed after that first error is cascade noise from the interrupted transfer.

## Cause

```
$ grep trusted-users /nix/store/...-nixos-system-homelab01/etc/nix/nix.conf
trusted-users = root
```

`coryg` is untrusted, so the remote daemon rejects unsigned store paths — and a closure built on the laptop is unsigned by definition.

This is why the same command against homelab02 succeeded earlier today: that deploy was of a revision CI had already built, so every path substituted from Cachix under a trusted key and nothing unsigned needed copying. Deploying anything *not* yet through CI — which is the entire point of iterating without a round-trip — is what breaks.

## Change

`trusted-users = [ "@wheel" ]` in the shared per-host module (nixpkgs already contributes `root`, and the option is a merged list).

`@wheel` rather than `*`, and worth naming the cost rather than burying it: a trusted user can add arbitrary paths to the store and name its own substituters, which is root-equivalent in practice. It is a small widening here — wheel already has sudo, and anything that can set the system profile can point it at a closure containing a root shell — but it is a real one, so flake.nix says so.

## Also: the README's deploy command could never have worked

```diff
-  --target-host root@homelab01 --build-host root@homelab01
+  --target-host coryg@homelab01 --elevate=sudo --ask-elevate-password
```

`cg.ssh-hardening` defaults to `PermitRootLogin = "no"` and `AllowUsers = [ "coryg" ]`, so root SSH is refused on both servers. The replacement includes the `--elevate=sudo` and `--ask-elevate-password` that `wheelNeedsPassword = true` makes necessary, plus a pointer to item 6 of the hardening plan — which exists precisely because that command is too long to reach for.

## Verification

- all three hosts build
- `nix flake check` passes
- `nix.settings.trusted-users` evaluates to `["root","@wheel"]` on every host, and reaches the generated `/etc/nix/nix.conf` as `trusted-users = root @wheel` on both servers

Not yet confirmed end to end against a live server, since that needs the change deployed first — which is the ordinary bootstrap for anything that fixes deployment. The first `--target-host` run after this lands is the real test.

## Relationship to the stack

Independent — branched from `master`, touches neither the boot-counting nor the `deploy-stable` work, and can merge in any order relative to #22–#24.

Worth noting the second half of why #22–#24 could not be test-deployed: stacked PRs do not trigger `ci.yml`, which is scoped to `branches: [master]`, so their closures were never pushed to Cachix and could not be substituted. That resolves itself as each base merges and the next PR retargets.