### PR TITLE
feat(upgrade-verify): roll back only generations nixos-upgrade staged

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -48,4 +48,5 @@ in
   digital-garden = testLib.mkTest ./digital-garden.nix;
   monitoring = testLib.mkTest ./monitoring.nix;
   reverse-proxy = testLib.mkTest ./reverse-proxy.nix;
+  upgrade-verify = testLib.mkTest ./upgrade-verify.nix;
 }

--- a/checks/upgrade-verify.nix
+++ b/checks/upgrade-verify.nix
@@ -1,0 +1,183 @@
+# Rollback refuses generations nobody staged, and does not refuse the ones it
+# staged.
+#
+# This is the only test here whose subject is a decision rather than a service.
+# The reason it earns a VM is that both ways of getting this wrong are silent.
+# Too eager and it reverts a change someone applied by hand while they are
+# still typing; too shy and `rollback.enable` is cosmetic, every generation
+# gets excused, and the safety net reports for months without ever once being
+# capable of acting. Neither shows up in a build, and neither shows up in
+# production until the night it matters.
+#
+# So the interesting assertion is not "a bad generation is refused". It is that
+# execution reaches a *later* rung of the guard ladder for a staged generation
+# than for a hand-applied one. Each subtest below pins the refusal to a
+# specific rung and checks the journal names that rung, which is what
+# distinguishes a working guard from one that happens to refuse everything.
+#
+# No rollback is ever performed. Subtest B stops at the cooldown rung by
+# writing a fresh `last-rollback` stamp, which is deterministic - relying on
+# the VM having only one generation would prove the same thing by accident and
+# break the day the harness stages two.
+{
+  name = "upgrade-verify";
+
+  nodes.machine =
+    { pkgs, lib, ... }:
+    {
+      imports = [ ../modules/nixos/upgrade-verify.nix ];
+
+      # upgrade-verify asserts on this, because it hangs its baseline off
+      # nixos-upgrade.service. The flake ref is never resolved: the timer is
+      # detached below so the upgrade itself never runs, which it could not do
+      # anyway inside a network-less build sandbox.
+      system.autoUpgrade = {
+        enable = true;
+        flake = "/dev/null#nothing";
+      };
+
+      # Both timers detached rather than disabled, so the units themselves stay
+      # exactly as a host would have them - this test reads their wiring. What
+      # is not wanted is either one firing underneath a subtest and blessing or
+      # judging a generation the script did not ask it to.
+      systemd.timers.nixos-upgrade.wantedBy = lib.mkForce [ ];
+      systemd.timers.nixos-upgrade-verify.wantedBy = lib.mkForce [ ];
+
+      cg.upgrade-verify = {
+        enable = true;
+
+        # The behaviour under test is the refusal ladder, which is reached
+        # identically whether or not rollback is armed - except that with it
+        # off, every path short-circuits at "reporting only" and the ladder is
+        # never exercised at all. On, therefore, which is also the
+        # configuration this test exists to de-risk.
+        rollback.enable = true;
+
+        # Defaults are 120s and 300s, chosen so a real host lets a service
+        # crash-loop a few times before judging it. Nothing here is racing a
+        # restart, and the globalTimeout is 600s.
+        settleSeconds = 1;
+        settleTimeoutSeconds = 10;
+      };
+
+      # Stands in for a service that came up broken under a new generation.
+      # Started by hand in the test, so its failure is timed rather than
+      # racing the boot transaction.
+      systemd.services.cg-verify-canary = {
+        description = "Deliberately failing unit, to give verification something to find";
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.coreutils}/bin/false";
+        };
+      };
+    };
+
+  testScript = ''
+    STATE = "/var/lib/nixos-deploy"
+    METRICS = "/var/lib/prometheus-node-exporter/nixos_verify.prom"
+
+
+    def metric(name):
+        """One gauge out of the textfile the node exporter would scrape."""
+        out = machine.succeed(
+            "grep -E '^{}\\{{' {} | awk '{{print $NF}}'".format(name, METRICS)
+        ).strip()
+        assert out, "metric {} was not written".format(name)
+        return out
+
+
+    def arm(staged, rolled_back_ago=None):
+        """Put the state dir in a known shape, then run verification.
+
+        `staged` is what nixos-upgrade will claim to have staged - None leaves
+        no record at all, which is how a host that has not upgraded since this
+        landed looks, and how any hand-applied generation looks.
+        """
+        machine.succeed("mkdir -p {}".format(STATE))
+        machine.succeed("rm -f {}/verified-system {}/automation-staged".format(STATE, STATE))
+
+        # Empty and fresh: nothing was failing before, so the canary counts as
+        # a new failure and the age guards are satisfied.
+        machine.succeed(": > {}/failed-units-baseline".format(STATE))
+
+        if staged is not None:
+            machine.succeed("echo {} > {}/automation-staged".format(staged, STATE))
+
+        if rolled_back_ago is None:
+            machine.succeed("rm -f {}/last-rollback".format(STATE))
+        else:
+            machine.succeed(
+                "expr $(date +%s) - {} > {}/last-rollback".format(rolled_back_ago, STATE)
+            )
+
+        machine.succeed("journalctl --rotate && journalctl --vacuum-time=1s")
+        # Verification exits non-zero whenever it refuses, by design - the
+        # refusal is the result, not an error.
+        machine.fail("systemctl start nixos-upgrade-verify.service")
+        return machine.succeed("journalctl -u nixos-upgrade-verify.service --no-pager")
+
+
+    machine.wait_for_unit("multi-user.target")
+    current = machine.succeed("readlink -f /run/current-system").strip()
+
+    with subtest("verification is triggered on both upgrade outcomes"):
+        # Regression guard for the ExecStartPost -> ExecStopPost fix: systemd
+        # skips ExecStartPost when ExecStart fails, which silently skipped
+        # verification in exactly the case it is wanted.
+        hooks = machine.succeed("systemctl show nixos-upgrade -p ExecStartPost -p ExecStopPost")
+        assert "nixos-upgrade-verify.service" in hooks, hooks
+        assert "nixos-upgrade-record-staged" in hooks, hooks
+
+        # Asserted per-line rather than on the blob: an unrelated ExecStartPost
+        # arriving later is fine, the verify trigger living in one is not.
+        start_post = [ln for ln in hooks.splitlines() if ln.startswith("ExecStartPost=")]
+        assert not any("nixos-upgrade-verify" in ln for ln in start_post), (
+            "verification must not hang off ExecStartPost:\n" + hooks
+        )
+
+    # Give verification something to find, for the two subtests that need a
+    # generation to judge as unhealthy.
+    machine.fail("systemctl start cg-verify-canary.service")
+    machine.succeed("systemctl is-failed cg-verify-canary.service")
+
+    with subtest("a hand-applied generation is reported but never rolled back"):
+        journal = arm(staged=None)
+
+        assert "applied by hand" in journal, journal
+        assert metric("nixos_verify_result") == "0"
+        assert metric("nixos_verify_manual_generation") == "1"
+        assert metric("nixos_verify_rolled_back") == "0"
+
+        # The point of the whole exercise: the running generation survived.
+        assert machine.succeed("readlink -f /run/current-system").strip() == current
+        machine.succeed("test ! -e {}/last-rollback".format(STATE))
+
+    with subtest("a staged generation reaches the guards beyond provenance"):
+        # Same unhealthy machine, the only difference being who staged it. If
+        # the provenance guard were over-firing, this would refuse for the same
+        # reason as above and rollback would be dead on every host.
+        journal = arm(staged=current, rolled_back_ago=60)
+
+        assert "applied by hand" not in journal, journal
+        assert "cooldown" in journal, journal
+        assert metric("nixos_verify_manual_generation") == "0"
+        assert metric("nixos_verify_result") == "0"
+        assert metric("nixos_verify_rolled_back") == "0"
+
+    with subtest("a healthy staged generation is blessed"):
+        machine.succeed("systemctl reset-failed cg-verify-canary.service")
+        machine.succeed("systemctl start nixos-upgrade-verify.service")
+
+        assert metric("nixos_verify_result") == "1"
+        assert metric("nixos_verify_manual_generation") == "0"
+        assert machine.succeed("cat {}/verified-system".format(STATE)).strip() == current
+
+    with subtest("a blessed generation is not judged twice"):
+        # The guard that lets every trigger fire freely. Without it, adding
+        # ExecStopPost would mean re-judging a generation on every upgrade.
+        machine.fail("systemctl start cg-verify-canary.service")
+        machine.succeed("systemctl start nixos-upgrade-verify.service")
+        journal = machine.succeed("journalctl -u nixos-upgrade-verify.service --no-pager")
+        assert "already verified" in journal, journal
+  '';
+}

--- a/modules/nixos/upgrade-verify.nix
+++ b/modules/nixos/upgrade-verify.nix
@@ -62,8 +62,8 @@
 # guards on top of that:
 #
 #   - no baseline, or one older than `baselineMaxAge`, means report but never
-#     roll back. That covers a manual `nixos-rebuild switch`, where nothing
-#     recorded what "before" looked like.
+#     roll back, since a new failure cannot be told from an old one.
+#   - no rollback for a generation nixos-upgrade did not stage. See below.
 #   - no rollback within `rollbackCooldown` of the last one, so a bad revision
 #     that keeps being re-offered flaps once a night rather than in a loop.
 #   - no rollback if the profile has no previous generation to return to.
@@ -71,6 +71,37 @@
 # `rollback.enable` is off by default. The failure mode of this module is
 # reverting a healthy server, and the honest way to find that out is to watch
 # it decide for a few weeks before letting it act.
+#
+# ---------------------------------------------------------------------------
+# Verifying by hand-applied generations, without fighting the person
+# ---------------------------------------------------------------------------
+#
+# Verification runs on whatever is booted, so a hand-run `nixos-rebuild switch`
+# gets judged too. That is wanted - it is a generation nothing else checks -
+# but it must never be reverted. Automatic rollback is worth having because
+# nobody is watching at 04:00; someone at a terminal mid-troubleshooting has
+# more context than this script does, and taking their work away is worse than
+# the degradation it would be protecting against.
+#
+# `baselineMaxAge` was once assumed to cover this. It does not: the baseline is
+# written by nixos-upgrade's ExecStartPre, so switching by hand at 08:00 after
+# an 04:00 upgrade leaves a baseline four hours old and comfortably inside the
+# limit. Rebooting to test a change - an ordinary thing to do while debugging -
+# then fires the OnBootSec trigger straight into an armed rollback.
+#
+# So rollback is gated on provenance rather than on the trigger or the clock:
+# nixos-upgrade records the generation it staged, and rollback is refused
+# unless that is what is running. It falls out of the profile symlink, which
+# nixos-upgrade already sets in both its `boot` and `switch` branches, so there
+# is no new lifecycle to keep honest. A missing record means refuse, which is
+# also what a freshly deployed host sees.
+#
+# It is worth being clear about what this gives up: a generation applied by
+# hand and then abandoned is never reverted automatically. That is the intended
+# reading - a human touched it, so a human owns it - and `nixos_verify_result`
+# still alerts either way. It also makes rollback structurally non-recursive,
+# since the generation reverted *to* was never the staged one, which the
+# cooldown previously handled more bluntly.
 #
 # ---------------------------------------------------------------------------
 # What it cannot do
@@ -105,6 +136,7 @@ let
   verifiedFile = "${stateDir}/verified-system";
   baselineFile = "${stateDir}/failed-units-baseline";
   rollbackStamp = "${stateDir}/last-rollback";
+  stagedFile = "${stateDir}/automation-staged";
 
   host = config.networking.hostName;
 
@@ -118,6 +150,16 @@ let
     mkdir -p "${stateDir}"
     ${failedUnits} | ${pkgs.gawk}/bin/awk '{print $1}' | sort -u > "${baselineFile}.tmp"
     mv "${baselineFile}.tmp" "${baselineFile}"
+  '';
+
+  # What nixos-upgrade staged, read off the profile symlink it just set. Run
+  # from ExecStopPost so it records on both outcomes, and so the `boot` branch
+  # is captured before the reboot that activates it.
+  stagedScript = pkgs.writeShellScript "nixos-upgrade-record-staged" ''
+    set -uo pipefail
+    mkdir -p "${stateDir}"
+    readlink -f /nix/var/nix/profiles/system > "${stagedFile}.tmp"
+    mv "${stagedFile}.tmp" "${stagedFile}"
   '';
 
   verifyScript = pkgs.writeShellScript "nixos-upgrade-verify" ''
@@ -136,6 +178,16 @@ let
     fi
 
     echo "Verifying generation: $current"
+
+    # Provenance, not trigger: rollback is refused below for anything
+    # nixos-upgrade did not stage. A missing record refuses too, which is what
+    # a host that has not upgraded since this landed will see.
+    if [ -r "${stagedFile}" ] && [ "$current" = "$(cat "${stagedFile}")" ]; then
+      manual=0
+    else
+      manual=1
+      echo "Not the generation nixos-upgrade staged; this one was applied by hand."
+    fi
 
     # Let units that are going to fail get on with failing. A switch returns as
     # soon as systemd has accepted the jobs, not when they have settled.
@@ -187,6 +239,9 @@ let
     # HELP nixos_verify_rolled_back Whether the last verification ended in a rollback (1=yes)
     # TYPE nixos_verify_rolled_back gauge
     nixos_verify_rolled_back{host="${host}"} $2
+    # HELP nixos_verify_manual_generation Whether the verified generation was applied by hand rather than staged by nixos-upgrade (1=manual, and so exempt from rollback)
+    # TYPE nixos_verify_manual_generation gauge
+    nixos_verify_manual_generation{host="${host}"} $manual
     EOF
       if [ -r "${rollbackStamp}" ]; then
         cat >> "$tmp" <<EOF
@@ -224,6 +279,12 @@ let
         ''
       else
         ''
+          if [ "$manual" = 1 ]; then
+            write_metrics 0 0
+            echo "This generation was applied by hand, not staged by nixos-upgrade; reporting only. Reverting someone's work mid-troubleshooting is not this script's call." >&2
+            exit 1
+          fi
+
           if [ "$baseline_age" -lt 0 ]; then
             write_metrics 0 0
             echo "No pre-upgrade baseline, so these failures cannot be attributed to this generation; refusing to roll back." >&2
@@ -378,6 +439,10 @@ in
         # would deadlock against that ordering, and a verification that waits
         # minutes to settle should not hold the upgrade unit open regardless.
         ExecStopPost = [
+          # Ordered before the trigger below, so the record is on disk by the
+          # time verification reads it. (It would be anyway - the queued job
+          # waits for this unit to deactivate - but not by accident.)
+          stagedScript
           "${pkgs.systemd}/bin/systemctl start --no-block nixos-upgrade-verify.service"
         ];
       };

--- a/modules/services/monitoring/alert-rules.yml
+++ b/modules/services/monitoring/alert-rules.yml
@@ -325,6 +325,11 @@ groups:
       #
       # Only counts units that were not already failing before the upgrade
       # started, so this is a claim about the new generation specifically.
+      #
+      # Fires for hand-applied generations too, which is the point - nothing
+      # else checks those. Rollback deliberately will not act on them, so
+      # check nixos_verify_manual_generation before wondering why the host is
+      # still sitting on a generation that failed verification.
       - alert: NixosVerifyFailed
         expr: nixos_verify_result == 0
         for: 10m
@@ -332,7 +337,7 @@ groups:
           severity: critical
         annotations:
           summary: "{{ $labels.host }} activated a generation that did not come up healthy"
-          description: "Verification found units failing that were not failing before the upgrade. Check: journalctl -u nixos-upgrade-verify.service"
+          description: "Verification found units failing that were not failing before the upgrade. If nixos_verify_manual_generation is 1 this generation was applied by hand and will not be rolled back automatically — it is yours to fix or revert. Check: journalctl -u nixos-upgrade-verify.service"
 
       # The silence problem, applied to the safety net itself. NixosVerifyFailed
       # only speaks when verification runs and fails; if it stopped running —


### PR DESCRIPTION
Follow-up to #40, ahead of the decision to arm `cg.upgrade-verify.rollback.enable`.

## The hazard is live today

Verification judges whatever is booted, so a hand-run `nixos-rebuild switch` gets checked too. That is worth having — nothing else checks those — but with rollback armed it means the script can revert your work while you are still typing.

The module header claimed `baselineMaxAge` covered this. **It does not.** The baseline is written by `nixos-upgrade`'s `ExecStartPre`, so switching by hand at 08:00 after an 04:00 upgrade leaves a baseline four hours old — comfortably inside the six-hour limit. Rebooting to test the change, an ordinary thing to do while debugging, then fires the `OnBootSec` trigger straight into an armed rollback.

Worth being explicit: this is a latent hazard in the current design, not one the periodic `OnCalendar` timer would have introduced.

## Gate on provenance, not on the trigger or the clock

`nixos-upgrade` records the generation it staged; rollback is refused unless that is what is running. It falls out of the profile symlink, which `nixos-upgrade` already sets in **both** its `boot` and `switch` branches, so there is no new lifecycle to keep honest. A missing record refuses — which is what a host that has not upgraded since this lands will see.

| Situation | `current` vs `automation-staged` | Outcome |
|---|---|---|
| Nightly, kernel unchanged | match | rollback eligible |
| Nightly, reboot path | match (written pre-reboot) | rollback eligible |
| Nightly, out of reboot window | no match; already blessed | no-op |
| **Hand-applied generation** | **no match** | **verified, alerted, never reverted** |
| After a rollback fires | no match | report-only — cannot cascade |

Verification and reporting are unchanged for hand-applied generations: still judged, still write metrics, still alert. Only the decision to *act* is withheld.

That last row is a side effect worth naming — rollback is now structurally non-recursive, which `cooldownSeconds` previously handled more bluntly.

## Metric

New gauge `nixos_verify_manual_generation`, so "verification is reporting on something applied by hand" is visible in Grafana rather than buried in the journal. `NixosVerifyFailed` now points at it — otherwise a generation that failed verification and was deliberately not reverted looks like a broken safety net.

## Test

New VM test, `checks/upgrade-verify.nix`. Both ways of getting this wrong are silent: too eager reverts a human's work; too shy leaves rollback cosmetic while still reporting for months. Neither shows up in a build.

So the test does not merely assert that a bad generation is refused — it pins each refusal to a **named rung** of the guard ladder, and checks that a staged generation reaches rungs a hand-applied one does not. That is what separates a working guard from one that refuses everything.

```
subtest: verification is triggered on both upgrade outcomes
subtest: a hand-applied generation is reported but never rolled back
subtest: a staged generation reaches the guards beyond provenance
subtest: a healthy staged generation is blessed
subtest: a blessed generation is not judged twice
```

No rollback is ever performed — subtest B stops deterministically at the cooldown rung by writing a fresh `last-rollback` stamp, rather than relying on the VM having only one generation (which would prove the same thing by accident and break the day the harness stages two).

The first subtest is also a regression guard for #40: it asserts per-line that the verify trigger does not live in an `ExecStartPost`.

**Mutation-checked**: inverting the provenance guard (`manual=1` → `manual=0`) makes the test fail. A safety test that cannot fail is worth nothing, so I confirmed this one can.

## Decision this encodes

A generation applied by hand is *never* auto-reverted, including one applied and then walked away from. A human touched it, so a human owns it. `nixos_verify_result` still alerts either way. Flagging it because it is a real position, not a neutral default.

With this in, the periodic `OnCalendar` timer I held back from #40 becomes safe to add — the worst it can do to a hand-applied generation is alert. Happy to do that separately if you want it before arming rollback.