### PR TITLE
fix(media-stack): stop podman healthchecks failing the nightly upgrade

### DIFF
--- a/hosts/homelab01/default.nix
+++ b/hosts/homelab01/default.nix
@@ -564,6 +564,13 @@
           url = "https://read.gyarmathy.co";
         }
         {
+          # /health rather than the bare root the other entries use: this is
+          # the readiness endpoint cleanuparr's podman healthcheck used to hit,
+          # so probing it keeps exactly the signal that healthcheck gave.
+          name = "cleanuparr";
+          url = "https://cleanuparr.gyarmathy.co/health";
+        }
+        {
           name = "maintainerr";
           url = "https://maintainerr.gyarmathy.co";
         }

--- a/modules/services/media-stack/cleanuparr.nix
+++ b/modules/services/media-stack/cleanuparr.nix
@@ -139,12 +139,9 @@ in
       extraOptions = [
         "--pull=newer"
         "--network=arr-network"
-        # Health check for container orchestration
-        "--health-cmd=curl -sf http://localhost:${toString cfg.port}${cfg.basePath}/health || exit 1"
-        "--health-interval=30s"
-        "--health-timeout=10s"
-        "--health-start-period=30s"
-        "--health-retries=3"
+        # No podman healthcheck here - see the note in maintainerr.nix. The
+        # /health endpoint is probed by blackbox_exporter instead, so the
+        # signal survives without a transient unit that can fail an upgrade.
       ];
     };
 

--- a/modules/services/media-stack/maintainerr.nix
+++ b/modules/services/media-stack/maintainerr.nix
@@ -127,12 +127,19 @@ in
         "--network=arr-network"
         # Allow container to reach host services (Jellyfin runs natively on host)
         "--add-host=host.containers.internal:host-gateway"
-        # Health check
-        "--health-cmd=curl -sf http://localhost:6246${cfg.basePath}/api/app/status || exit 1"
-        "--health-interval=30s"
-        "--health-timeout=10s"
-        "--health-start-period=60s"
-        "--health-retries=3"
+        # No podman healthcheck here on purpose. Readiness is probed by
+        # blackbox_exporter (cg.monitoring.httpProbes), which actually alerts;
+        # a podman healthcheck only coloured `podman ps` and fed nothing.
+        #
+        # It also broke the nightly upgrade. Podman runs each healthcheck as a
+        # transient systemd unit, and `podman healthcheck run` exits non-zero
+        # while a container is still starting - podman itself treats that as
+        # fine (health_status=starting, streak 0), but systemd records a failed
+        # unit either way. When `system.autoUpgrade` takes the kernel-unchanged
+        # path it does an in-unit `nixos-rebuild switch`, which restarts this
+        # container and then sweeps for failed units; a healthcheck firing in
+        # that window made switch-to-configuration exit 4 and failed the whole
+        # upgrade after it had already succeeded.
       ];
     };
 


### PR DESCRIPTION
homelab01's 2026-08-19 upgrade activated fine and then reported failure. `switch-to-configuration` exits 4 when any unit is failing once activation finishes, and it found two transient podman healthcheck units — the ones for `maintainerr` and `cleanuparr`, the only two containers here that set `--health-cmd`.

## Cause

Podman runs each healthcheck as a transient systemd unit, and `podman healthcheck run` exits non-zero while a container is still starting. Podman itself treats that as fine:

```
health_status=starting, health_failing_streak=0     ← podman: still booting, no failure
status=1/FAILURE                                    ← systemd: the unit failed
```

`system.autoUpgrade` with `allowReboot` does an in-unit `nixos-rebuild switch` whenever the kernel is unchanged, which restarts these containers and then sweeps for failed units. A healthcheck firing in that window fails an upgrade that had already succeeded — `/run/current-system` was the new generation the whole time.

That is also why it took ten nights to surface: kernel-changing nights reboot instead, and containers come up during boot where nothing runs the sweep.

## Fix

The healthchecks were not earning that risk. Nothing consumed them — no `--health-on-failure`, nothing scraped them — so they only coloured `podman ps`. `maintainerr` was already covered by a blackbox probe, which does alert.

- Drop `--health-*` from both containers.
- Add a `cleanuparr` probe on `/health`, the same endpoint its healthcheck used, so no signal is lost.

Verified: `nix build` of the homelab01 toplevel passes, the generated `podman-maintainerr.service` / `podman-cleanuparr.service` carry no `--health` flags, and `cleanuparr` is present in the built `blackbox-http` targets. Both candidate probe URLs were confirmed to return 200 from the host.

## Two follow-ups, not in this PR

1. `nixos-upgrade-verify` runs as `nixos-upgrade`'s `ExecStartPost`, and systemd skips `ExecStartPost` when `ExecStart` fails — so this failure also silently skipped verification. `verified-system` still names the 08-16 generation. Worth deciding whether verification should be resilient to the trigger failing.
2. The `nixos_deploy_last_run_success` alert description (`alert-rules.yml:284`) says *"the host keeps running its previous generation, so nothing is broken yet"*. In this failure mode that is not true — the host is running the new one. Misleading at 4am.