### PR TITLE
feat(boot): extend boot counting to homelab02 and xps15

### DIFF
--- a/hosts/homelab02/default.nix
+++ b/hosts/homelab02/default.nix
@@ -83,6 +83,13 @@
     };
     user-security.enable = true;
 
+    # This host reboots unattended inside the 04:00-05:00 window and holds the
+    # pool, so an initrd or kernel that will not come up is the failure that
+    # costs the most here - and the one nobody can fix without standing in
+    # front of it. Enabled after homelab01 proved the full round trip: counter
+    # written, boot counted, boot-complete.target reached, entry blessed.
+    boot-counting.enable = true;
+
     # Reporting only, and deliberately not armed here even when homelab01's is.
     # This host holds the pool and the NFS export; it is the last place to give
     # an automatic reverter the benefit of the doubt.

--- a/hosts/xps15/default.nix
+++ b/hosts/xps15/default.nix
@@ -44,6 +44,10 @@
       enable = true;
       firmware.enable = true;
     };
+    # Cheap here, and this is the machine most likely to be handed a
+    # half-finished configuration - it is the one built from a working tree
+    # rather than only from a revision CI has proven.
+    boot-counting.enable = true;
     firewall = {
       enable = true;
       # allowedTCPPorts = [ 9000 ];


### PR DESCRIPTION
The second half of item 1, now that homelab01 has proven the mechanism end to end.

## Why it waited

#22 deliberately enabled this on homelab01 alone. The concern was never the *writing* of the counter — it was the clearing. Blessing only happens on a boot **from** a counted entry, and if `boot-complete.target` were not reached on these hosts, the counter would never clear and the **third reboot would mark a perfectly good generation bad** and fall back. That is a failure boot counting would have *introduced*, and not one worth discovering on the machine holding the pool.

homelab01 was rebooted deliberately to find out. It clears:

```
$ bootctl | grep 'Current Entry'
  Current Entry: nixos-62c2ed95…c877a8ef.conf     # no +N — cleared

$ systemctl is-active systemd-bless-boot.service
active                                            # Result=success, status 0

$ ls /boot/loader/entries/ | grep '+'
                                                  # nothing counting down
```

Full round trip observed rather than inferred: written `+3` → booted → decremented → `boot-complete.target` reached → cleared → blessed. `loader.conf` also kept its `preferred` line through the blessing.

## Change

Two lines, one per host.

- **homelab02** is the host this was written for: it reboots unattended in the 04:00–05:00 window and holds the ZFS pool and the NFS export, so a kernel or initrd that will not come up is both the most expensive failure here and the only one that genuinely needs someone in front of the machine.
- **xps15** because it costs nothing, and it is the one machine built from a working tree rather than from a revision CI has already proven — so it is the most likely to be handed a half-finished configuration.

## Verification

- `bootCounting` evaluates to `{enable = true; tries = 3;}` on all three hosts
- both new hosts build, and their generated bootloader installers carry `BOOT_COUNTING = "True"` / `BOOT_COUNTING_TRIES = "3"`
- formatting clean

## After merging

The counter appears on each host's next `nixos-rebuild boot`/`switch`, and clears on the reboot after that. homelab02 reboots on its own only when a kernel changes, so its first blessing will likely come from a nightly lock bump rather than immediately — worth the same three-command check on it once that happens, since it is the host where the clearing half matters most.

That completes item 1's "done when": both servers booted at least once with counting enabled, showing entries blessed rather than counting down.