### PR TITLE
feat(upgrade-verify): re-check the running generation on a schedule

### DIFF
--- a/checks/upgrade-verify.nix
+++ b/checks/upgrade-verify.nix
@@ -72,6 +72,34 @@
       };
     };
 
+  # A second machine, because the trigger under test is the one that fires
+  # when nothing asks it to - which cannot be shown on a node whose timer is
+  # detached so the subtests can control their own timing.
+  nodes.scheduled =
+    { lib, ... }:
+    {
+      imports = [ ../modules/nixos/upgrade-verify.nix ];
+
+      system.autoUpgrade = {
+        enable = true;
+        flake = "/dev/null#nothing";
+      };
+
+      # The upgrade never runs, so nothing here announces a generation. The
+      # verify timer is left armed - it is the subject.
+      systemd.timers.nixos-upgrade.wantedBy = lib.mkForce [ ];
+
+      cg.upgrade-verify = {
+        enable = true;
+        settleSeconds = 1;
+        settleTimeoutSeconds = 10;
+
+        # Every ten seconds, so the wait below stays comfortably inside the
+        # three minute OnBootSec that must not be what fires.
+        recheckSchedule = "*:*:0/10";
+      };
+    };
+
   testScript = ''
     STATE = "/var/lib/nixos-deploy"
     METRICS = "/var/lib/prometheus-node-exporter/nixos_verify.prom"
@@ -172,6 +200,14 @@
         assert metric("nixos_verify_manual_generation") == "0"
         assert machine.succeed("cat {}/verified-system".format(STATE)).strip() == current
 
+    with subtest("both triggers are armed on one timer"):
+        timer = machine.succeed(
+            "systemctl show nixos-upgrade-verify.timer -p TimersMonotonic -p TimersCalendar"
+        )
+        # systemd renders OnBootSec= back as OnBootUSec.
+        assert "OnBootUSec=3min" in timer, timer
+        assert "OnCalendar=" in timer, timer
+
     with subtest("a blessed generation is not judged twice"):
         # The guard that lets every trigger fire freely. Without it, adding
         # ExecStopPost would mean re-judging a generation on every upgrade.
@@ -179,5 +215,30 @@
         machine.succeed("systemctl start nixos-upgrade-verify.service")
         journal = machine.succeed("journalctl -u nixos-upgrade-verify.service --no-pager")
         assert "already verified" in journal, journal
+
+    with subtest("the schedule verifies a generation nothing announced"):
+        # Nothing on this node ever starts verification: no upgrade runs, and
+        # the test does not ask. The only other trigger is OnBootSec at three
+        # minutes, so the uptime assertion is what makes this a claim about the
+        # calendar entry rather than about verification working at all.
+        scheduled.wait_for_unit("multi-user.target")
+        scheduled.wait_for_file("{}/verified-system".format(STATE), timeout=100)
+
+        uptime = float(scheduled.succeed("cut -d' ' -f1 /proc/uptime").strip())
+        assert uptime < 170, "OnBootSec may have fired; uptime was {}".format(uptime)
+
+        current_scheduled = scheduled.succeed("readlink -f /run/current-system").strip()
+        blessed = scheduled.succeed("cat {}/verified-system".format(STATE)).strip()
+        assert blessed == current_scheduled, (blessed, current_scheduled)
+
+        # A host that has never upgraded has no staged record, so provenance
+        # reads this as hand-applied - correctly, and harmlessly, since a
+        # healthy generation is never a rollback candidate anyway.
+        manual = scheduled.succeed(
+            "grep -E '^nixos_verify_manual_generation\\{{' {} | awk '{{print $NF}}'".format(
+                METRICS
+            )
+        ).strip()
+        assert manual == "1", manual
   '';
 }

--- a/modules/nixos/upgrade-verify.nix
+++ b/modules/nixos/upgrade-verify.nix
@@ -30,7 +30,9 @@
 # system differs from it. That single rule covers all three branches. The unit
 # is started from two places, and either one arriving first is fine:
 #
-#   - a timer at boot, for the reboot path
+#   - a timer at boot, for the reboot path, which also re-checks on a schedule
+#     (`recheckSchedule`) so that a generation nothing thought to announce is
+#     still eventually judged
 #   - nixos-upgrade's ExecStopPost, for the same-unit switch path (where it is
 #     a no-op in the other two branches, because the running system has not
 #     changed)
@@ -102,6 +104,15 @@
 # still alerts either way. It also makes rollback structurally non-recursive,
 # since the generation reverted *to* was never the staged one, which the
 # cooldown previously handled more bluntly.
+#
+# Provenance is also what makes `recheckSchedule` safe to have. Verification
+# used to run only when something announced a change, so a generation that
+# arrived quietly was never judged; re-checking on a schedule closes that, but
+# only became reasonable once a periodic firing could no longer revert
+# somebody's afternoon. What is left is bounded by `baselineMaxAge` doing the
+# job it was always meant to do: rollback needs evidence contemporary with the
+# upgrade, so a scheduled run can only act inside that window, and reports for
+# the rest of the generation's life.
 #
 # ---------------------------------------------------------------------------
 # What it cannot do
@@ -372,6 +383,23 @@ in
       '';
     };
 
+    recheckSchedule = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = "hourly";
+      example = "*:0/30";
+      description = ''
+        systemd calendar expression for re-checking the running generation,
+        alongside the boot and post-upgrade triggers. `null` disables it,
+        leaving verification dependent on something thinking to ask for it.
+
+        This is a safety net rather than a schedule: a generation that has
+        already been blessed is a no-op, so almost every firing does nothing
+        but read a file. What it catches is the case with no trigger at all -
+        a `nixos-rebuild switch` run by hand, or an upgrade path that failed
+        in a way that skipped its own hook.
+      '';
+    };
+
     baselineMaxAgeSeconds = lib.mkOption {
       type = lib.types.ints.positive;
       default = 6 * 60 * 60;
@@ -468,15 +496,23 @@ in
       ];
     };
 
-    # The reboot path: the generation activates at boot, long after
-    # nixos-upgrade.service has gone. A timer rather than wantedBy, so
-    # verification is not inside the boot transaction it waits on.
+    # Two triggers in one timer. OnBootSec covers the reboot path, where the
+    # generation activates long after nixos-upgrade.service has gone; the
+    # calendar entry covers everything with no trigger at all. A timer rather
+    # than wantedBy, so verification is not inside the boot transaction it
+    # waits on.
+    #
+    # Deliberately not Persistent: a missed calendar run would then fire at
+    # boot, which is what OnBootSec is already there for.
     systemd.timers.nixos-upgrade-verify = {
-      description = "Timer for post-boot generation verification";
+      description = "Timer for post-boot and periodic generation verification";
       wantedBy = [ "timers.target" ];
       timerConfig = {
         OnBootSec = "3min";
         Unit = "nixos-upgrade-verify.service";
+      }
+      // lib.optionalAttrs (cfg.recheckSchedule != null) {
+        OnCalendar = cfg.recheckSchedule;
       };
     };
   };

--- a/modules/services/monitoring/alert-rules.yml
+++ b/modules/services/monitoring/alert-rules.yml
@@ -356,9 +356,18 @@ groups:
       # which is NixosRebootPending's business and would otherwise fire here
       # first and more noisily for the same underlying condition.
       #
-      # 6h rather than something tighter because a manual `nixos-rebuild
-      # switch` also trips this — correctly, since it activates a generation
-      # nothing verifies — and iterating on a service should not page you.
+      # This used to be the alert a manual `nixos-rebuild switch` tripped,
+      # since that activated a generation nothing would ever verify, and 6h was
+      # chosen so that iterating on a service did not page anyone. Verification
+      # now re-checks on a schedule (cg.upgrade-verify.recheckSchedule), so a
+      # hand-applied generation is judged within the hour like any other and no
+      # longer reaches this at all.
+      #
+      # What is left is the case it was named for: verification not running.
+      # The 6h window is generous for that, but the cost of leaving it there is
+      # a slower page on a broken timer, and the cost of tightening it is
+      # inventing a new false positive. It stays until something argues for a
+      # different number.
       - alert: NixosVerifyStale
         expr: |
           (nixos_deploy_staged_timestamp_seconds - nixos_verify_timestamp_seconds > 21600)


### PR DESCRIPTION
Completes the thread from #40 and #41. This is the periodic timer I held back from #40, now that #41 makes it safe.

## The gap

Verification only ran when something announced a change: `nixos-upgrade`'s `ExecStopPost`, or the boot timer. A generation that arrived quietly was never judged — a hand-run `nixos-rebuild switch` most obviously, but also any upgrade path that failed in a way that skipped its own hook, which is how #40 came to be written in the first place.

## The change

`recheckSchedule`, a `nullOr str` defaulting to `"hourly"`, added as an `OnCalendar` entry on the existing timer via `lib.optionalAttrs` so `null` cleanly omits it. Both hosts pick it up from the default — verified with `nix eval`, no host config change needed.

A safety net rather than a schedule: an already-blessed generation no-ops on a file read, so almost every firing does nothing. The guard that lets every trigger fire freely is what makes a third one free.

Deliberately **not** `Persistent` — a missed calendar run would then fire at boot, which is what `OnBootSec` is already there for.

## Why it is only reasonable now

Before #41, a periodic firing could revert a generation someone applied by hand and was still working on. That is why this was held back rather than shipped alongside it.

What exposure remains is bounded by `baselineMaxAge` doing the job it was always meant to do: rollback needs evidence contemporary with the upgrade, so a scheduled run can only act inside that window, and reports for the rest of the generation's life.

## Test

Two subtests. The first reads the timer. The second is behavioural and needed **its own node** — the claim is about a trigger that fires when nothing asks it to, which cannot be shown on a node whose timer is detached so the other subtests can control their own timing.

That node sets a ten-second schedule, runs no upgrade, and the test never starts verification. The load-bearing assertion is the uptime check:

```python
scheduled.wait_for_file(".../verified-system", timeout=100)
uptime = float(scheduled.succeed("cut -d\x27 \x27 -f1 /proc/uptime").strip())
assert uptime < 170, "OnBootSec may have fired; uptime was {}".format(uptime)
```

Without it the test would pass on either trigger and prove nothing about this one.

```
subtest: verification is triggered on both upgrade outcomes
subtest: a hand-applied generation is reported but never rolled back
subtest: a staged generation reaches the guards beyond provenance
subtest: a healthy staged generation is blessed
subtest: both triggers are armed on one timer
subtest: a blessed generation is not judged twice
subtest: the schedule verifies a generation nothing announced   (22.5s)
```

**Mutation-checked**: removing the `OnCalendar` entry makes the test fail.

## Documentation correction this forced

`NixosVerifyStale` carried the rationale that a manual `nixos-rebuild switch` trips it *"correctly, since it activates a generation nothing verifies"*. That premise is exactly what this commit removes — a hand-applied generation is now judged within the hour and no longer reaches that alert.

Rewritten to say what it actually catches now: verification not running at all, which is what it was named for. The 6h threshold is left alone, with a note on why — tightening it would invent a new false positive, and the only cost of leaving it is a slower page on a broken timer. That is a tuning call, not a side effect of this change.

Worth noting for the arming decision: this makes `NixosVerifyStale` a sharper signal than it was, which matters when part of what you are judging is that no alerts fired.

## Verification

`nix flake check` passes on exactly this tree (re-run after the alert-rules edit, so `monitoring` rebuilt against the new rule file rather than a stale one). homelab01 and homelab02 both build.