### PR TITLE
ci(dependabot): manage action versions with a 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,123 @@
+version: 2
+
+# Dependabot covers the one dependency surface the other two updaters cannot
+# reach: the actions pinned inside .github/workflows.
+#
+#   flake-update.yml    -> flake inputs (nixpkgs et al)
+#   package-update.yml  -> packages pinned to an upstream tag or npm version
+#   this file           -> the actions those two workflows are themselves built from
+#
+# Dependabot has no Nix ecosystem, so it cannot touch flake.lock and cannot
+# compete with either of the above. The three carve the space up cleanly.
+#
+# Why actions need an updater at all: they are pinned to full commit SHAs, which
+# is the right call for supply chain but makes staleness invisible. Nothing
+# about `actions/checkout@3d3c42e...` says it is behind, and the trailing
+# `# v7.0.1` comment is only as truthful as the last person to hand-edit it.
+# Dependabot rewrites both.
+
+updates:
+  # ---------------------------------------------------------------------------
+  # GitHub Actions
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    # `/` is correct even though the workflows live in .github/workflows -
+    # Dependabot always scans that directory relative to the repository root.
+    directory: "/"
+
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC" # 14:00 Perth
+      # Deliberately between package-update (03:00 UTC Mon) and flake-update
+      # (15:00 UTC daily). `protect-main` sets strict_required_status_checks_policy,
+      # so two auto-merging PRs in flight at once means the second has to rebase
+      # before it can land. Dependabot rebases its own PRs, so this self-heals -
+      # the offset just keeps it from happening every week on purpose.
+
+    # The whole safety argument for merging these unread. A compromised action
+    # release is typically public within a day or two (tj-actions/changed-files,
+    # March 2025), so waiting a week means the ecosystem does the review that no
+    # one is realistically going to do by squinting at a SHA diff. It costs
+    # nothing ongoing and expires by itself, so nothing rots in a queue.
+    #
+    # GitHub Actions supports `default-days` ONLY - the semver-major-days /
+    # semver-minor-days / semver-patch-days keys are rejected for this ecosystem,
+    # so majors cannot be made to wait longer than patches here. The `groups`
+    # split below is what separates them instead.
+    #
+    # Dependabot *security* updates ignore cooldown by design: a known CVE should
+    # not sit for a week. That is the correct trade and is not configurable.
+    cooldown:
+      default-days: 7
+
+    # Two version-update PRs at most, plus headroom for a security update
+    # arriving in the same window.
+    open-pull-requests-limit: 4
+
+    labels:
+      - dependencies
+      - github-actions
+
+    # Matches the conventional-commit style already in git log
+    # (`build(nix): update flake.lock`) -> `ci(deps): bump ...`.
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
+    groups:
+      # One PR for the boring bumps. Six separate PRs a month is the noise that
+      # trains you to stop reading them.
+      actions:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+      # Majors get their own PR - not to force a review, but so that a break is
+      # attributable to one action instead of a batch of six. Half these actions
+      # only ever run in the cron-triggered workflows (see the auto-merge
+      # workflow's header), so a regression can surface a day later in
+      # flake-update rather than in the PR's own gate. When it does, the fix
+      # should be a one-line revert, not a bisect.
+      actions-major:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["major"]
+
+  # ---------------------------------------------------------------------------
+  # Go - dormant on purpose
+  # ---------------------------------------------------------------------------
+  #
+  # packages/project-launcher has no `require` block and no go.sum: it is stdlib
+  # only, which is why its derivation sets `vendorHash = null`. Dependabot has
+  # nothing to do here today, and it does NOT bump the `go 1.22` directive, so
+  # this entry is a no-op until the program grows its first dependency.
+  #
+  # It is here so that day is not silent. Read the note in
+  # packages/project-launcher/default.nix before merging the first PR this ever
+  # opens: a go.mod bump invalidates vendorHash, which Dependabot knows nothing
+  # about, so the PR will look clean and fail `nix build`. The gate catches it -
+  # it cannot land broken - but the fix belongs in package-update.yml's
+  # updateScript contract rather than here.
+  - package-ecosystem: "gomod"
+    directory: "/packages/project-launcher"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    open-pull-requests-limit: 2
+    labels:
+      - dependencies
+      - go
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    groups:
+      go:
+        applies-to: version-updates
+        patterns: ["*"]

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -27,10 +27,19 @@ The laptop follows `deploy` too, but never switches on its own: it builds in the
 | `ci.yml`             | every PR and push to master | builds all three hosts, `nix flake check` (incl. the VM tests in `checks/`), fast-forwards `deploy` |
 | `flake-update.yml`   | daily, 15:00 UTC            | `nix flake update`, per-host closure diff, PR, auto-merge on green |
 | `package-update.yml` | Mondays, 03:00 UTC          | runs each package's own updater, one PR per package                |
+| `dependabot-auto-merge.yml` | every Dependabot PR  | schedules the merge; `nixos ci` is still the gate                  |
 
 CI builds are pushed to a [Cachix](https://cachix.org) cache that the hosts substitute from, so a closure is built once rather than once per machine.
 
 Lock updates auto-merge when green. Package updates do not - they cross an upstream release boundary, where "it built" is the weakest form of evidence.
+
+### Dependabot
+
+`.github/dependabot.yml` covers the actions pinned inside these workflows - the one dependency surface the two Nix updaters cannot reach. It has no Nix ecosystem, so it never touches `flake.lock` and cannot compete with `flake-update.yml`. A second, dormant entry watches `packages/project-launcher`, which is stdlib-only today.
+
+Action bumps auto-merge without being read, which is a deliberate trade rather than laziness: the diff is a SHA, so review conveys nothing, and the safety comes from a 7-day `cooldown` instead - long enough that the ecosystem finds a compromised release before this repo consumes it, and short enough that nothing rots. Security updates bypass the cooldown by design. Majors are split into their own PR so a break is attributable to one action rather than a batch of six.
+
+That last point matters more here than it looks. `ci.yml` only ever runs three of the six pinned actions, so a bump to `upload-artifact`, `download-artifact` or `create-pull-request` goes green from a workflow that never executed it - see the invariant below.
 
 ### How a night runs
 
@@ -63,6 +72,12 @@ Both servers land on the same revision the same night. The 15 minute offset is n
 **`flake.lock` is CI's to move.** Running `nix flake update` by hand only creates a conflict with the nightly PR.
 
 **`flake-update.yml` checks out and opens its PR with `FLAKE_UPDATE_TOKEN`, not `GITHUB_TOKEN`.** GitHub suppresses workflow events on PRs opened by `GITHUB_TOKEN`, so `ci.yml` would never run, the required check would never arrive, and the PR would be unmergeable forever.
+
+**`dependabot-auto-merge.yml` needs `FLAKE_UPDATE_TOKEN` in _Dependabot_ secrets, not Actions secrets.** Workflow runs triggered by Dependabot read from a separate secret store and get a read-only `GITHUB_TOKEN`; the same name set under Actions resolves to empty there. The workflow fails with an explicit message rather than an opaque `gh` auth error, and it is not a required check, so the PR just sits unmerged. Note this is also why Dependabot PRs run without `CACHIX_AUTH_TOKEN` - harmless, because both `cachix-action` steps are `skipPush` against a public cache and the one real push is `continue-on-error`. They build slower, not wrong.
+
+**Auto-merge must be enabled by the PAT, for the same reason the PR is opened by it.** An auto-merge inherits the actor that enabled it, so a `GITHUB_TOKEN` merge lands on `master` without triggering `ci.yml` - `promote` never runs and `deploy` silently stops tracking `master`. An actions-only bump changes no host's closure, so nothing would look broken until an unrelated merge fast-forwarded past it.
+
+**`nixos ci` passing does not mean a bumped action works.** `ci.yml` runs only `checkout`, `nix-installer-action` and `cachix-action`. `upload-artifact`, `download-artifact` and `create-pull-request` appear exclusively in `flake-update.yml` and `package-update.yml`, which are `schedule` + `workflow_dispatch` and never fire on a pull request. A green gate on those three is a check that tested something else. Expect the failure at 15:00 UTC the next day, and revert rather than debug forward.
 
 ## Knowing whether it worked
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,77 @@
+name: dependabot-auto-merge
+
+# Schedules Dependabot's PRs for merge. The `nixos ci` gate is still the arbiter -
+# this only sets the intent, exactly as flake-update.yml does for the nightly lock
+# bump.
+#
+# Why these merge unread. An action pin is a SHA, so the diff is
+# `3d3c42e... -> a1b2c3d...` and no amount of staring at it conveys anything. The
+# honest version of "review" is reading someone else's TypeScript changelog every
+# Monday, which will not happen; what replaces it is a queue of stale PRs that
+# eventually get bulk-approved with less attention than this workflow gives them.
+# Stale actions carry their own unpatched-CVE risk, so friction that depends on
+# human attention is the thing to avoid. The evidence that a bump is safe is the
+# gate plus the 7-day cooldown in dependabot.yml - latency the wider ecosystem
+# spends finding compromised releases on this repo's behalf.
+#
+# What the gate does NOT cover, which is why the cooldown carries real weight:
+#
+#   - ci.yml only ever runs three of the six pinned actions: checkout,
+#     nix-installer-action and cachix-action. Bumps to upload-artifact,
+#     download-artifact and create-pull-request get a green `nixos ci` from a
+#     workflow that never executed them - those three run only in
+#     flake-update.yml and package-update.yml, which are cron-triggered and never
+#     fire on a pull request. "It passed CI" is a category error for that half.
+#
+#   - the Cachix push in ci.yml is `continue-on-error` and both cachix-action
+#     steps are `skipPush` (ADR 0001: the cache is a performance dependency, not a
+#     correctness one). So a cachix-action regression that breaks pushing stays
+#     green here forever and surfaces as hosts building from source at 04:00.
+#     Cache hit rate is the signal for that, not this workflow.
+#
+# Merging uses FLAKE_UPDATE_TOKEN rather than GITHUB_TOKEN, for the mirror image
+# of the reason flake-update.yml opens its PR that way. GitHub suppresses workflow
+# events for anything GITHUB_TOKEN does, and an auto-merge inherits the actor that
+# enabled it - so a GITHUB_TOKEN merge would land on master WITHOUT triggering
+# ci.yml, `promote` would never run, and `deploy` would quietly stop tracking
+# master. An actions-only bump does not change any host's closure, so nothing
+# would look wrong until the next unrelated merge fast-forwarded past it.
+#
+# That token has to live in *Dependabot* secrets, not Actions secrets. Workflow
+# runs triggered by Dependabot read from a separate store and are handed a
+# read-only GITHUB_TOKEN; `secrets.FLAKE_UPDATE_TOKEN` resolves to empty here
+# unless it is set under Settings > Secrets and variables > Dependabot. The step
+# below says so out loud rather than failing as an opaque gh auth error.
+
+on: pull_request
+
+# Nothing here uses GITHUB_TOKEN - the merge is performed with the PAT below.
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  auto-merge:
+    name: enable auto-merge
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      # Idempotent: re-running against an already-scheduled PR is a no-op, which
+      # matters because Dependabot rebases its own PRs whenever master moves and
+      # each rebase re-triggers this workflow.
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.FLAKE_UPDATE_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::FLAKE_UPDATE_TOKEN is empty. Dependabot-triggered runs read Dependabot secrets, not Actions secrets - add it under Settings > Secrets and variables > Dependabot."
+            exit 1
+          fi
+
+          gh pr merge --auto --squash "$PR_URL"

--- a/packages/project-launcher/default.nix
+++ b/packages/project-launcher/default.nix
@@ -21,6 +21,14 @@ buildGoModule {
   src = ./.;
 
   # No external Go dependencies — stdlib only.
+  #
+  # This is load-bearing for .github/dependabot.yml, which has a dormant `gomod`
+  # entry pointed here. The moment this program gains its first dependency,
+  # vendorHash stops being null, and a Dependabot go.mod/go.sum bump will produce
+  # a PR that looks clean and fails `nix build` — it has no idea the hash exists.
+  # The gate catches it, so it cannot land broken, but the fix is to give this
+  # package a `passthru.updateScript` that bumps the module and regenerates the
+  # hash, and let package-update.yml own it instead of Dependabot.
   vendorHash = null;
 
   # Tests are not included yet; this keeps the build path simple.


### PR DESCRIPTION
Adds Dependabot for the one dependency surface `flake-update.yml` and `package-update.yml` cannot reach: the actions pinned inside `.github/workflows`. Dependabot has no Nix ecosystem, so it never touches `flake.lock` and cannot compete with the nightly lock bump. The three updaters now carve the space up cleanly — flake inputs, out-of-flake upstreams, CI actions.

## Why these auto-merge unread

An action pin is a SHA, so the diff is `3d3c42e… → a1b2c3d…` and reviewing it conveys nothing actionable. The realistic alternative to auto-merge is not careful review, it is a queue of stale PRs that eventually gets bulk-approved with less attention than the gate applies — while unpatched actions accumulate risk of their own.

Safety comes from a **7-day cooldown** instead. A compromised action release is typically public within a day or two, so the wait lets the ecosystem do the review nobody was going to do by hand. It costs nothing ongoing and expires by itself, so nothing rots. Security updates bypass it by design.

Majors get their own PR — not to force a review, but so a break is attributable to one action rather than a batch of six.

## What the gate does not prove

Worth stating plainly, because "it passed CI" is doing less work here than it looks:

- `ci.yml` runs only three of the six pinned actions (`checkout`, `nix-installer-action`, `cachix-action`). `upload-artifact`, `download-artifact` and `create-pull-request` run **only** in `flake-update.yml` and `package-update.yml`, which are `schedule` + `workflow_dispatch` and never fire on a pull request. A green `nixos ci` on those three is a check that tested something else, and the failure surfaces at 15:00 UTC the next day.
- The Cachix push is `continue-on-error` and both `cachix-action` steps are `skipPush` (ADR 0001 — the cache is a performance dependency, not a correctness one). A regression that breaks pushing stays green forever and shows up as hosts building from source at 04:00. Cache hit rate is the signal for that, not CI.

Neither is an argument for reading the diff. Both are arguments that the cooldown is carrying more weight than the gate, and that a revert is the first move when something breaks.

## Token choice

Auto-merge uses `FLAKE_UPDATE_TOKEN`, for the mirror image of the reason `flake-update.yml` opens its PR that way. An auto-merge inherits the actor that enabled it, so a `GITHUB_TOKEN` merge would land on `master` **without triggering `ci.yml`** — `promote` would never run and `deploy` would silently stop tracking `master`. An actions-only bump changes no host's closure, so nothing would look wrong until an unrelated merge fast-forwarded past it.

The token has to live in **Dependabot** secrets rather than Actions secrets, since Dependabot-triggered runs read a separate store. Already added; the workflow fails with an explicit message rather than an opaque `gh` auth error if it ever goes missing.

## Expected first run: zero PRs

All six pins are already current, and every version comment resolves to the tag it claims:

| Action | Pinned | Latest |
| --- | --- | --- |
| `actions/checkout` | v7.0.1 | v7.0.1 |
| `actions/upload-artifact` | v7.0.1 | v7.0.1 |
| `actions/download-artifact` | v8.0.1 | v8.0.1 |
| `cachix/cachix-action` | v17 | v17 |
| `DeterminateSystems/nix-installer-action` | v22 | v22 |
| `peter-evans/create-pull-request` | v8 → v8.1.1 | v8.1.1 |

Silence on Monday is success, not a broken config. When the first real bump lands, Dependabot will rewrite `create-pull-request`'s `# v8` comment to `# v8.1.1`, since it pins precise releases rather than moving tags.

## Also

The `gomod` entry is dormant — `project-launcher` is stdlib only, and Dependabot does not bump the `go` directive — and is here so the day it stops being dormant is not silent. `default.nix` now documents the trap: a go.mod bump invalidates `vendorHash`, which Dependabot knows nothing about, so the PR will look clean and fail `nix build`. The gate catches it; the fix belongs in `package-update.yml`'s `updateScript` contract.

Verified: both YAML files parse, `project-launcher` still builds, `allow_auto_merge` is on, and `protect-main` requires zero approving reviews — so auto-merge needs only the `nixos ci` check.