### PR TITLE
docs(plan): record the first real evidence from items 1 and 3

### DIFF
--- a/docs/plans/deployment-hardening.md
+++ b/docs/plans/deployment-hardening.md
@@ -8,7 +8,7 @@ Six pieces. The first two are small and independent; the rest can proceed in any
 
 | #   | Item                      | Size    | Status                                                   |
 | --- | ------------------------- | ------- | -------------------------------------------------------- |
-| 1   | Boot counting             | ~1 line | **partly done** - homelab01 only, awaiting first boot    |
+| 1   | Boot counting             | ~1 line | **armed on homelab01** - blessing unproven until a reboot |
 | 2   | Retire `deploy-stable`    | small   | **done** 2026-08-16                                      |
 | 3   | Health-gated activation   | medium  | **landed, not armed** - reports, does not yet roll back  |
 | 4   | Behaviour tests           | large   | not started - now the highest-value item                 |
@@ -19,8 +19,8 @@ Six pieces. The first two are small and independent; the rest can proceed in any
 
 Items 1-3 landed today as four PRs (#22-#25). What remains before any of them can be called finished:
 
-- **Item 1** is on `homelab01` alone, and `homelab01` has not yet booted with it - it takes the config at 04:00 and the counters only appear on the next `nixos-rebuild boot`/`switch`. Confirm `bootctl` shows entries blessed, then a second PR enables `homelab02` and `xps15`.
-- **Item 3** landed with `rollback.enable = false` on both servers. It verifies, exports metrics and alerts; it does not act. Arming it is one line per host, and should wait for a few weeks of evidence about how often it would have fired on a host that was actually fine.
+- **Item 1** is on `homelab01` alone and is armed but unexercised: the entry carries its counter, and nothing has yet booted from a counted entry, so the clearing half of the mechanism has never run. One reboot settles it, then a second PR enables `homelab02` and `xps15`.
+- **Item 3** landed with `rollback.enable = false` on both servers and has passed once on each. It verifies, exports metrics and alerts; it does not act. Arming it is one line per host, and should wait for a few weeks of evidence about how often it would have fired on a host that was actually fine.
 - **Item 4** is now the binding constraint. ADR 0002 made behaviour tests the primary pre-deploy gate, and until they exist the gate is still "it builds" - which is precisely the class of failure items 1 and 3 are left cleaning up after.
 
 A note on sequencing, since it caught us out today: item 2's ordering section argued it was safe to take before item 3, and that held - but only because the interval was hours. Both servers now take a promoted revision on the same night with no automated recovery from a bad one, and that stays true until item 3 is armed.
@@ -61,7 +61,40 @@ Both servers have booted at least once with counting enabled, and `bootctl` show
 
 Confirmed on `homelab01` before it took the config: the ESP already held `nixos-<hash>.conf` entries and `loader.conf` held a plain `default`, which is exactly the state the corrected risk note above predicts - the renaming was never boot counting's doing.
 
-**Still outstanding:** `homelab01` had not yet activated it as of 2026-08-16 afternoon. Counters appear on the next `nixos-rebuild boot`/`switch`, so the first evidence arrives after the 04:00 run. Then a second PR for `homelab02` and `xps15`.
+### First evidence, 2026-08-16 16:08
+
+Activated on `homelab01` ahead of the 04:00 run. Everything on the _write_ side does what it should:
+
+```
+$ cat /boot/loader/loader.conf
+timeout 5
+preferred nixos-62c2ed95…c877a8ef.conf
+default nixos-*
+console-mode keep
+
+$ ls /boot/loader/entries/ | grep '+'
+nixos-62c2ed95…c877a8ef+3.conf          # the new generation, and only it
+
+$ bootctl
+  Current Boot Loader: systemd-boot 261.1
+             Features: ✓ Boot counting
+Default Boot Loader Entry:
+                tries: 3 left
+```
+
+Exactly one of the 32 entries carries a counter - the other 31 predate this and have none, which is what makes the fallback safe: an entry that was never counted is treated as good, so `default nixos-*` still has somewhere to land.
+
+`systemd-bless-boot.service` and `boot-complete.target` are both present in the running system and both `inactive`, which is correct rather than concerning: this boot came from an uncounted entry, so `systemd-bless-boot-generator` had no reason to pull them in.
+
+**The clearing side is still unproven, and it is the half that can bite.** Blessing only happens on a boot _from_ a counted entry. If `boot-complete.target` is not reached on this host, the counter never clears, and the third reboot marks a perfectly good generation bad and falls back. `boot-complete.target` requires only `sysinit.target`, so this is very likely fine - which is exactly the sort of "very likely" worth confirming once rather than assuming forever. After the next reboot:
+
+```bash
+bootctl | grep 'Current Entry'                 # expect no +N suffix
+systemctl is-active systemd-bless-boot.service # expect active (exited)
+ls /boot/loader/entries/ | grep '+'            # expect only not-yet-booted entries
+```
+
+**Still outstanding:** that reboot, then a second PR enabling `homelab02` and `xps15`.
 
 ---
 
@@ -158,6 +191,24 @@ One addition worth considering: arm the rollback _before_ switching rather than 
 ### Landed in two stages
 
 Shipped reporting-only (#24): `modules/nixos/upgrade-verify.nix`, the `NixosVerifyFailed` and `NixosRolledBack` rules, and `criticalUnits` on both servers - with the rollback itself behind `cg.upgrade-verify.rollback.enable`, default false. The failure mode of this module is reverting a healthy server, and watching it decide for a few weeks costs nothing while guessing at the false-positive rate could cost a night's uptime on the storage node. Arming it afterwards is a one-line change per host.
+
+### First run, 2026-08-16
+
+Both servers, triggered by `nixos-upgrade`'s `ExecStartPost` rather than the boot timer - so the same-unit switch path is exercised and works:
+
+```
+Verifying generation: /nix/store/xzd1cyim…-nixos-system-homelab01-…
+systemd reports: running
+Verification passed.
+Consumed 69ms CPU time over 2min 90ms wall clock time, 4.2M memory peak
+```
+
+`homelab02` identical. Two useful readings beyond "it passed":
+
+- **The critical unit lists are right.** A pass means every unit in them was active, so `srv-media.automount`, `caddy`, `jellyfin`, `zfs-import-tank`, `nfs-server` all reported correctly. Had the automount trap not been caught, this is where it would have shown up as a spurious failure on `homelab01`.
+- **It is free.** Under 70ms of CPU; the two minutes of wall clock are the deliberate settle, and it runs `--no-block` so nothing waits on it.
+
+One deliberate gap: this exercised the branch where the kernel is unchanged. The reboot path - verification started by the boot timer - is unexercised until a kernel bump, and that is the branch the original design got wrong, so it deserves an explicit look the first time it runs.
 
 **Stage two, still outstanding:** arm `rollback.enable`, `homelab01` first. The signal to look for beforehand is `nixos_verify_result` staying at 1 across a few weeks of nightly upgrades - every 0 in that window is a rollback that would have happened, and worth understanding before it does.
 

--- a/docs/plans/deployment-hardening.md
+++ b/docs/plans/deployment-hardening.md
@@ -219,7 +219,19 @@ Consumed 69ms CPU time over 2min 90ms wall clock time, 4.2M memory peak
 - **The critical unit lists are right.** A pass means every unit in them was active, so `srv-media.automount`, `caddy`, `jellyfin`, `zfs-import-tank`, `nfs-server` all reported correctly. Had the automount trap not been caught, this is where it would have shown up as a spurious failure on `homelab01`.
 - **It is free.** Under 70ms of CPU; the two minutes of wall clock are the deliberate settle, and it runs `--no-block` so nothing waits on it.
 
-One deliberate gap: this exercised the branch where the kernel is unchanged. The reboot path - verification started by the boot timer - is unexercised until a kernel bump, and that is the branch the original design got wrong, so it deserves an explicit look the first time it runs.
+### The boot timer, 2026-08-16 16:27
+
+The reboot of `homelab01` for item 1 incidentally exercised item 3's other trigger, three minutes into the new boot:
+
+```
+Starting Verify the running NixOS generation came up healthy...
+Generation already verified: /nix/store/xzd1cyim…-nixos-system-homelab01-…
+Finished Verify the running NixOS generation came up healthy.
+```
+
+Small output, three things proven. The timer fires at all, so the reboot path has a trigger - this is the branch the plan's original `ExecStartPost` design could never have reached. The generation-keyed guard works: the running system had been blessed before the reboot, so it exited immediately rather than re-verifying and re-sleeping. And nothing deadlocked, which is what the timer exists to avoid - a unit ordered inside the boot transaction while waiting on `is-system-running --wait` would have hung the boot instead.
+
+What remains unexercised is the timer finding _new_ work: booting into a generation that has never been verified, which needs a kernel bump. The trigger is proven; the verdict it will reach on a fresh generation is not.
 
 **Stage two, still outstanding:** arm `rollback.enable`, `homelab01` first. The signal to look for beforehand is `nixos_verify_result` staying at 1 across a few weeks of nightly upgrades - every 0 in that window is a rollback that would have happened, and worth understanding before it does.
 

--- a/docs/plans/deployment-hardening.md
+++ b/docs/plans/deployment-hardening.md
@@ -8,7 +8,7 @@ Six pieces. The first two are small and independent; the rest can proceed in any
 
 | #   | Item                      | Size    | Status                                                   |
 | --- | ------------------------- | ------- | -------------------------------------------------------- |
-| 1   | Boot counting             | ~1 line | **armed on homelab01** - blessing unproven until a reboot |
+| 1   | Boot counting             | ~1 line | **proven on homelab01** - remaining hosts still to follow |
 | 2   | Retire `deploy-stable`    | small   | **done** 2026-08-16                                      |
 | 3   | Health-gated activation   | medium  | **landed, not armed** - reports, does not yet roll back  |
 | 4   | Behaviour tests           | large   | not started - now the highest-value item                 |
@@ -19,7 +19,7 @@ Six pieces. The first two are small and independent; the rest can proceed in any
 
 Items 1-3 landed today as four PRs (#22-#25). What remains before any of them can be called finished:
 
-- **Item 1** is on `homelab01` alone and is armed but unexercised: the entry carries its counter, and nothing has yet booted from a counted entry, so the clearing half of the mechanism has never run. One reboot settles it, then a second PR enables `homelab02` and `xps15`.
+- **Item 1** is proven end to end on `homelab01` - counter written, boot counted, `boot-complete.target` reached, entry blessed - and is still on that host alone. A second PR enables `homelab02` and `xps15`.
 - **Item 3** landed with `rollback.enable = false` on both servers and has passed once on each. It verifies, exports metrics and alerts; it does not act. Arming it is one line per host, and should wait for a few weeks of evidence about how often it would have fired on a host that was actually fine.
 - **Item 4** is now the binding constraint. ADR 0002 made behaviour tests the primary pre-deploy gate, and until they exist the gate is still "it builds" - which is precisely the class of failure items 1 and 3 are left cleaning up after.
 
@@ -86,15 +86,26 @@ Exactly one of the 32 entries carries a counter - the other 31 predate this and 
 
 `systemd-bless-boot.service` and `boot-complete.target` are both present in the running system and both `inactive`, which is correct rather than concerning: this boot came from an uncounted entry, so `systemd-bless-boot-generator` had no reason to pull them in.
 
-**The clearing side is still unproven, and it is the half that can bite.** Blessing only happens on a boot _from_ a counted entry. If `boot-complete.target` is not reached on this host, the counter never clears, and the third reboot marks a perfectly good generation bad and falls back. `boot-complete.target` requires only `sysinit.target`, so this is very likely fine - which is exactly the sort of "very likely" worth confirming once rather than assuming forever. After the next reboot:
+### Blessing confirmed, 2026-08-16 16:25
 
-```bash
-bootctl | grep 'Current Entry'                 # expect no +N suffix
-systemctl is-active systemd-bless-boot.service # expect active (exited)
-ls /boot/loader/entries/ | grep '+'            # expect only not-yet-booted entries
+`homelab01` was rebooted rather than left to a kernel bump, because the clearing half of the mechanism is the half that can bite: blessing only happens on a boot _from_ a counted entry, and had `boot-complete.target` not been reached on this host, the counter would never clear and the third reboot would mark a perfectly good generation bad and fall back to an older one. Worth one deliberate reboot on the compute node to find out, rather than discovering it on the storage node three reboots later.
+
+```
+$ bootctl | grep 'Current Entry'
+  Current Entry: nixos-62c2ed95…c877a8ef.conf     # no +N - the counter was cleared
+
+$ systemctl is-active systemd-bless-boot.service
+active
+
+$ ls /boot/loader/entries/ | grep '+'
+                                                  # nothing counting down
 ```
 
-**Still outstanding:** that reboot, then a second PR enabling `homelab02` and `xps15`.
+`systemd-bless-boot.service` entered active at 16:24:51 with `Result=success` and exit status 0, and `loader.conf` kept its `preferred` line through the blessing. The round trip is therefore complete and observed: entry written `+3` → booted → decremented → `boot-complete.target` reached → counter cleared → entry blessed.
+
+Item 1's "done when" is met for `homelab01`.
+
+**Still outstanding:** enabling `homelab02` and `xps15`, now that the mechanism has been proven end to end somewhere it was safe to prove it.
 
 ---
 


### PR DESCRIPTION
Both items were activated on the servers ahead of the 04:00 run, so #26's "not yet activated" note was stale within hours of being written.

## Item 1: armed, but the half that can bite is unexercised

The **write** side is confirmed on homelab01:

```
$ cat /boot/loader/loader.conf
timeout 5
preferred nixos-62c2ed95…c877a8ef.conf
default nixos-*

$ ls /boot/loader/entries/ | grep '+'
nixos-62c2ed95…c877a8ef+3.conf     # the new generation, and only it

$ bootctl
  Current Boot Loader: systemd-boot 261.1
             Features: ✓ Boot counting
Default Boot Loader Entry:
                tries: 3 left
```

Exactly one of 32 entries carries a counter. The other 31 predate this and have none — which is what makes the fallback safe, since an entry that was never counted is treated as good, so `default nixos-*` still has somewhere to land.

`systemd-bless-boot.service` and `boot-complete.target` are present and both `inactive`. That's correct rather than concerning: this boot came from an *uncounted* entry, so `systemd-bless-boot-generator` had no reason to pull them in.

**But the clearing side has never run.** Blessing only happens on a boot *from* a counted entry, and nothing has rebooted. If `boot-complete.target` turns out not to be reached on this host, the counter never clears and the third reboot marks a perfectly good generation bad and falls back. It requires only `sysinit.target`, so this is very likely fine — which is exactly the sort of "very likely" worth confirming once rather than assuming forever. The three commands to confirm it are recorded in the plan.

So item 1's "done when" is **not met**. One reboot settles it.

## Item 3: passed on both servers

```
Verifying generation: /nix/store/xzd1cyim…-nixos-system-homelab01-…
systemd reports: running
Verification passed.
Consumed 69ms CPU time over 2min 90ms wall clock time, 4.2M memory peak
```

Two readings beyond "it passed":

- **The critical unit lists are right.** A pass means every unit in them was active, so `srv-media.automount`, `caddy`, `jellyfin`, `zfs-import-tank` and `nfs-server` all reported correctly. Had the automount trap not been caught, homelab01 is exactly where it would have surfaced — as a spurious failure every single night.
- **It's free.** Under 70ms of CPU; the two minutes are the deliberate settle, and it runs `--no-block` so nothing waits on it.

Both runs came via `ExecStartPost`, so the same-unit switch path is exercised. **The reboot path is not** — it needs a kernel bump — and that is precisely the branch the plan's original design got wrong, so it earns an explicit look the first time it runs.

## Verification

`nix flake check` passes. Prose only, no config changes.