### PR TITLE
fix(upgrade-verify): run verification when the upgrade fails, not just when it succeeds

### DIFF
--- a/modules/nixos/upgrade-verify.nix
+++ b/modules/nixos/upgrade-verify.nix
@@ -31,9 +31,17 @@
 # is started from two places, and either one arriving first is fine:
 #
 #   - a timer at boot, for the reboot path
-#   - nixos-upgrade's ExecStartPost, for the same-unit switch path (where it is
+#   - nixos-upgrade's ExecStopPost, for the same-unit switch path (where it is
 #     a no-op in the other two branches, because the running system has not
 #     changed)
+#
+# ExecStopPost rather than ExecStartPost, because systemd skips ExecStartPost
+# when ExecStart fails - which used to skip verification in precisely the case
+# it is most wanted. `nixos-rebuild switch` exits non-zero if any unit is
+# failing once activation has finished, so a failed nixos-upgrade quite often
+# means "the new generation is live and something on it is unhappy", which is
+# the judgement this module exists to make. Trusting the trigger's exit code
+# would also undo the point of anchoring on the generation.
 #
 # The timer exists rather than `wantedBy = multi-user.target` because
 # `systemctl is-system-running --wait` blocks until startup completes. A unit
@@ -360,11 +368,16 @@ in
     systemd.services.nixos-upgrade = {
       serviceConfig = {
         ExecStartPre = [ baselineScript ];
-        # --no-block: this fires while nixos-upgrade is still finishing, and a
-        # verification that waits minutes to settle should not hold the upgrade
-        # unit open behind it. In the reboot branch it is a no-op anyway, since
-        # the running system has not changed yet.
-        ExecStartPost = [
+        # ExecStopPost fires on both outcomes; ExecStartPost would not fire at
+        # all when the upgrade failed. See the header. deploy-metrics.nix hangs
+        # off the same hook for the same reason.
+        #
+        # --no-block: this fires while nixos-upgrade is still deactivating, and
+        # the queued job is ordered After=nixos-upgrade.service, so it waits for
+        # this unit to finish rather than running mid-activation. Blocking here
+        # would deadlock against that ordering, and a verification that waits
+        # minutes to settle should not hold the upgrade unit open regardless.
+        ExecStopPost = [
           "${pkgs.systemd}/bin/systemctl start --no-block nixos-upgrade-verify.service"
         ];
       };

--- a/modules/services/monitoring/alert-rules.yml
+++ b/modules/services/monitoring/alert-rules.yml
@@ -274,6 +274,13 @@ groups:
           summary: "Restic backup {{ $labels.job }} on {{ $labels.host }} hasn't run in over 26 hours"
   - name: deploy
     rules:
+      # A non-zero exit does not tell you which generation is running.
+      # `nixos-rebuild switch` exits non-zero if any unit is failing once
+      # activation has finished, so the common case is that the new generation
+      # activated fine and something on it is unhappy - not that the upgrade
+      # was declined. Saying otherwise sends you looking in the wrong place at
+      # 4am. Once upgrade-verify's rollback is armed the previous generation
+      # will be the usual outcome again, and this wording should follow it.
       - alert: NixosDeployFailed
         expr: nixos_deploy_last_run_success == 0
         for: 10m
@@ -281,7 +288,7 @@ groups:
           severity: warning
         annotations:
           summary: "NixOS auto-upgrade failed on {{ $labels.host }}"
-          description: "The last nixos-upgrade run exited non-zero. The host keeps running its previous generation, so nothing is broken yet — but it has stopped receiving updates."
+          description: "The last nixos-upgrade run exited non-zero. Check `readlink /run/current-system` against `journalctl -u nixos-upgrade` before assuming anything: activation may have completed and then tripped the post-activation check for failed units. Either way the host has stopped tracking the promoted ref."
 
       # The one that catches silence. A host that stops upgrading raises nothing
       # at all otherwise: no failed unit, no failed probe, just a machine


### PR DESCRIPTION
Follow-up to #39.

## The gap

Verification hangs off `nixos-upgrade`'s `ExecStartPost`, and systemd skips `ExecStartPost` when `ExecStart` fails. A failed upgrade therefore skipped verification entirely — the case it is most wanted for.

Not hypothetical: on 2026-08-19 homelab01 activated a generation successfully and *then* exited 4, because `nixos-rebuild switch` exits non-zero if any unit is failing once activation has finished (two transient podman healthcheck units, fixed in #39). The new generation was live and unjudged, and `verified-system` still named the generation from three days earlier.

## The fix

`ExecStopPost` runs on both outcomes. `deploy-metrics.nix:141` already hangs off that hook for the same reason.

Confirmed against systemd 261 rather than taken from the manual — a transient unit with a failing `ExecStart`:

```
Result=exit-code  ExecMainStatus=1
hooks that ran:   STOPPOST-RAN        (ExecStartPost did not run)
```

Verified in the built unit:

```
ExecStartPre=…-nixos-upgrade-baseline
ExecStopPost=…-nixos-deploy-metrics
ExecStopPost=…/systemctl start --no-block nixos-upgrade-verify.service
```

Metrics are written before verification is queued, which is the right order.

**Nothing else needed to change**, and that is the interesting part: the module was already anchored on the generation rather than on the trigger, so the guard that makes two triggers idempotent makes a third firing safe too. Trusting the trigger's exit code was the one place that anchoring had been quietly undone.

`--no-block` stays, and now matters more: the queued job is ordered `After=nixos-upgrade.service`, so blocking from `ExecStopPost` would deadlock against that ordering.

## Alert wording

`NixosDeployFailed` said *"the host keeps running its previous generation, so nothing is broken yet"*. That describes the intended behaviour once `upgrade-verify`'s rollback is armed, not what happens today, and it sends you looking in the wrong place at 4am. Reworded to say the exit code does not identify the running generation, with the two commands that do. Comment above the rule notes the wording should follow the behaviour once rollback is armed.

`nix flake check` passes, including `promtool check rules` over the alert file.

## Not included

A periodic safety-net timer (`OnCalendar`) instead of only `OnBootSec` would make verification fully trigger-independent and would also catch a manual `nixos-rebuild switch`. I left it out deliberately: the baseline is only written by `nixos-upgrade`'s `ExecStartPre`, so once rollback is armed a periodic timer could judge a hand-applied switch against a baseline from that morning's upgrade and revert your manual work. Worth doing only alongside a rule for what a manual switch means — happy to take it on separately.