### PR TITLE
docs(adr): record that service confinement is bounded by hardlinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ flowchart LR
 | [The deployment pipeline](.github/workflows/README.md)             | how the refs and workflows behave, the invariants, and recovery procedures |
 | [ADR 0001](docs/adr/0001-gitops-deployment-with-a-promoted-ref.md) | why the pipeline is designed this way, and what was rejected               |
 | [ADR 0002](docs/adr/0002-protect-at-activation-not-in-the-rollout.md) | why the staged rollout was retired, and what replaces it                |
+| [ADR 0003](docs/adr/0003-service-confinement-is-bounded-by-hardlinking.md) | _proposed_ - why confining services to their own data is mostly not available |
 | [Deployment hardening plan](docs/plans/deployment-hardening.md)    | the gaps that remain and how they are meant to close                       |
 
 ## Working on it

--- a/docs/adr/0003-service-confinement-is-bounded-by-hardlinking.md
+++ b/docs/adr/0003-service-confinement-is-bounded-by-hardlinking.md
@@ -1,0 +1,72 @@
+# ADR 0003: Service confinement is bounded by hardlinking
+
+- **Status:** Proposed
+- **Date:** 2026-08-16
+- **Related Artefacts:**
+  - Removes: item 5 from `docs/plans/deployment-hardening.md`
+  - Informs: the `data-safety` test, item 4 of that plan
+  - Evidence: `docs/recovery-2026-07-25-qbittorrent-reconciliation.md` §10
+
+## Context
+
+Two mass deletions of the shared download root, on 2026-07-25 and 2026-07-27, cost 3.68 TiB across 537 torrents. Both were LazyLibrarian's PostProcessor, which had `download_dir = /data/downloads/complete` — the _shared_ completed-downloads root rather than its own subdirectory. Every ten minutes it enumerated the root as its own, then removed and recreated the tree, sparing only the nine torrents it tracked.
+
+The proposal was to prevent a recurrence declaratively: narrow each service's view of the media tree so that a service which cannot see the shared root cannot destroy it.
+
+Two things shape what that can look like.
+
+**Permissions are not the lever.** LazyLibrarian ran as uid 1000, which _owns_ those files, which is why the `root_squash` NFS hardening never applied to it. Nor was it acting outside its configured scope — it was doing exactly what it was told, to the wrong directory. Any defence has to work by _visibility_: the shared root should not exist inside the service's mount namespace, so that a misconfiguration naming it finds nothing rather than everything. That property is also independent of the application's own config, which is where the fault was.
+
+**The media stack is podman, not native units.** `sonarr.service` and friends are container wrappers with `MainPID=0`; `ProtectSystem=strict` and `ReadWritePaths` on those units constrain the podman client, not the workload. The genuinely native services are already hardened by nixpkgs — `caddy` has `ProtectSystem=full`, `ProtectHome=yes`, `ReadWritePaths=/var/lib/caddy`; `jellyfin` has `ProtectSystem=yes`, `PrivateTmp`, `NoNewPrivileges`. So confinement here means narrowing bind mounts, and nothing else.
+
+## The measurement
+
+`modules/services/media-stack/media-stack.nix` mounts the whole tree into every service as `/data`, with the comment "All child services mount this as `/data` for hardlink support". The narrowing proposal assumed this was conservatism, and that per-service mounts of subdirectories would preserve hardlinking because they share one filesystem.
+
+That was tested rather than assumed, with the production images and uid:
+
+| Setup                                             | Result           |
+| ------------------------------------------------- | ---------------- |
+| same filesystem, no container, two subtrees       | ✅ `links=2`     |
+| two separate bind mounts, NFS (`homelab01`)        | ❌ `EXDEV`       |
+| two separate bind mounts, ZFS (`homelab02`)        | ❌ `EXDEV`       |
+| **single** parent bind mount, ZFS                  | ✅ `links=2`     |
+
+The assumption is wrong, and instructively so. Both mounts report an identical `st_dev` — 107 on the NFS host, 46 on the ZFS host — and `link()` still fails. The kernel refuses to link across a **mount boundary**, not merely across a filesystem, so `st_dev` is the wrong thing to reason from. Splitting `/data` into per-service mounts breaks hardlinked imports on both hosts and both filesystems.
+
+The wholesale mount is therefore load-bearing, not an oversight.
+
+## Decision
+
+Proposed, not yet accepted; this records the constraint so the question is not re-litigated from first principles.
+
+1. **Keep the wholesale `/data` mount for any service that hardlinks.** Today: `sonarr`, `radarr`, `cross-seed`. There is no arrangement of bind mounts that narrows their view and preserves imports.
+2. **Narrow only services that never hardlink.** Today that is `bazarr` alone, which writes subtitles alongside media and never touches `downloads` — it can take `tv` and `movies` and drop the rest.
+3. **Treat "a service does not touch data outside its scope" as a property to assert in tests, not one to enforce structurally.** That is the `data-safety` test in item 4 of the hardening plan, whose value rises considerably given prevention is unavailable.
+4. **Do not restructure the media tree or split service uids for this.** See alternatives.
+
+Most of the stack is already narrow, which is why the residual scope is one service. `prowlarr`, `huntarr`, `maintainerr`, `seerr` and `wizarr` mount no data at all; `qbittorrent`, `cleanuparr` and `shelfmark` mount only `downloads`; `grimmory` already mounts per-library — `books`, `comics`, `manga`, `doujin`, `lightnovels`, `audiobooks`, `bookdrop` — and is the in-repo precedent for the pattern where it is available.
+
+## Consequences
+
+**Positive**
+
+- The constraint is measured and written down, so the next attempt starts from evidence rather than from the same wrong assumption about `st_dev`.
+- Hardlinked imports keep working. Losing them would double storage consumption on a 2×4TB pool, which is a considerably worse outcome than the risk being mitigated.
+- `bazarr` is a real reduction: from the entire media tree to two library directories.
+- Effort is redirected to the `data-safety` test, which covers every service including the ones confinement cannot reach.
+
+**Negative**
+
+- **The failure class that actually happened remains structurally possible** for `sonarr`, `radarr` and `cross-seed`. A service pointed at the shared root can still destroy it.
+- The remaining defence is detection, not prevention — a test that fails in CI, and an alert afterwards, rather than an `EACCES` at the moment of the mistake.
+- It continues to rest on each application's own configuration being right, and that config is runtime state rather than Nix. The recovery doc already flags this: `download_dir` is not restored by a rebuild and must be verified after any config restore.
+- This is the one item that would have prevented the incident outright, and it is being deliberately given up. Worth revisiting if the stack grows another service that wants a download root.
+
+## Alternatives considered
+
+- **Per-service bind mounts for everything.** Measured above; fails with `EXDEV` on both hosts. This was the original proposal.
+- **Restructure the tree so each service has a narrow common ancestor.** A hardlinking service needs its download directory and its library directory inside one mount, so the mount must be their common ancestor — which, given the current layout, is the tree root by construction. Fixing that means a per-library download root and a data migration of several TB, to protect against a class of mistake that has occurred once.
+- **Per-service uids and ACLs instead of visibility.** Abandons the shared-ownership model the whole stack is built on. It also would not have helped: the deletion was performed by the uid that owned the files, so this needs per-service ownership of every file in the tree, not merely per-service accounts.
+- **systemd hardening directives on the units.** Near-useless here, as measured: the units are podman wrappers, and the native services are already hardened by nixpkgs.
+- **Copy instead of hardlink on import.** Removes the constraint entirely and is the only option that makes full confinement possible. Rejected on storage: the pool is 2×4TB and the library is already 3.68 TiB in torrents alone.

--- a/docs/plans/deployment-hardening.md
+++ b/docs/plans/deployment-hardening.md
@@ -4,7 +4,7 @@ Status: revised 2026-08-16 to follow [ADR 0002](../adr/0002-protect-at-activatio
 
 Already in place, and assumed by everything below: the deployment metrics in `modules/services/monitoring/deploy-metrics.nix` and the `NixosDeployFailed` / `NixosDeployStale` / `NixosRebootPending` rules in `modules/services/monitoring/alert-rules.yml`. No new monitoring work is required to start.
 
-Six pieces. The first two are small and independent; the rest can proceed in any order once they are in.
+Six pieces originally; five now, since service confinement moved out to [ADR 0003](../adr/0003-service-confinement-is-bounded-by-hardlinking.md). The first two are small and independent; the rest can proceed in any order once they are in.
 
 | #   | Item                      | Size    | Status                                                   |
 | --- | ------------------------- | ------- | -------------------------------------------------------- |
@@ -12,7 +12,7 @@ Six pieces. The first two are small and independent; the rest can proceed in any
 | 2   | Retire `deploy-stable`    | small   | **done** 2026-08-16                                      |
 | 3   | Health-gated activation   | medium  | **landed, not armed** - reports, does not yet roll back  |
 | 4   | Behaviour tests           | large   | not started - now the highest-value item                 |
-| 5   | Service confinement       | medium  | _proposed, not yet decided_                              |
+| 5   | Service confinement       | -       | **moved out** - [ADR 0003](../adr/0003-service-confinement-is-bounded-by-hardlinking.md) |
 | 6   | `deploy-rs` interactively | small   | not started - one prerequisite removed                   |
 
 ### Where this stands, 2026-08-16
@@ -21,7 +21,7 @@ Items 1-3 landed today as four PRs (#22-#25). What remains before any of them ca
 
 - **Item 1** is proven end to end on `homelab01` - counter written, boot counted, `boot-complete.target` reached, entry blessed - and is still on that host alone. A second PR enables `homelab02` and `xps15`.
 - **Item 3** landed with `rollback.enable = false` on both servers and has passed once on each. It verifies, exports metrics and alerts; it does not act. Arming it is one line per host, and should wait for a few weeks of evidence about how often it would have fired on a host that was actually fine.
-- **Item 4** is now the binding constraint. ADR 0002 made behaviour tests the primary pre-deploy gate, and until they exist the gate is still "it builds" - which is precisely the class of failure items 1 and 3 are left cleaning up after.
+- **Item 4** is now the binding constraint, and more so since ADR 0003. Behaviour tests were already the primary pre-deploy gate per ADR 0002, and until they exist the gate is still "it builds" - which is precisely the class of failure items 1 and 3 are left cleaning up after. ADR 0003 then found that service confinement cannot enforce the data-safety property structurally, so the `data-safety` test is now the only thing that will cover it.
 
 A note on sequencing, since it caught us out today: item 2's ordering section argued it was safe to take before item 3, and that held - but only because the interval was hours. Both servers now take a promoted revision on the same night with no automated recovery from a bad one, and that stays true until item 3 is armed.
 
@@ -304,7 +304,7 @@ The third is the most faithful and the most work. Start with the second and see 
 | `digital-garden` | quartz builds a vault and the result is served                      | the failure mode is a _successful_ build and an empty site                       |
 | `media-stack`    | the arr services reach their ports                                  | the largest module, and the one with the most moving parts                       |
 
-`data-safety` is new and first for a reason: two of the three recent incidents were a service touching data it had no business touching, and it is the cheapest assertion in the table.
+`data-safety` is first for a reason, and ADR 0003 sharpened it. The recent data loss was one root cause - LazyLibrarian's PostProcessor pointed at the shared download root - firing twice, two days apart, for 3.68 TiB. ADR 0003 then established that no arrangement of bind mounts can prevent a recurrence for the services that hardlink, because the kernel will not link across a mount boundary. So this test is not a cheap complement to confinement, as this plan originally had it; for `sonarr`, `radarr` and `cross-seed` it is the only thing that will cover the property at all.
 
 `digital-garden` remains the most valuable per line among the rest: it is the one place where the current gate is actively misleading, because a broken plugin index produces a build that succeeds.
 
@@ -320,26 +320,13 @@ At least one test exists, the gate runs it, and a deliberately broken service co
 
 ---
 
-## 5. Service confinement _(proposed - not part of ADR 0002)_
+## 5. Service confinement _(moved out - see [ADR 0003](../adr/0003-service-confinement-is-bounded-by-hardlinking.md))_
 
-### The problem
+Removed from this plan. It was prevention rather than deployment hardening, and it arrived late in the discussion that produced ADR 0002 - the "decide first" this section used to carry has been decided by moving it out.
 
-Two of the three recent incidents were a service damaging data outside its own scope. Detection after the fact is expensive; prevention is declarative and cheap. A service that cannot write to the shared download root cannot delete it.
+It also turned out to be mostly infeasible, for a reason worth knowing before anyone proposes it again. Narrowing a service's view means per-service bind mounts, and the kernel refuses to hardlink across a mount boundary even within one filesystem - measured on both hosts and both filesystems, with identical `st_dev` on each side and `EXDEV` anyway. The wholesale `/data` mount every service gets is therefore load-bearing for hardlinked imports, not conservatism.
 
-### Approach
-
-Tighten the systemd units the service modules generate - `ProtectSystem=strict`, `ProtectHome`, `PrivateTmp`, and an explicit `ReadWritePaths` naming only what the service legitimately writes. For the podman-hosted services the equivalent is narrowing the bind mounts rather than mounting the media tree wholesale.
-
-Pairs naturally with the `data-safety` test in item 4: the test asserts the property, the confinement enforces it.
-
-### Risks
-
-- Several of these services legitimately need broad access - qBittorrent writes into the download root by design, unpackerr extracts across it, cross-seed reads the whole media tree. The win is narrowing _which_ tree, not eliminating access, and getting it wrong shows up as a service that starts and then silently fails on IO.
-- Worth doing one module at a time, behind the VM tests, rather than as a sweep.
-
-### Decide first
-
-Whether this belongs in this plan at all or as its own piece of work. It is prevention rather than deployment hardening, and it arrived late in the discussion that produced ADR 0002.
+What survives is one service and a redirection of effort: `bazarr` never hardlinks and can be narrowed, and the property confinement would have enforced is now something for the `data-safety` test in item 4 to assert instead. That raises item 4's value rather than lowering it - the test covers every service, including the ones confinement cannot reach.
 
 ---
 

--- a/modules/services/monitoring/alert-rules.yml
+++ b/modules/services/monitoring/alert-rules.yml
@@ -327,6 +327,37 @@ groups:
           summary: "{{ $labels.host }} activated a generation that did not come up healthy"
           description: "Verification found units failing that were not failing before the upgrade. Check: journalctl -u nixos-upgrade-verify.service"
 
+      # The silence problem, applied to the safety net itself. NixosVerifyFailed
+      # only speaks when verification runs and fails; if it stopped running —
+      # timer broken, module disabled, unit masked — nixos_verify_result would
+      # sit at 1 forever and the absence of alerts would read as evidence of
+      # health. That absence is exactly what the decision to arm
+      # cg.upgrade-verify.rollback.enable rests on, so it needs checking.
+      #
+      # Not a plain staleness check on the timestamp: verification deliberately
+      # no-ops when the generation has not changed, and exits before writing
+      # metrics, so on a night where `deploy` did not move the timestamp goes
+      # stale for entirely correct reasons. What is wrong is a generation
+      # staged well after the last verification — activated, but never checked.
+      #
+      # `pending_reboot == 0` excludes the staged-but-not-yet-activated case,
+      # which is NixosRebootPending's business and would otherwise fire here
+      # first and more noisily for the same underlying condition.
+      #
+      # 6h rather than something tighter because a manual `nixos-rebuild
+      # switch` also trips this — correctly, since it activates a generation
+      # nothing verifies — and iterating on a service should not page you.
+      - alert: NixosVerifyStale
+        expr: |
+          (nixos_deploy_staged_timestamp_seconds - nixos_verify_timestamp_seconds > 21600)
+          and nixos_deploy_pending_reboot == 0
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.host }} is running a generation that activation verification never checked"
+          description: "A generation was activated over 6 hours ago and nixos-upgrade-verify has not recorded a result since. Either it is not running, or the generation was applied by hand. Check: systemctl status nixos-upgrade-verify.timer"
+
       # Loud on purpose. A host that reverts itself stops tracking the promoted
       # ref, and would otherwise announce that two days later as NixosDeployStale
       # — an alert whose text points nowhere near the actual cause.

--- a/modules/services/monitoring/monitoring.nix
+++ b/modules/services/monitoring/monitoring.nix
@@ -385,6 +385,15 @@ in
 
         services.prometheus = {
           enable = true;
+          # Up from the 15d default, because the questions this stack is asked
+          # are monthly ones: whether health-gated activation ever wanted to
+          # roll back, whether a threshold was right, how often the lock update
+          # produced an empty diff. A 30d query against 15d of data silently
+          # returns 15d and looks better-evidenced than it is.
+          #
+          # Cheap here - a handful of targets at a 1m interval, against 160GB
+          # free on the host holding the pool.
+          retentionTime = "30d";
           globalConfig = {
             scrape_interval = "1m";
             scrape_timeout = "30s"; # was defaulting to 10s


### PR DESCRIPTION
Item 5 moved out of the hardening plan into [ADR 0003](docs/adr/0003-service-confinement-is-bounded-by-hardlinking.md), **Status: Proposed** — the direction is clear, the work is deferred.

## The idea was right in shape

The LazyLibrarian deletions (3.68 TiB, twice, two days apart) were by the uid that *owned* the files, doing exactly what it was told to the wrong directory. So permissions were never the lever — `root_squash` never applied. The defence has to be **visibility**: the shared root shouldn't exist in the service's namespace, so a misconfiguration naming it finds nothing rather than everything. That's also independent of the app config, which is where the fault actually was.

## But it doesn't work, and I measured it rather than assuming

Narrowing means per-service bind mounts. The kernel refuses to hardlink across a **mount boundary**, even within one filesystem:

| Setup | Result |
| --- | --- |
| same fs, no container, two subtrees | ✅ `links=2` |
| two separate bind mounts, NFS (homelab01) | ❌ `EXDEV` |
| two separate bind mounts, ZFS (homelab02) | ❌ `EXDEV` |
| **single** parent bind mount, ZFS | ✅ `links=2` |

Tested with the production images and uid, on both hosts and both filesystems.

The instructive part: **both mounts report an identical `st_dev`** — 107 on NFS, 46 on ZFS — and `link()` fails anyway. `st_dev` is the wrong thing to reason from, which is exactly why the proposal looked plausible. I'd asserted this would work in my previous message; it doesn't.

So the wholesale `/data` mount is **load-bearing for hardlinked imports, not conservatism**. The module comment saying "for hardlink support" was accurate and I'd read it as over-caution.

## What survives

Much less than the plan implied, because most of the stack is already narrow:

| | |
| --- | --- |
| no data mount at all | prowlarr, huntarr, maintainerr, seerr, wizarr |
| `downloads` only | qbittorrent, cleanuparr, shelfmark |
| already per-library | grimmory (books, comics, manga, doujin, lightnovels, audiobooks, bookdrop) |
| **wholesale `/data`** | **sonarr, radarr, bazarr, cross-seed** |

Of those four, only `bazarr` never hardlinks — it writes subtitles alongside media and never touches `downloads`. It's the one service that can be narrowed.

## Consequence worth being explicit about

**The failure class that actually happened remains structurally possible** for sonarr, radarr and cross-seed. The remaining defence is detection — the `data-safety` test — not prevention. That's a deliberate trade recorded in the ADR's Negative consequences, not an oversight.

It also raises item 4's value rather than lowering it: the test covers every service, including the ones confinement can't reach.

## Also in here

- Item 5's section replaced with a pointer and the reason, so nobody re-proposes it from the same wrong assumption
- Status table and the "binding constraint" note updated
- README documentation table gains ADR 0003, marked _proposed_
- **A factual correction in item 4**: it claimed "two of the three recent incidents" were a service touching data it shouldn't. Reading the recovery doc, it was *one root cause firing twice*. ADR 0003 leans on that record, so it's worth being accurate.

## Note on the artefact choice

An ADR rather than a plan, because the durable output is a **constraint discovered by experiment**, which will outlive any plan and would otherwise be rediscovered the hard way. `Proposed` rather than `Accepted` since you're revisiting later. A plan document would have been mostly empty — the actionable work is one service.