### PR TITLE
docs(ci): explain why master rebuilds what the PR just built

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -48,6 +48,10 @@ Both servers land on the same revision the same night. The 15 minute offset is n
 
 **The gate job name is a required status check.** `nixos ci` in `ci.yml` is the context named by the `protect-main` ruleset. Rename the job and every merge blocks, with no bypass, until the ruleset is updated to match. Treat the two as a pair.
 
+**A PR must be up to date with `master` before it can merge.** `protect-main` sets `strict_required_status_checks_policy`, so GitHub will not merge a branch whose base has moved since its last green run. This costs an "Update branch" click whenever two PRs are in flight at once, and it buys the thing the gate is supposed to guarantee: a PR builds `refs/pull/N/merge`, its head merged into `master` _as of that run_, so without the strict policy two independently-green PRs can merge minutes apart and produce a `master` tree that nothing ever built. That happened on 2026-08-16 - #24 and #25 landed 33 seconds apart, and #24's CI run started before #25 existed.
+
+**The master build is not the PR build run twice.** `self.rev` is baked into `system.configurationRevision`, so the toplevel store path is a function of the commit SHA, and a squash merge always mints a new one. Master's toplevel has never been built at PR time even when the tree is identical - the run substitutes the closure and builds the rev-dependent tail on top. It is what puts the promoted closure in Cachix, so it stays even though the strict policy above already settled which _tree_ lands.
+
 **Never create a branch under `deploy/`.** Git stores refs as paths, so `deploy/my-branch` turns `refs/heads/deploy` into a directory and promotion fails with `directory file conflict` for as long as that branch exists. The `reserve-deploy-namespace` ruleset blocks this at the server; the failure is obscure enough to be worth naming twice.
 
 **`deploy` rejects non-fast-forward pushes, with zero bypass actors.** Not even an admin or `GITHUB_TOKEN` can force-push or delete it. This is deliberate, and it means the recovery below requires temporarily relaxing a ruleset - there is no way around it from the client side.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,21 @@ name: NixOS CI
 # hosts substitute from - CI builds the closure once instead of each host
 # rebuilding it independently at 04:00.
 #
+# NOTE: the PR build and the master build look like the same build run twice.
+# They are not, and dropping the master one breaks promotion. `self.rev` is
+# baked into `system.configurationRevision` (flake.nix), so the toplevel store
+# path is a function of the commit SHA - and a squash merge always mints a new
+# SHA. Master's toplevel therefore cannot have been built on the PR even when
+# the tree is byte-identical. In practice the master run substitutes the whole
+# closure and builds ~19 rev-dependent derivations on top. Without it,
+# `promote` would move `deploy` to a closure the gate never built and the cache
+# never held, and every host would build that tail itself at 04:00.
+#
+# What the master run is *not* covering is a merge of stale content: the
+# `protect-main` ruleset sets `strict_required_status_checks_policy`, so a PR
+# must be up to date with master before it can merge, which makes the merge ref
+# the PR built the tree that actually lands.
+#
 # NOTE: the `nixos ci` job name is the status-check context required by the
 # `protect-main` repository ruleset. Renaming that job silently blocks every
 # merge until the ruleset is updated to match, so treat the two as a pair.


### PR DESCRIPTION
Follows up on a question about the pipeline: why does opening a PR build all three hosts, and then merging build all three hosts again?

## The master build is load-bearing

It is not the PR build run twice. `flake.nix` sets `system.configurationRevision = self.rev`, consumed by `modules/services/monitoring/deploy-metrics.nix`, so the toplevel store path is a function of the commit SHA — and a squash merge always mints a new one. Master's toplevel cannot have been built at PR time even when the tree is byte-identical.

In practice the master run substitutes the closure and builds the rev-dependent tail. From the `dd52531` run:

```
these 19 derivations will be built:
these 1698 paths will be fetched (4.0 GiB download, 11.1 GiB unpacked):
```

Nineteen derivations, not a rebuild. Drop that run and `promote` moves `deploy` to a closure the gate never built and Cachix never held, leaving each host to build the tail itself at 04:00.

## The actual gap was elsewhere

`protect-main` had `strict_required_status_checks_policy: false`, so a PR could merge without being up to date with master. A PR builds `refs/pull/N/merge` — its head merged into master _as of that run_ — so two independently-green PRs merging minutes apart can produce a master tree nothing ever built.

Not hypothetical: #25 (`4d2ad99`) landed 07:51:06 and #24 (`612e6ea`) landed 07:51:39 on 2026-08-16. #24's run started 07:47:59, before #25 existed.

The policy is now enabled on the ruleset. The cost is an "Update branch" click when two PRs are in flight at once.

## This PR

Documentation only — no workflow behaviour changes. Rulesets live server-side, so the strict policy is recorded as an invariant in the README; nothing in the repo would otherwise show it.