### PR TITLE
build(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1786717298,
-        "narHash": "sha256-asdPlqtM0AweQ5YNLad6eY4tSYW55YNr1uyayf7mOMQ=",
+        "lastModified": 1786867632,
+        "narHash": "sha256-ez+ubZlA1RtdjCB18a6zJ9M4u8qoPDy08EcnsW5M3Xw=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "2dda192987ab6815e44df0130f03d6c907b79134",
+        "rev": "ff17823245ab9ff7bcae6acf950bd89cba82c38c",
         "type": "github"
       },
       "original": {
@@ -185,11 +185,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786719456,
-        "narHash": "sha256-B74DLQs/VjlqyhnnX3tguWwghqJHWSJX30TKZuAljIg=",
+        "lastModified": 1786929086,
+        "narHash": "sha256-kzpwMyT7i2fTQ41tf/WlsIHuJtf3e0leRBEPkBhUzBY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "83b7606dcf44abe3a94b86e8bb2b3355d22e8797",
+        "rev": "aac4965ddb7ea2ff0f3cadd9502c7042b7aa07ba",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1786723161,
-        "narHash": "sha256-TwOM4sZZMJIU60+rYqCToveUQjti7XSPFcisqIEcVc8=",
+        "lastModified": 1786935457,
+        "narHash": "sha256-kraAoy5+byR1VkJdQk2FTPSUAN6Pta4fyN3ywHcPAcc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4746f0c303f040b7148947095e3758be86e8e337",
+        "rev": "4df4976d944e0057c4c9f99919c6cda2c623563a",
         "type": "github"
       },
       "original": {
@@ -245,11 +245,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1786862985,
+        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `flake.lock` update.

The per-host deltas below are recorded in the commit body so they
land in `git log` on merge (ADR 0001).

Each host was built at the current lock and at the updated one, and
the closures compared. All three builds passing is a precondition of
this PR existing at all — but the `nixos ci` gate still has to pass
before it can merge, and merging is what promotes `deploy`.

### homelab01

gtk+: 2.24.33 removed, -27.1 MiB
kguiaddons: 6.28.0 → 6.29.0
lcevcdec: 4.2.0 → 4.2.1, 23.7 KiB
libtraceevent: 1.9 → 1.9.0
lua-language-server: 3.19.0 → 3.19.1, 42.2 KiB
nixos-manual: -66.9 KiB
nixos-system-homelab01: 26.11.20260813.0e251e2 → 26.11.20260816.e5bdc4a
pinentry-all: -125.7 KiB
postgresql: 16.14, 18.4 → 16.15, 18.6, 43.4 KiB
postgresql-and-plugins: 16.14 → 16.15
python3: 3.12.13 → 3.12.14, 38.0 KiB
python3.14-autocommand: 2.2.2 added, 92.8 KiB
python3.14-distutils: 83.0.0 added, 14.7 KiB
python3.14-jaraco-classes: 3.4.0 added, 53.7 KiB
python3.14-jaraco-collections: 5.2.1 added, 116.0 KiB
python3.14-jaraco-context: 6.1.0 added, 47.8 KiB
python3.14-jaraco-functools: 4.4.0 added, 79.3 KiB
python3.14-jaraco-text: 4.0.0 added, 92.0 KiB
recyclarr: 8.7.0 → 8.7.1, -173.8 KiB
sops-install-secrets: 12.3 KiB
source: 191.7 KiB

### homelab02

gtk+: 2.24.33 removed, -27.1 MiB
initrd-linux: 30.0 KiB
kguiaddons: 6.28.0 → 6.29.0
libtraceevent: 1.9 → 1.9.0
lua-language-server: 3.19.0 → 3.19.1, 42.2 KiB
nixos-manual: -66.9 KiB
nixos-system-homelab02: 26.11.20260813.0e251e2 → 26.11.20260816.e5bdc4a
pinentry-all: -125.7 KiB
python3: 3.12.13 → 3.12.14, 38.0 KiB
python3.14-autocommand: 2.2.2 added, 92.8 KiB
python3.14-distutils: 83.0.0 added, 14.7 KiB
python3.14-jaraco-classes: 3.4.0 added, 53.7 KiB
python3.14-jaraco-collections: 5.2.1 added, 116.0 KiB
python3.14-jaraco-context: 6.1.0 added, 47.8 KiB
python3.14-jaraco-functools: 4.4.0 added, 79.3 KiB
python3.14-jaraco-text: 4.0.0 added, 92.0 KiB
sops-install-secrets: 12.3 KiB
source: 191.7 KiB

### xps15

breeze-icons: 6.28.0 → 6.29.0, 10.0 KiB
claude-code: 2.1.228 → 2.1.232, 13.8 MiB
faugus-launcher: 2.0.6 → 2.1.0, 108.1 KiB
firefox-unwrapped: -45.7 KiB
flatpak: 1.18.0 → 1.18.1, 35.0 KiB
gtk+: 2.24.33 removed, -27.1 MiB
hyprutils: 0.14.0 → 0.14.1, 45.1 KiB
karchive: 6.28.0 → 6.29.0, 25.0 KiB
kauth: 6.28.0 → 6.29.0
kbookmarks: 6.28.0 → 6.29.0
kcmutils: 6.28.0 → 6.29.0, 8.7 KiB
kcodecs: 6.28.0 → 6.29.0, 203.8 KiB
kcolorscheme: 6.28.0 → 6.29.0
kcompletion: 6.28.0 → 6.29.0
kconfig: 6.28.0 → 6.29.0, 23.2 KiB
kconfigwidgets: 6.28.0 → 6.29.0
kcontacts: 6.28.0 → 6.29.0
kcoreaddons: 6.28.0 → 6.29.0, 28.5 KiB
kcrash: 6.28.0 → 6.29.0
kdbusaddons: 6.28.0 → 6.29.0
kdoctools: 6.28.0 → 6.29.0
kglobalaccel: 6.28.0 → 6.29.0
kguiaddons: 6.28.0 → 6.29.0
ki18n: 6.28.0 → 6.29.0, 8.3 KiB
kiconthemes: 6.28.0 → 6.29.0
kio: 6.28.0 → 6.29.0, 76.0 KiB
kirigami: 6.28.0 → 6.29.0
kitemmodels: 6.28.0 → 6.29.0
kitemviews: 6.28.0 → 6.29.0
kjobwidgets: 6.28.0 → 6.29.0
knotifications: 6.28.0 → 6.29.0, -55.5 KiB
kpackage: 6.28.0 → 6.29.0
kpeople: 6.28.0 → 6.29.0
kservice: 6.28.0 → 6.29.0
kstatusnotifieritem: 6.28.0 → 6.29.0
ktextwidgets: 6.28.0 → 6.29.0
kwallet: 6.28.0 → 6.29.0, -23.9 KiB
kwidgetsaddons: 6.28.0 → 6.29.0, 13.4 KiB
kwindowsystem: 6.28.0 → 6.29.0
kxmlgui: 6.28.0 → 6.29.0
libtraceevent: 1.9 → 1.9.0
lua-language-server: 3.19.0 → 3.19.1, 42.2 KiB
modemmanager-qt: 6.28.0 → 6.29.0
nixos-manual: -66.9 KiB
nixos-system-xps15: 26.11.20260813.0e251e2 → 26.11.20260816.e5bdc4a
nss: 3.126 → 3.127
opencode: 1.18.16 → 1.18.18, 29.4 KiB
pinentry-all: -125.7 KiB
python3: 3.12.13 → 3.12.14, 38.0 KiB
python3.14-autocommand: 2.2.2 added, 92.8 KiB
python3.14-distutils: 83.0.0 added, 14.7 KiB
python3.14-jaraco-collections: 5.2.1 added, 116.0 KiB
python3.14-jaraco-text: 4.0.0 added, 92.0 KiB
qqc2-desktop-style: 6.28.0 → 6.29.0, 19.8 KiB
solid: 6.28.0 → 6.29.0
sonnet: 6.28.0 → 6.29.0
sops-install-secrets: 12.3 KiB
source: 191.7 KiB
wireshark-qt: 4.6.7 → 4.6.8, 133.8 KiB
yazi: 26.5.6 → 26.8.15, 11.7 MiB