### PR TITLE
feat(monitoring): alert when the safety net stops checking, and keep 30d

### DIFF
--- a/modules/services/monitoring/alert-rules.yml
+++ b/modules/services/monitoring/alert-rules.yml
@@ -327,6 +327,37 @@ groups:
           summary: "{{ $labels.host }} activated a generation that did not come up healthy"
           description: "Verification found units failing that were not failing before the upgrade. Check: journalctl -u nixos-upgrade-verify.service"
 
+      # The silence problem, applied to the safety net itself. NixosVerifyFailed
+      # only speaks when verification runs and fails; if it stopped running —
+      # timer broken, module disabled, unit masked — nixos_verify_result would
+      # sit at 1 forever and the absence of alerts would read as evidence of
+      # health. That absence is exactly what the decision to arm
+      # cg.upgrade-verify.rollback.enable rests on, so it needs checking.
+      #
+      # Not a plain staleness check on the timestamp: verification deliberately
+      # no-ops when the generation has not changed, and exits before writing
+      # metrics, so on a night where `deploy` did not move the timestamp goes
+      # stale for entirely correct reasons. What is wrong is a generation
+      # staged well after the last verification — activated, but never checked.
+      #
+      # `pending_reboot == 0` excludes the staged-but-not-yet-activated case,
+      # which is NixosRebootPending's business and would otherwise fire here
+      # first and more noisily for the same underlying condition.
+      #
+      # 6h rather than something tighter because a manual `nixos-rebuild
+      # switch` also trips this — correctly, since it activates a generation
+      # nothing verifies — and iterating on a service should not page you.
+      - alert: NixosVerifyStale
+        expr: |
+          (nixos_deploy_staged_timestamp_seconds - nixos_verify_timestamp_seconds > 21600)
+          and nixos_deploy_pending_reboot == 0
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.host }} is running a generation that activation verification never checked"
+          description: "A generation was activated over 6 hours ago and nixos-upgrade-verify has not recorded a result since. Either it is not running, or the generation was applied by hand. Check: systemctl status nixos-upgrade-verify.timer"
+
       # Loud on purpose. A host that reverts itself stops tracking the promoted
       # ref, and would otherwise announce that two days later as NixosDeployStale
       # — an alert whose text points nowhere near the actual cause.

--- a/modules/services/monitoring/monitoring.nix
+++ b/modules/services/monitoring/monitoring.nix
@@ -385,6 +385,15 @@ in
 
         services.prometheus = {
           enable = true;
+          # Up from the 15d default, because the questions this stack is asked
+          # are monthly ones: whether health-gated activation ever wanted to
+          # roll back, whether a threshold was right, how often the lock update
+          # produced an empty diff. A 30d query against 15d of data silently
+          # returns 15d and looks better-evidenced than it is.
+          #
+          # Cheap here - a handful of targets at a 1m interval, against 160GB
+          # free on the host holding the pool.
+          retentionTime = "30d";
           globalConfig = {
             scrape_interval = "1m";
             scrape_timeout = "30s"; # was defaulting to 10s


### PR DESCRIPTION
Both gaps found while tracing whether `nixos_verify_result` actually reaches an inbox.

**It does.** Confirmed end to end on the live hosts: script writes the textfile → node_exporter exposes it → Prometheus scrapes both hosts → `NixosVerifyFailed` and `NixosRolledBack` are loaded → `severity: critical` routes to email with `send_resolved`. Nothing was broken. But the way that would be *used* is unsound in two ways.

## 1. Nothing checks that the check is running

`NixosVerifyFailed` only speaks when verification runs **and** fails. If it stopped running — timer broken, module disabled, unit masked — `nixos_verify_result` would sit at `1` forever, and the absence of alerts would read as evidence of health.

That absence is exactly what the decision to arm `cg.upgrade-verify.rollback.enable` rests on. Arming a rollback because "it never wanted to fire" is only sound if it was actually asked.

**Deliberately not a plain staleness check on the timestamp.** Verification no-ops when the generation hasn't changed, and exits *before* writing metrics, so on a night when `deploy` didn't move, a stale timestamp is correct behaviour. What's actually wrong is a generation staged well after the last verification — activated, but never checked:

```promql
(nixos_deploy_staged_timestamp_seconds - nixos_verify_timestamp_seconds > 21600)
and nixos_deploy_pending_reboot == 0
```

Two judgement calls in there:

- **`pending_reboot == 0`** excludes the staged-but-not-yet-activated case. That's `NixosRebootPending`'s job, and without the guard this would fire first and more noisily for the same underlying condition.
- **6h**, not something tighter, because a manual `nixos-rebuild switch` trips this too — correctly, since it activates a generation nothing verifies — and iterating on a service shouldn't page you.

## 2. Retention was 15d, and the questions are monthly

No `retentionTime` was set, so Prometheus's own 15d default applied. The queries this stack exists to answer are monthly ones — whether health-gated activation ever wanted to roll back, whether 48h was the right staleness threshold, how often the lock update produced an empty diff. **A 30d query against 15d of data silently returns 15d** and looks better-evidenced than it is.

Now `30d`. Cheap here: a handful of targets at a 1m interval, against 160GB free on the host. (I couldn't measure the current TSDB size — it needs root — so that's headroom reasoning rather than a measurement.)

## Verification

- `nix flake check` → `promtool` sees **35 rules**, up from 34
- built homelab02 and confirmed both changes reach the shipped artefacts: `--storage.tsdb.retention.time=30d` on the unit, and `NixosVerifyStale` present in the `checkrules`-validated rules file
- **the expression was run against live Prometheus**, not just parsed: it returns empty today, and the per-host gap is **−122 seconds** on both hosts

That −122s is the useful number. The profile mtime updates at activation and verification records its result 120s later, after its deliberate settle — so healthy sits comfortably negative, and only an unverified activation drives it positive. The 6h threshold has enormous margin against normal operation.

## What this changes about the arming decision

The pair of queries to run in a few weeks, now backed by enough retention to mean something:

```promql
min_over_time(nixos_verify_result[30d])        # 0 if it ever wanted to roll back
changes(nixos_verify_timestamp_seconds[30d])   # how many times it actually ran
```

The second matters as much as the first. "Never failed" means nothing if it only ran twice — and `NixosVerifyStale` is what makes a low count visible rather than something you'd have to think to check.