### PR TITLE
build(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -185,11 +185,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786929086,
-        "narHash": "sha256-kzpwMyT7i2fTQ41tf/WlsIHuJtf3e0leRBEPkBhUzBY=",
+        "lastModified": 1786999651,
+        "narHash": "sha256-MTGMFlLDTklsXhCp4r5GXB4VAVadPdalXLvUjd/K7h0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "aac4965ddb7ea2ff0f3cadd9502c7042b7aa07ba",
+        "rev": "353742587cbaf079b3caee743115d037bc51fea6",
         "type": "github"
       },
       "original": {
@@ -213,11 +213,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1786711500,
-        "narHash": "sha256-QvnceIGTBeDvDd9oCn+GvdsnkquliuwbVgpiRH68qaQ=",
+        "lastModified": 1786943417,
+        "narHash": "sha256-b4qgjdFtlz5TAZ1Hi7DFJeqX3sjaDUnrwr9OO+O1rM0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "02e08985a27c65ffd33d434eeb2e660a2e4dc84d",
+        "rev": "0dd31db7e6dbf9ce05697c4545f6fe01accec994",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1786935457,
-        "narHash": "sha256-kraAoy5+byR1VkJdQk2FTPSUAN6Pta4fyN3ywHcPAcc=",
+        "lastModified": 1787056454,
+        "narHash": "sha256-mwSuxTG/BIwFJUHBwhS8ENlq2LJodCPXyk+AG4Dv6yk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4df4976d944e0057c4c9f99919c6cda2c623563a",
+        "rev": "ced43465ad23b2fdea055be721e79895cbf96c28",
         "type": "github"
       },
       "original": {
@@ -245,11 +245,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1786862985,
-        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
+        "lastModified": 1787001381,
+        "narHash": "sha256-Ue1Yo8gfHdD4TMtNewhA4tkSYeFqXThju0nCyJc3ALo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
+        "rev": "ec2d622de0773551768cf98f3fc50cbcc003b9c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `flake.lock` update.

The per-host deltas below are recorded in the commit body so they
land in `git log` on merge (ADR 0001).

Each host was built at the current lock and at the updated one, and
the closures compared. All three builds passing is a precondition of
this PR existing at all — but the `nixos ci` gate still has to pass
before it can merge, and merging is what promotes `deploy`.

### homelab01

dash: 0.5.13.5 removed, -189.3 KiB
frei0r-plugins: 3.2.1 → 3.2.3
fzf: 0.74.2 → 0.74.3, 20.2 KiB
getty: (no version) removed
htop: 3.5.2 → 3.5.3, 8.8 KiB
nixos-manual: 45.7 KiB
nixos-system-homelab01: 26.11.20260816.e5bdc4a → 26.11.20260817.ec2d622
nunicode: 1.11.1 → 1.12, 44.0 KiB
openssh: 10.4p1 → 10.5p1, 12.7 KiB
podman: 5.8.4 → 5.8.6
podman-docker-compat: 5.8.4 → 5.8.6
ruff: 0.16.2 → 0.16.3, -216.6 KiB
source: 255.3 KiB

### homelab02

dash: 0.5.13.5 removed, -189.3 KiB
fzf: 0.74.2 → 0.74.3, 20.2 KiB
getty: (no version) removed
htop: 3.5.2 → 3.5.3, 8.8 KiB
nixos-manual: 45.7 KiB
nixos-system-homelab02: 26.11.20260816.e5bdc4a → 26.11.20260817.ec2d622
openssh: 10.4p1 → 10.5p1, 12.7 KiB
podman: 5.8.4 → 5.8.6
podman-docker-compat: 5.8.4 → 5.8.6
ruff: 0.16.2 → 0.16.3, -216.6 KiB
source: 255.3 KiB

### xps15

claude-code: 2.1.232 → 2.1.233, 1.5 MiB
dash: 0.5.13.5 removed, -189.3 KiB
fc: -16.9 KiB
firefox-unwrapped: 89.1 KiB
fzf: 0.74.2 → 0.74.3, 20.2 KiB
getty: (no version) removed
htop: 3.5.2 → 3.5.3, 8.8 KiB
initrd-linux: 7.1.8 → 7.2, 29.2 KiB
linux: 7.1.8 → 7.2, 1.3 MiB
nixos-manual: 45.7 KiB
nixos-system-xps15: 26.11.20260816.e5bdc4a → 26.11.20260817.ec2d622
nvidia-open: 595.91.07-7.1.8 → 595.91.07-7.2, 37.1 KiB
opencode: -896.0 KiB
openssh: 10.4p1 → 10.5p1, 12.7 KiB
ruff: 0.16.2 → 0.16.3, -216.6 KiB
source: 255.3 KiB
squashfs: 4.7.5 removed, -680.5 KiB
squashfs-tools: 4.7.5 added, 680.5 KiB
thermald: 2.5.11 → 2.5.12, 89.1 KiB
unifont: -22.6 MiB
vivaldi: 8.1.4087.61 → 8.1.4087.66, 32.3 KiB
zotero: 34.8 KiB