### PR TITLE
test(checks): boot real VMs for monitoring and the reverse proxy

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,7 +24,7 @@ The laptop follows `deploy` too, but never switches on its own: it builds in the
 
 | Workflow             | When                        | Does                                                               |
 | -------------------- | --------------------------- | ------------------------------------------------------------------ |
-| `ci.yml`             | every PR and push to master | builds all three hosts, `nix flake check`, fast-forwards `deploy`  |
+| `ci.yml`             | every PR and push to master | builds all three hosts, `nix flake check` (incl. the VM tests in `checks/`), fast-forwards `deploy` |
 | `flake-update.yml`   | daily, 15:00 UTC            | `nix flake update`, per-host closure diff, PR, auto-merge on green |
 | `package-update.yml` | Mondays, 03:00 UTC          | runs each package's own updater, one PR per package                |
 
@@ -51,6 +51,8 @@ Both servers land on the same revision the same night. The 15 minute offset is n
 **A PR must be up to date with `master` before it can merge.** `protect-main` sets `strict_required_status_checks_policy`, so GitHub will not merge a branch whose base has moved since its last green run. This costs an "Update branch" click whenever two PRs are in flight at once, and it buys the thing the gate is supposed to guarantee: a PR builds `refs/pull/N/merge`, its head merged into `master` _as of that run_, so without the strict policy two independently-green PRs can merge minutes apart and produce a `master` tree that nothing ever built. That happened on 2026-08-16 - #24 and #25 landed 33 seconds apart, and #24's CI run started before #25 existed.
 
 **The master build is not the PR build run twice.** `self.rev` is baked into `system.configurationRevision`, so the toplevel store path is a function of the commit SHA, and a squash merge always mints a new one. Master's toplevel has never been built at PR time even when the tree is identical - the run substitutes the closure and builds the rev-dependent tail on top. It is what puts the promoted closure in Cachix, so it stays even though the strict policy above already settled which _tree_ lands.
+
+**`flake-check` boots VMs now, and its runtime depends on KVM.** `nix flake check` runs the behaviour tests in `checks/`, which are NixOS VM tests. Locally, with `/dev/kvm`, the two of them take about 80 seconds; without it QEMU falls back to TCG emulation and the same tests take long enough to matter for a job that also has to promote. The job logs which case it is in rather than failing either way, so a gate that suddenly got slow says why in its own output. Adding a test that needs several minutes is a decision about the nightly lock PR's auto-merge latency, not just about coverage.
 
 **Never create a branch under `deploy/`.** Git stores refs as paths, so `deploy/my-branch` turns `refs/heads/deploy` into a directory and promotion fails with `directory file conflict` for as long as that branch exists. The `reserve-deploy-namespace` ruleset blocks this at the server; the failure is obscure enough to be worth naming twice.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,26 @@ jobs:
         with:
           name: corygyarmathy-dotfiles
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          # Substitute only; nothing worth pushing is built here.
+          # Substitute only. This job does now build things - the behaviour
+          # test VMs in ./checks - but nothing a host will ever need, and the
+          # test runners themselves have to execute on every commit regardless
+          # of whether their closure was cached.
           skipPush: true
+
+      # The behaviour tests boot real VMs. With KVM that is around a minute
+      # each; without it QEMU falls back to TCG emulation and the same tests
+      # take long enough to matter for a gate that also has to promote. This
+      # step does not fail the build either way - it just makes the answer
+      # visible in the log, so a gate that suddenly got slow has an
+      # explanation rather than a mystery. See the "Cost and risks" section of
+      # docs/plans/deployment-hardening.md.
+      - name: Report KVM availability
+        run: |
+          if [ -e /dev/kvm ]; then
+            echo "::notice::/dev/kvm present - NixOS tests run accelerated"
+          else
+            echo "::warning::/dev/kvm absent - NixOS tests fall back to TCG emulation"
+          fi
 
       - name: Check flake
         run: nix flake check --print-build-logs

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ dotfiles/
 │   ├── nixos/             # System-level modules
 │   ├── services/          # Homelab service modules (auto-imported)
 │   └── home/              # Home-manager modules
+├── checks/                # Behaviour tests: NixOS VMs booted by `nix flake check`
 ├── configs/               # Portable dotfiles, symlinked by home-manager
 ├── overlays/              # Package overlays
 ├── packages/              # Custom package definitions
@@ -155,7 +156,7 @@ sops secrets/homelab.yaml                   # edit
 
 Stated plainly, because a pipeline whose limits are undocumented invites more trust than it has earned:
 
-- **Building is the only pre-deploy gate, and building is not working.** A package that compiles and then fails at runtime will auto-merge and deploy. The alert rules catch it afterwards. NixOS VM tests are the intended fix.
+- **Building is still most of the pre-deploy gate.** A package that compiles and then fails at runtime will auto-merge and deploy. NixOS VM tests in `checks/` now cover the monitoring stack and the reverse proxy — enough to catch a Prometheus config that will not load or a Caddyfile that will not parse, which between them would take down every service on a host — but the media stack is not covered, and that is where the failure history actually is. The alert rules still catch the rest afterwards.
 - **Automated rollback covers only a generation that will not boot, and only on homelab01 so far.** systemd's boot assessment gives a new generation three attempts to reach `boot-complete.target`; one that never does is skipped in favour of an older entry, without anyone standing in front of the machine.
 - **A generation that boots and then comes up broken is detected but not yet reverted.** Both servers verify what they activated and alert if units are failing that were not failing before, but the rollback that check is wired to is deliberately switched off until there is evidence about its false-positive rate. Until then this is a faster, better-aimed alert, not a recovery.
 - **Nothing protects against a change that cuts the host off.** Verification runs on the host, so a machine that has lost its network still believes it is fine — and locally, it is. A bad firewall or sshd change still means a trip to the cupboard.

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -1,0 +1,50 @@
+# Behaviour tests - item 4 of docs/plans/deployment-hardening.md, and the
+# primary pre-deploy gate per ADR 0002.
+#
+# The build gate proves that a host configuration evaluates and that its
+# derivations realise. It proves nothing about whether the services that
+# configuration ships actually start, or whether the config files they are
+# handed are accepted by the programs that read them. Service configuration is
+# the failure class this homelab actually experiences, so that gap is the
+# whole point of this directory: these tests boot real VMs and assert against
+# them.
+#
+# Exposed as flake `checks`, so `nix flake check` runs them and the existing
+# `nixos ci` gate picks them up with no workflow changes.
+#
+# TEST MODULES, NOT HOSTS. A whole host configuration will not boot in a VM:
+# disko expects real disks, ZFS expects a pool, sops expects host keys,
+# homelab01 expects an NFS server on homelab02. Each test instantiates the
+# service module under examination in an otherwise minimal machine, with
+# secrets stubbed by ./lib.nix.
+#
+# NO NETWORK. The VMs run inside the Nix build sandbox, which has none. That
+# is a constraint on what can be tested here rather than an inconvenience:
+# anything whose behaviour depends on fetching something at runtime - every
+# `virtualisation.oci-containers` service in modules/services, all of which
+# pull `:latest` from a registry - cannot be started in this harness as
+# written. See the `data-safety` discussion in the plan.
+{
+  pkgs,
+  self,
+  inputs,
+}:
+let
+  testLib = import ./lib.nix { inherit pkgs self inputs; };
+in
+{
+  # Static validation. Cheap, and worth keeping separate from the VM test
+  # below: when both fail, which one failed says whether the rule file is
+  # malformed or merely rejected in context.
+  #
+  # promtool lives in the `cli` output, not `out`.
+  alert-rules =
+    pkgs.runCommand "check-alert-rules" { nativeBuildInputs = [ pkgs.prometheus.cli ]; }
+      ''
+        promtool check rules ${../modules/services/monitoring/alert-rules.yml}
+        touch $out
+      '';
+
+  monitoring = testLib.mkTest ./monitoring.nix;
+  reverse-proxy = testLib.mkTest ./reverse-proxy.nix;
+}

--- a/checks/lib.nix
+++ b/checks/lib.nix
@@ -1,0 +1,35 @@
+# Shared plumbing for the behaviour tests in this directory.
+#
+# See ./default.nix for what these tests are for and why they instantiate
+# service modules rather than whole hosts, and ./stub-secrets.nix for how they
+# get around sops.
+{
+  pkgs,
+  self,
+  inputs,
+}:
+{
+  # runNixOSTest with the specialArgs this repository's modules are written
+  # against. `self` is not optional: several modules reach into self.packages
+  # for things this flake builds itself, and one that does will not evaluate
+  # without it.
+  mkTest =
+    module:
+    pkgs.testers.runNixOSTest {
+      imports = [ module ];
+
+      # Applies to every node of every test.
+      node.specialArgs = { inherit self inputs; };
+
+      defaults = {
+        # Option definitions only, until a secret is actually declared - so
+        # this costs nothing for the tests that need no secrets, and saves
+        # every test that does need one from remembering to import it.
+        imports = [ inputs.sops-nix.nixosModules.sops ];
+
+        # The VM has no persistent state and one job. Skip the parts of a real
+        # host that only cost boot time here.
+        documentation.enable = false;
+      };
+    };
+}

--- a/checks/monitoring.nix
+++ b/checks/monitoring.nix
@@ -1,0 +1,140 @@
+# Prometheus starts, loads its rules, and scrapes a target that is really
+# reporting - including the deployment pipeline's own telemetry.
+#
+# The `alert-rules` check next door runs `promtool check rules` over
+# alert-rules.yml, which proves that one file is syntactically valid in
+# isolation. It says nothing about the config Prometheus is actually handed:
+# scrape jobs, relabelling, the alertmanager block and the rule file are
+# assembled by monitoring.nix from options, and a mistake there surfaces only
+# when the server refuses to start on the host - i.e. after activation, on the
+# machine that is meant to be watching everything else.
+#
+# The last subtest is the one worth having. ADR 0001's deployment metrics
+# reach Prometheus through a chain of four independent pieces - deploy-metrics
+# writes a .prom file, monitoring.nix has to enable node_exporter's textfile
+# collector, node_exporter has to be pointed at the right directory, and
+# Prometheus has to scrape it - and a break anywhere along it is silent. The
+# alerts simply never fire, which is indistinguishable from nothing being
+# wrong. deploy-metrics.nix already carries a comment about having had to
+# override a `mkDefault` that left the collector off on homelab01, so this is
+# not a hypothetical.
+#
+# `cloudflaredTarget` is set here rather than left at its default because the
+# default is `null` and monitoring.nix drops it into a static_configs target
+# list unconditionally. Both hosts set it, so the null path is unreachable in
+# production - it is called out so that this test is not blamed for it later.
+{
+  name = "monitoring";
+
+  nodes.machine = {
+    imports = [
+      ../modules/services/monitoring/monitoring.nix
+      ../modules/services/monitoring/deploy-metrics.nix
+    ];
+
+    cg.service.monitoring = {
+      enable = true;
+      prometheus.enable = true;
+
+      # Scrape this machine's own node_exporter. A real target, so `up` means
+      # the scrape loop genuinely completed rather than that the config parsed.
+      scrapeTargets = [ "localhost:9100" ];
+      cloudflaredTarget = "localhost:20241";
+
+      # On a host this defaults on wherever system.autoUpgrade is enabled,
+      # which no test VM is. Forced on because it is half of what this test is
+      # here to cover.
+      deploy.enable = true;
+
+      httpProbes = [
+        {
+          name = "self";
+          url = "http://localhost:9090/-/healthy";
+        }
+      ];
+    };
+
+    # Prometheus plus three exporters; the default leaves this thrashing.
+    virtualisation.memorySize = 2048;
+  };
+
+  testScript = ''
+    import json
+    from datetime import timedelta
+
+    def query(expr):
+        out = machine.succeed(
+            "curl -sf --get --data-urlencode 'query={}' "
+            "http://localhost:9090/api/v1/query".format(expr)
+        )
+        return json.loads(out)["data"]["result"]
+
+    machine.wait_for_unit("prometheus.service")
+    machine.wait_for_open_port(9090)
+    machine.wait_until_succeeds("curl -sf http://localhost:9090/-/ready", timeout=120)
+
+    with subtest("the rule file is loaded by the server, not merely valid on disk"):
+        rules = json.loads(machine.succeed("curl -sf http://localhost:9090/api/v1/rules"))
+        assert rules["status"] == "success", rules
+        groups = rules["data"]["groups"]
+        assert groups, "Prometheus started with no rule groups loaded"
+
+        names = {r["name"] for g in groups for r in g["rules"]}
+        # One representative from each family the deployment pipeline depends
+        # on. If alert-rules.yml is reorganised these names may legitimately
+        # change - but they should change deliberately, not silently.
+        for expected in ["NixosDeployFailed", "NixosDeployStale", "NixosVerifyFailed"]:
+            assert expected in names, f"{expected} missing from loaded rules: {sorted(names)}"
+
+    with subtest("a target is actually scraped"):
+        machine.wait_for_unit("prometheus-node-exporter.service")
+        machine.wait_for_open_port(9100)
+
+        # scrape_interval is 1m and Prometheus jitters each target's first
+        # scrape across that window, so this can genuinely take a minute.
+        def node_up(_):
+            result = query('up{job="node"}')
+            return bool(result) and result[0]["value"][1] == "1"
+
+        retry(node_up, timeout=timedelta(seconds=180))
+
+    with subtest("deployment metrics reach Prometheus"):
+        # NOT wait_for_unit: nixos-deploy-metrics is a Type=oneshot without
+        # RemainAfterExit, so it reads `inactive` the moment it succeeds and
+        # waiting for it to be active waits forever. Starting it explicitly is
+        # also the deterministic choice - it already ran at multi-user.target,
+        # and this removes the race with node_exporter's first read.
+        #
+        # (The same shape is the trap item 3 documents for criticalUnits:
+        # `is-active` is only meaningful for a oneshot that sets
+        # RemainAfterExit. This unit is not probed there, but it is the same
+        # mistake waiting to be made.)
+        machine.succeed("systemctl start nixos-deploy-metrics.service")
+
+        # First that the file is written where the collector is looking, so a
+        # failure here points at deploy-metrics rather than at the scrape.
+        machine.succeed("test -s /var/lib/prometheus-node-exporter/nixos_deploy.prom")
+
+        # Then that node_exporter's textfile collector is switched on and
+        # pointed at that directory - the wiring deploy-metrics.nix has to
+        # override a mkDefault to get.
+        #
+        # Written to a file rather than piped into grep: the test driver runs
+        # commands under `pipefail`, and `grep -q` exits at the first match,
+        # which hands curl an EPIPE and fails the whole pipeline for a match
+        # that was actually found. The symptom is a passing condition that
+        # times out, so it is worth not writing it the obvious way.
+        machine.wait_until_succeeds(
+            "curl -sf -o /tmp/node-metrics http://localhost:9100/metrics "
+            "&& grep -q nixos_deploy_revision_info /tmp/node-metrics",
+            timeout=60,
+        )
+
+        # And finally that it survives the scrape, which is the only step that
+        # proves the whole ADR 0001 telemetry chain is connected.
+        def revision_exported(_):
+            return bool(query("nixos_deploy_revision_info"))
+
+        retry(revision_exported, timeout=timedelta(seconds=180))
+  '';
+}

--- a/checks/reverse-proxy.nix
+++ b/checks/reverse-proxy.nix
@@ -1,0 +1,179 @@
+# Caddy starts with the generated config, and routes to a backend over TLS.
+#
+# Every publicly reachable service on this fleet sits behind this module, and
+# a routing regression is completely invisible to a build: reverse-proxy.nix
+# assembles a Caddyfile out of options, and Caddy only reads it at activation.
+# A malformed directive, a plugin that stopped providing `rate_limit`, a
+# header block that no longer parses - all of them build perfectly and take
+# every service on the host down when they land.
+#
+# The only substitution this test makes is the certificate issuer. Production
+# gets an individual Let's Encrypt certificate per vhost over the ACME DNS-01
+# challenge against Cloudflare, which needs the network the sandbox does not
+# have; `tls internal` puts Caddy's own CA in its place, through the module's
+# existing per-service `extraConfig` rather than by overriding anything. So
+# the sites are still served over HTTPS on 443, and everything except
+# issuance is the configuration the hosts actually run.
+#
+# `auto_https off` was the first attempt and is the wrong tool: it stops
+# certificate provisioning but does not move the listener, so Caddy sits on
+# 443 with no certificate and every request fails. Worth recording, since the
+# option name suggests otherwise.
+{
+  name = "reverse-proxy";
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    let
+      backendPort = 8123;
+
+      # Echoes the request headers back as JSON, so the test can assert on
+      # what the proxy actually forwarded rather than only on a status code.
+      # The `header_up` lines in mkProxyHost are the part of that module most
+      # likely to be edited by someone with no easy way to check the result.
+      backend = pkgs.writeText "backend.py" ''
+        import json
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                body = json.dumps({
+                    "path": self.path,
+                    "headers": {k.lower(): v for k, v in self.headers.items()},
+                }).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args):
+                pass
+
+
+        HTTPServer(("127.0.0.1", ${toString backendPort}), Handler).serve_forever()
+      '';
+
+      # 40 characters of [A-Za-z0-9_-], because that is the shape of a
+      # Cloudflare API token and caddy-dns/cloudflare validates it while
+      # provisioning the TLS app - before any request is served, and even
+      # though nothing here will ever call the API with it. A placeholder that
+      # does not parse takes Caddy down at startup, which is worth knowing
+      # about the real secret too.
+      token = "TESTONLY-not-a-real-cloudflare-token-abc";
+    in
+    {
+      imports = [
+        ../modules/services/reverse-proxy.nix
+        (import ./stub-secrets.nix {
+          secrets."cloudflare/api-token" = token;
+          templates."caddy-cloudflare-env" = "CF_API_TOKEN=${token}\n";
+        })
+      ];
+
+      cg.service.reverse-proxy = {
+        enable = true;
+        email = "test@example.invalid";
+        # Exactly how the hosts wire it (hosts/homelab01/default.nix:370), so
+        # the test breaks if that indirection changes.
+        cloudflareTokenFile = config.sops.templates."caddy-cloudflare-env".path;
+
+        services = {
+          # The common case: a LAN-only service. mkProxyHost's allowlist
+          # includes 127.0.0.1, so a request from inside the VM is permitted.
+          internal = {
+            subdomain = "internal";
+            port = backendPort;
+            localOnly = true;
+            extraConfig = "tls internal";
+          };
+
+          # An internet-facing service, which takes the other branch of
+          # mkProxyHost entirely: security headers and the rate_limit
+          # directive - the latter being the one thing here that depends on
+          # the Caddy build actually carrying the caddy-ratelimit plugin.
+          public = {
+            subdomain = "public";
+            port = backendPort;
+            localOnly = false;
+            rateLimitProfile = "media";
+            extraConfig = "tls internal";
+          };
+        };
+      };
+
+      systemd.services.test-backend = {
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig.ExecStart = "${pkgs.python3}/bin/python3 ${backend}";
+      };
+    };
+
+  testScript = ''
+    import json
+
+    # --resolve rather than a Host header: the vhosts are matched on SNI, and
+    # -H 'Host:' does not set it. -k because the certificate is issued by
+    # Caddy's own CA, which is the whole point of `tls internal` here.
+    def curl(host, args="", path="/"):
+        return "curl -sk {} --resolve {}:443:127.0.0.1 https://{}{}".format(
+            args, host, host, path
+        )
+
+    def get(host, path="/"):
+        return json.loads(machine.succeed(curl(host, "-f", path)))
+
+    # Lowercased, because these vhosts are served over TLS and therefore
+    # HTTP/2, where header names are lowercase on the wire. Comparing against
+    # the mixed case written in reverse-proxy.nix does not merely fail - the
+    # "these headers are absent" subtest below would pass for every input,
+    # which is worse.
+    def headers_of(host):
+        return machine.succeed(curl(host, "-o /dev/null -D -")).lower()
+
+    machine.wait_for_unit("test-backend.service")
+    machine.wait_for_open_port(${toString 8123})
+
+    with subtest("caddy accepts the generated config"):
+        # The assertion that pays for this whole test. Caddy validates its
+        # config at startup and refuses to run on a bad one, so a unit that
+        # reaches active means every directive the module emitted parsed -
+        # including the ones reachable only through a rate limit profile.
+        machine.wait_for_unit("caddy.service")
+        machine.wait_for_open_port(443)
+
+    with subtest("a LAN-only service routes to its backend"):
+        body = get("internal.gyarmathy.co", "/some/path")
+        assert body["path"] == "/some/path", body
+
+    with subtest("the upstream sees the headers mkProxyHost sets"):
+        headers = get("internal.gyarmathy.co")["headers"]
+        # header_up Host {host}: the backend must see the original vhost, not
+        # 127.0.0.1. Getting this wrong breaks every service that builds an
+        # absolute URL, which is most of them.
+        assert headers["host"] == "internal.gyarmathy.co", headers
+        assert headers["x-forwarded-proto"] == "https", headers
+        assert "x-real-ip" in headers, headers
+        assert "x-forwarded-for" in headers, headers
+
+    with subtest("an internet-facing service gets the security headers"):
+        response = headers_of("public.gyarmathy.co")
+        for expected in [
+            "x-frame-options: sameorigin",
+            "x-content-type-options: nosniff",
+            "referrer-policy: strict-origin-when-cross-origin",
+            "strict-transport-security:",
+        ]:
+            assert expected in response, f"{expected!r} missing from:\n{response}"
+
+    with subtest("a LAN-only service does not get them"):
+        # Not pedantry: localOnly selects between two branches of mkProxyHost,
+        # so a service silently flipping branch shows up as headers appearing
+        # or disappearing rather than as anything failing outright.
+        response = headers_of("internal.gyarmathy.co")
+        assert "x-frame-options" not in response, response
+
+    with subtest("an unconfigured host is not routed anywhere"):
+        machine.fail(curl("nothing-here.gyarmathy.co", "-f"))
+  '';
+}

--- a/checks/stub-secrets.nix
+++ b/checks/stub-secrets.nix
@@ -1,0 +1,61 @@
+# Replace sops decryption with plaintext fixtures, for tests.
+#
+# sops cannot decrypt inside a test VM. It derives its age key from the SSH
+# host key (modules/nixos/sops-nix.nix), and a VM built in the Nix sandbox has
+# neither that key nor any way to be handed one without committing a
+# decryption key to this repository.
+#
+# So short-circuit it rather than reproduce it: point each secret and template
+# at a plaintext fixture in the store, and switch off the installer that would
+# otherwise try to decrypt the real file.
+#
+# What this deliberately does NOT do is remove the module's own
+# `sops.secrets.<name>` and `sops.templates.<name>` declarations. Those stay,
+# so a test still covers the wiring between a module and the secret names it
+# consumes - only the decryption step is replaced. Name a secret here that the
+# module under test does not declare and the override lands on nothing, which
+# is a silent pass; name one it does and the fixture is what it reads.
+#
+# The cost is that these tests prove nothing about sops itself. That is the
+# trade the plan names; the more faithful alternative - a throwaway age key
+# committed here alongside an encrypted fixture file - is available if a test
+# ever needs to cover the sops wiring rather than work around it.
+#
+# Usage, from a test's node definition:
+#
+#   imports = [
+#     (import ./stub-secrets.nix {
+#       secrets."cloudflare/api-token" = "not-a-real-token";
+#       templates."caddy-cloudflare-env" = "CF_API_TOKEN=not-a-real-token\n";
+#     })
+#   ];
+{
+  secrets ? { },
+  templates ? { },
+}:
+{ lib, pkgs, ... }:
+let
+  # The name is a sops key path, so it contains slashes; only the last segment
+  # is usable as a store path name.
+  fixture = name: content: toString (pkgs.writeText "stub-${baseNameOf name}" content);
+in
+{
+  sops.secrets = lib.mapAttrs (name: content: {
+    path = lib.mkForce (fixture name content);
+  }) secrets;
+
+  sops.templates = lib.mapAttrs (name: content: {
+    path = lib.mkForce (fixture name content);
+  }) templates;
+
+  # Satisfies sops-nix's "no key source configured" assertion, which fires as
+  # soon as any secret is declared. Nothing reads the path, because the unit
+  # that would is disabled just below.
+  sops.age.sshKeyPaths = lib.mkForce [ "/etc/ssh/ssh_host_ed25519_key" ];
+
+  # sops-nix installs secrets from one of two places depending on
+  # `useSystemdActivation`. Disable both rather than depend on which is in
+  # force, since the answer is an upstream default that can move.
+  systemd.services.sops-install-secrets.enable = false;
+  system.activationScripts.setupSecrets = lib.mkForce "";
+}

--- a/docs/plans/deployment-hardening.md
+++ b/docs/plans/deployment-hardening.md
@@ -11,7 +11,7 @@ Six pieces originally; five now, since service confinement moved out to [ADR 000
 | 1   | Boot counting             | ~1 line | **proven on homelab01** - remaining hosts still to follow |
 | 2   | Retire `deploy-stable`    | small   | **done** 2026-08-16                                      |
 | 3   | Health-gated activation   | medium  | **landed, not armed** - reports, does not yet roll back  |
-| 4   | Behaviour tests           | large   | not started - now the highest-value item                 |
+| 4   | Behaviour tests           | large   | **harness + 2 tests landed** - `data-safety` needs rethinking |
 | 5   | Service confinement       | -       | **moved out** - [ADR 0003](../adr/0003-service-confinement-is-bounded-by-hardlinking.md) |
 | 6   | `deploy-rs` interactively | small   | not started - one prerequisite removed                   |
 
@@ -21,7 +21,7 @@ Items 1-3 landed today as four PRs (#22-#25). What remains before any of them ca
 
 - **Item 1** is proven end to end on `homelab01` - counter written, boot counted, `boot-complete.target` reached, entry blessed - and is still on that host alone. A second PR enables `homelab02` and `xps15`.
 - **Item 3** landed with `rollback.enable = false` on both servers and has passed once on each. It verifies, exports metrics and alerts; it does not act. Arming it is one line per host, and should wait for a few weeks of evidence about how often it would have fired on a host that was actually fine.
-- **Item 4** is now the binding constraint, and more so since ADR 0003. Behaviour tests were already the primary pre-deploy gate per ADR 0002, and until they exist the gate is still "it builds" - which is precisely the class of failure items 1 and 3 are left cleaning up after. ADR 0003 then found that service confinement cannot enforce the data-safety property structurally, so the `data-safety` test is now the only thing that will cover it.
+- **Item 4** is now the binding constraint, and more so since ADR 0003. Behaviour tests were already the primary pre-deploy gate per ADR 0002, and until they exist the gate is still "it builds" - which is precisely the class of failure items 1 and 3 are left cleaning up after. ADR 0003 then found that service confinement cannot enforce the data-safety property structurally, so the `data-safety` test is now the only thing that will cover it. **This is where the plan was most wrong**: the harness and two tests landed the same day, and `data-safety` turned out to be the one candidate on the list that cannot be built as written and would assert nothing if it were. See below.
 
 A note on sequencing, since it caught us out today: item 2's ordering section argued it was safe to take before item 3, and that held - but only because the interval was hours. Both servers now take a promoted revision on the same night with no automated recovery from a bad one, and that stays true until item 3 is armed.
 
@@ -296,17 +296,17 @@ The third is the most faithful and the most work. Start with the second and see 
 
 ### Candidates, in order of value
 
-| Test             | Asserts                                                             | Why it earns its place                                                           |
-| ---------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `data-safety`    | a canary file in the shared download root survives service startup  | models the LazyLibrarian incidents directly, and costs three lines per service    |
-| `reverse-proxy`  | Caddy starts, routes to a stub backend, serves 200                  | every public service depends on it; a routing regression is invisible to a build |
-| `monitoring`     | Prometheus starts, loads rules, scrapes a target                    | rule and config errors only surface at activation                                |
-| `digital-garden` | quartz builds a vault and the result is served                      | the failure mode is a _successful_ build and an empty site                       |
-| `media-stack`    | the arr services reach their ports                                  | the largest module, and the one with the most moving parts                       |
+| Test             | Asserts                                                             | Why it earns its place                                                           | Status |
+| ---------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ------ |
+| ~~`data-safety`~~ | ~~a canary file in the shared download root survives service startup~~ | **struck** - the assertion is vacuous; see below                              | struck |
+| `reverse-proxy`  | Caddy starts, routes to a stub backend, serves 200                  | every public service depends on it; a routing regression is invisible to a build | **done** |
+| `monitoring`     | Prometheus starts, loads rules, scrapes a target                    | rule and config errors only surface at activation                                | **done** |
+| `digital-garden` | quartz builds a vault and the result is served                      | the failure mode is a _successful_ build and an empty site                       | next   |
+| `media-stack`    | the arr services reach their ports                                  | the largest module, and the one with the most moving parts                       | waiting on the move off containers |
 
-`data-safety` is first for a reason, and ADR 0003 sharpened it. The recent data loss was one root cause - LazyLibrarian's PostProcessor pointed at the shared download root - firing twice, two days apart, for 3.68 TiB. ADR 0003 then established that no arrangement of bind mounts can prevent a recurrence for the services that hardlink, because the kernel will not link across a mount boundary. So this test is not a cheap complement to confinement, as this plan originally had it; for `sonarr`, `radarr` and `cross-seed` it is the only thing that will cover the property at all.
+The original ordering put `data-safety` first, and ADR 0003 sharpened the case: the recent data loss was one root cause - LazyLibrarian's PostProcessor pointed at the shared download root - firing twice, two days apart, for 3.68 TiB, and ADR 0003 established that no arrangement of bind mounts can prevent a recurrence for the services that hardlink, because the kernel will not link across a mount boundary. The conclusion drawn from that - _therefore the test is the only thing that covers it_ - did not follow, and is corrected below. It is a good example of a real argument for needing something being mistaken for evidence that the proposed something works.
 
-`digital-garden` remains the most valuable per line among the rest: it is the one place where the current gate is actively misleading, because a broken plugin index produces a build that succeeds.
+`digital-garden` is now first, and for the reason it was always ranked highly: it is the one place where the current gate is actively misleading, because a broken plugin index produces a build that succeeds.
 
 ### Cost and risks
 
@@ -317,6 +317,84 @@ The third is the most faithful and the most work. Start with the second and see 
 ### Done when
 
 At least one test exists, the gate runs it, and a deliberately broken service configuration fails CI rather than merging.
+
+### What landed
+
+`checks/`, wired into `flake.nix` as `checks.x86_64-linux` and therefore picked up by `nix flake check` in the existing `flake-check` job - no workflow changes, as the approach above predicted.
+
+- `checks/default.nix` - the index, and where `alert-rules` moved to from `flake.nix`.
+- `checks/lib.nix` - `mkTest`, a `runNixOSTest` wrapper supplying the `specialArgs` this repo's modules are written against. `self` is not optional; several modules reach into `self.packages`.
+- `checks/stub-secrets.nix` - the secret stubbing, discussed below.
+- `checks/monitoring.nix`, `checks/reverse-proxy.nix` - the two tests.
+
+Restricted to `x86_64-linux` rather than `forAllSystems`. Every host is x86_64, and a NixOS test for another system makes `nix flake check` evaluate an entire foreign NixOS closure only to decline to build it.
+
+`ci.yml` gained a step that reports whether `/dev/kvm` exists on the runner. It fails nothing - it exists so that a gate which suddenly got five times slower has an explanation in its own log rather than being a mystery. That is the "verify early" from the risks section, moved into the pipeline instead of being done once by hand and forgotten.
+
+**Secret stubbing went with option two, roughly.** Each test hands `stub-secrets.nix` a name-to-content map; it overrides `sops.secrets.<name>.path` and `sops.templates.<name>.path` to plaintext fixtures in the store, and disables the installer that would otherwise try to decrypt the real file. What it deliberately does not do is delete the module's `sops.secrets.<name>` declarations - those stay, so the wiring between a module and the secret names it consumes is still covered, and only the decryption is replaced. The honest cost is that these tests prove nothing about sops itself. Option three - a throwaway age key committed here with an encrypted fixture - remains available for a test that needs to cover the sops wiring rather than route around it.
+
+One wrinkle worth knowing: sops-nix installs secrets from an activation script or a systemd unit depending on `useSystemdActivation`, and the stub disables both rather than depend on which upstream default is in force.
+
+### Evidence, 2026-08-16
+
+Both tests pass locally, on KVM:
+
+```
+vm-test-run-monitoring>      test script finished in 59.81s
+vm-test-run-reverse-proxy>   test script finished in 16.61s
+```
+
+`monitoring` asserts three things, in increasing order of what they are worth. That Prometheus starts at all with the config `monitoring.nix` assembles - the `alert-rules` check validates one file in isolation and says nothing about the scrape jobs, relabelling or alertmanager block around it. That the rule file is loaded _by the running server_, with `NixosDeployFailed`, `NixosDeployStale` and `NixosVerifyFailed` present in `/api/v1/rules`. And that a deployment metric written by `deploy-metrics.nix` travels the whole chain - `.prom` file, node_exporter's textfile collector, scrape, query - which is four independent pieces whose failure is completely silent, because a broken link means the alerts simply never fire.
+
+`reverse-proxy` asserts that Caddy accepts the generated Caddyfile (it validates at startup and refuses to run on a bad one, so an active unit means every directive parsed, including those reachable only through a rate limit profile), that a request reaches the backend, that the backend sees the `header_up` values `mkProxyHost` sets, and that the `localOnly` branch is the one actually taken - security headers present on the public vhost and absent on the LAN-only one.
+
+**The "done when" is met, and was checked rather than assumed.** `deploy-metrics.nix` line 130 sets `cg.service.monitoring.textfileCollector.enable = true`, overriding a `mkDefault` that would otherwise leave the collector off on `homelab01`; it is a real bug that was really made once. Flipping that `true` to `false`:
+
+```
+$ nix build .#nixosConfigurations.homelab01.config.system.build.toplevel
+BUILD_EXIT=0                                    # the existing gate is happy
+
+$ nix build .#checks.x86_64-linux.monitoring
+!!! Test "deployment metrics reach Prometheus" failed
+CHECK_EXIT=1                                    # the new one is not
+```
+
+That is the whole argument for item 4 in six lines: a change that builds perfectly, would have merged, would have deployed, and would have silently stopped the deployment pipeline reporting on itself.
+
+### Four things that only show up by running it
+
+All four produced a test that looked right and was not. Recorded because three of them fail _open_.
+
+- **`auto_https off` does not move the listener.** The first attempt at serving the vhosts over plain HTTP set it, on the reasonable-sounding assumption that disabling automatic HTTPS makes a bare-hostname site listen on 80. It does not: Caddy sat on 443 with no certificate and every request failed. The fix was better anyway - `tls internal` through the module's own per-service `extraConfig`, so the sites are served over real TLS by Caddy's own CA and the only thing substituted is the issuer.
+- **HTTP/2 lowercases header names.** Asserting `"X-Frame-Options: SAMEORIGIN" in response` fails over TLS. The dangerous half is the neighbouring subtest: `assert "X-Frame-Options" not in response` was passing _for every possible input_, and would have gone on passing after the header was deleted from the module. An absence assertion that can never fail is worse than no assertion, because it is counted.
+- **The test driver runs commands under `pipefail`.** `curl -sf … | grep -q x` exits non-zero on a _successful_ match: `grep -q` returns at the first hit, curl takes EPIPE, and the pipeline reports the failure. The symptom is a condition that is already true timing out. Redirect to a file and grep the file.
+- **`wait_for_unit` never succeeds for a `Type=oneshot` without `RemainAfterExit`.** `nixos-deploy-metrics` reads `inactive` the moment it succeeds. This is the same trap item 3 documents for `criticalUnits`, met from the other direction.
+
+### The `data-safety` test does not survive contact
+
+It was first on the candidate list, ADR 0003 sharpened the case for it, and it is the one test here that cannot be written as specified. Two reasons, and the second is the one that matters.
+
+**It cannot run in this harness.** `sonarr`, `radarr`, `cross-seed` and `qbittorrent` are all `virtualisation.oci-containers` services pulling `:latest` from a registry with `--pull=newer`. NixOS tests run inside the Nix build sandbox, which has no network, so those containers cannot start. This is not fatal on its own - `dockerTools.pullImage` is a fixed-output derivation and so _is_ allowed to fetch, which would let the images be pinned by digest and loaded into podman offline. That was not attempted here. It costs a pinned digest and hash per image, permanently, in exchange for testing an image that is by construction not the `:latest` the host will run.
+
+**More decisively, the assertion is vacuous.** "A canary file in the shared download root survives service startup" would pass on an empty configuration, because a freshly started arr container with no `/config` does not post-process anything. The loss it models was not a startup behaviour: it was LazyLibrarian's PostProcessor, _configured_ to point at the shared download root, doing post-processing. Reproducing that means driving a service through a real post-processing run with its real settings - and those settings live in a service-managed SQLite database, not in Nix. So the "three lines per service" this plan budgeted buys a green check that would not have caught the incident it was written for, which is strictly worse than an acknowledged gap.
+
+That does not make the property unenforceable, it makes it the wrong shape for this harness. Cheaper things that would have caught the actual incident, in rough order of value per line:
+
+- an assertion over the _evaluated configuration_ - no VM needed - that no service's output or post-processing directory is equal to, or a parent of, `${dataPath}/downloads`. That is the invariant that was violated, it is checkable statically, and it is the one thing ADR 0003 established confinement cannot enforce;
+- a periodic canary on the hosts: a sentinel file in the download root, alerting through the existing textfile metrics if it disappears. Detection rather than prevention, but it covers every service including the ones no test will ever drive, and it rides a stack that already exists.
+
+**Decided, 2026-08-16: stop trying to prove the negative.** No test can establish that a service will never be told to do something destructive later, and a suite that implies otherwise is worse than an acknowledged gap - it is the same failure as the vacuous canary, just more expensive. The two items above are worth having on their own merits, one as a static invariant over configuration and one as detection, and neither is dressed up as proof. `data-safety` is struck from the candidate list rather than deferred.
+
+**Also decided: the container services are on their way out.** The intended direction is nixpkgs' own service modules instead of `oci-containers`, for the complexity they add as much as for anything here. That retires the first half of the blocker above on its own schedule, and it changes the arithmetic for `media-stack`: a natively packaged `sonarr` needs no registry, no pinned digest and no `podman load`, so the test that is currently blocked becomes ordinary. Worth knowing before anyone invests in pinning image digests to work around a constraint that is being removed anyway.
+
+**Item 4 is not finished**; what is finished is the harness, the two tests that pay for it, and a candidate list that no longer contains a test which would have passed while the thing it named went on being possible.
+
+### Still outstanding
+
+- `digital-garden` - the highest value of the remainder, and the reason is unchanged: a broken plugin index produces a build that _succeeds_ and a site that is empty, so the current gate is not merely silent there but actively misleading. It needs a vault fixture and `source = "obsidian-sync"`, which reads the vault from disk rather than cloning it, and so is the one path through that module that does not want the network.
+- `media-stack` - the largest of the candidates, and now waiting on the migration off `oci-containers` rather than on anything in this harness. Taking it before that migration means pinning image digests that are about to become irrelevant.
+- KVM on GitHub's runners is still unverified. The first CI run after this merges answers it.
+- Nothing yet measures what these tests cost the nightly lock PR's auto-merge. Two VMs is around 80 seconds locally; the number that matters is the one on a runner that may have no KVM.
 
 ---
 

--- a/flake.nix
+++ b/flake.nix
@@ -225,23 +225,23 @@
 
       # Checks run by `nix flake check`, and therefore by the CI gate.
       #
-      # Building a host proves its Nix evaluates, not that the config files it
-      # ships are valid. A malformed alert rule builds perfectly and then takes
-      # Prometheus down on activation, so validate it here where it is cheap.
-      checks = forAllSystems (
-        system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-        in
-        {
-          alert-rules =
-            # promtool lives in the `cli` output, not `out`.
-            pkgs.runCommand "check-alert-rules" { nativeBuildInputs = [ pkgs.prometheus.cli ]; } ''
-              promtool check rules ${./modules/services/monitoring/alert-rules.yml}
-              touch $out
-            '';
-        }
-      );
+      # Building a host proves its Nix evaluates, not that the services it
+      # ships come up or that the config files they are handed are valid. See
+      # ./checks for what lives here and why.
+      #
+      # x86_64-linux only. Every host is x86_64, and a NixOS VM test for
+      # another system needs a builder for it - `nix flake check` would
+      # evaluate a whole foreign NixOS system just to skip building it.
+      checks = {
+        x86_64-linux = import ./checks {
+          pkgs = import nixpkgs {
+            system = "x86_64-linux";
+            overlays = builtins.attrValues self.overlays;
+            config.allowUnfree = true;
+          };
+          inherit self inputs;
+        };
+      };
 
       # Development shell for working on this config
       devShells = forAllSystems (system: {


### PR DESCRIPTION
Item 4 of [the hardening plan](docs/plans/deployment-hardening.md), and the primary pre-deploy gate per ADR 0002. The gate proved a host evaluates and its derivations realise. It proved nothing about whether the services that configuration ships come up, or whether the config files they are handed are accepted by the programs that read them.

`checks/` is the harness. Tests instantiate a service module in a minimal machine rather than a host, since no host will boot in a VM — disko wants real disks, ZFS a pool, sops host keys, `homelab01` an NFS server. Exposed as flake `checks`, so the existing `flake-check` job picks them up with no workflow changes.

## The two tests

**`monitoring`** — Prometheus starts with the config `monitoring.nix` assembles (the existing `alert-rules` check validates one file in isolation and says nothing about the scrape jobs around it), the rule file is loaded *by the running server*, and a `deploy-metrics` metric survives the whole chain to a query. That chain is four independent pieces whose failure is silent: a break anywhere means the alerts simply never fire.

**`reverse-proxy`** — Caddy accepts the generated Caddyfile, which it validates at startup and refuses to run on, so an active unit means every directive parsed. Then that a request reaches the backend, that the backend sees the `header_up` values `mkProxyHost` sets, and that `localOnly` selects the branch it should. Only the certificate issuer is substituted — `tls internal` through the module's own per-service `extraConfig` — so the sites are still served over TLS on 443.

## The "done when", checked rather than assumed

Flipping `deploy-metrics.nix`'s `textfileCollector` override to `false` — a mistake that file already carries a comment about having made once:

```
nix build .#nixosConfigurations.homelab01...toplevel   → exit 0   (existing gate happy)
nix build .#checks.x86_64-linux.monitoring             → exit 1   (new one is not)
```

A change that builds perfectly, would have merged, would have deployed, and would have silently stopped the deployment pipeline reporting on itself.

## `data-safety` is struck, not deferred

It was first on the candidate list and it is the one test here that cannot be written as specified.

It cannot run in this harness — every service it names is an `oci-container` pulling `:latest` from a registry the sandbox cannot reach. That is escapable by pinning digests, and pointless to do given the intended move to nixpkgs' own service modules.

More decisively, **the assertion is vacuous**. "A canary file survives service startup" passes on an empty configuration, because a fresh arr container with no `/config` post-processes nothing. The loss it models was a *configured* PostProcessor doing post-processing, and those settings live in a service-managed SQLite database, not in Nix. No test can establish that a service will never later be told to do something destructive, and a suite implying otherwise is worse than an acknowledged gap.

The plan records two honest alternatives — a static invariant over the evaluated configuration, and a host-side canary riding the existing textfile metrics — with neither dressed up as proof.

## Four things that only showed up by running it

Three of them fail *open*, which is why they are in the plan rather than only in the diff:

- **`auto_https off` does not move the listener.** Caddy sat on 443 with no certificate and every request failed.
- **HTTP/2 lowercases header names.** `assert "X-Frame-Options" not in response` was passing for every possible input, and would have gone on passing after the header was deleted from the module.
- **The test driver runs commands under `pipefail`.** `curl -sf … | grep -q x` exits non-zero on a *successful* match, via EPIPE. The symptom is a condition that is already true timing out.
- **`wait_for_unit` never succeeds for a `Type=oneshot` without `RemainAfterExit`.** The same trap item 3 documents for `criticalUnits`, met from the other direction.

## Cost

`ci.yml` gained a step reporting whether `/dev/kvm` exists. It fails nothing — it exists so a gate that suddenly got five times slower explains itself in its own log. Locally the two tests take about 80 seconds with KVM; **whether GitHub's runners have it is unverified, and this PR's own run is what answers that.**
