### PR TITLE
fix(comskip): stop ffprobe reading a recording's name as a flag

### DIFF
--- a/packages/comskip-chapters/edl-to-chapters.py
+++ b/packages/comskip-chapters/edl-to-chapters.py
@@ -39,10 +39,16 @@ def get_video_duration(video_path: Path) -> float:
         "-print_format",
         "json",
         "-show_format",
+        # `--` ends option parsing: without it a recording named e.g.
+        # `-show_streams` is read as an ffprobe flag rather than an input, and
+        # ffprobe then exits 0 having probed nothing at all.
+        "--",
         str(video_path),
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    # check=True so a failed probe raises here rather than surfacing as a
+    # KeyError on `data["format"]` three lines down.
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     data = json.loads(result.stdout)
     return float(data["format"]["duration"])
 

--- a/packages/comskip-cut/edl-to-segments.py
+++ b/packages/comskip-cut/edl-to-segments.py
@@ -39,6 +39,10 @@ def get_video_duration(video_path: Path) -> float:
         "-print_format",
         "json",
         "-show_format",
+        # `--` ends option parsing: without it a recording named e.g.
+        # `-show_streams` is read as an ffprobe flag rather than an input, and
+        # ffprobe then exits 0 having probed nothing at all.
+        "--",
         str(video_path),
     ]
 


### PR DESCRIPTION
Follow-up to the finding that fell out of the CodeQL threat-model experiment in #36.

Both comskip scripts passed the video path as the last element of the ffprobe argv with nothing marking the end of option parsing, so a recording whose name starts with a dash was read as a flag rather than an input. Adding `--` fixes it.

## What CodeQL claimed vs what is actually wrong

It reported `py/command-line-injection` at **critical**. That is not what this is — the command is an argv list with no `shell=True`, so no shell exists to inject into. The real issue is *argument* injection, which is genuine but much smaller, and is what this fixes.

## Demonstrated, not assumed

Against a file named `-show_streams.mp3`, before the fix:

```
edl-to-chapters.py:  Expecting value: line 1 column 1 (char 0)
edl-to-segments.py:  Command '[... '-show_streams.mp3']' returned non-zero exit status 1
```

After, both return the same values as for a normally named file (5s input, 2s commercial → 3s content, segment 2.0–5.0). The worst case is narrower still but nastier: a file named *exactly* `-show_streams` makes ffprobe **exit 0 having probed nothing**, and the caller then reads a duration out of `{}`.

Not reachable by an attacker — comskip names these files from the recording — so this is hardening, not a live vulnerability.

## Also: `check=True` in edl-to-chapters

`edl-to-segments` already had it; `edl-to-chapters` did not. That is the whole difference between the two error messages above. Without it, a failed probe surfaces as a `json.loads` error that never mentions ffprobe; with it, you get the command and the mangled argv. Two-line change, same failure path, so it is fixed here rather than left for later.

Both packages build. Note this does **not** show up as a CodeQL alert either way — the current `remote` threat model does not treat argv as tainted, which is the correct setting for the reasons recorded in `.github/workflows/README.md`. It was found by reading the alerts from the `remote_and_local` experiment before reverting it.