### PR TITLE
fix(upgrade-verify): judge a rollback by what is running, not by exit codes

### DIFF
--- a/checks/upgrade-verify.nix
+++ b/checks/upgrade-verify.nix
@@ -156,6 +156,58 @@
       };
     };
 
+  # A fourth machine, where installing the bootloader always fails. That is the
+  # fault behind the defect under test: switch-to-configuration installs the
+  # bootloader *before* it activates, so a failure there leaves the profile
+  # moved and nothing else done, and the old code read the moved profile as
+  # proof of a successful rollback.
+  #
+  # Injected directly rather than by leaving grub enabled and letting the VM's
+  # grub-install fail on its ext2 disk. That does reproduce it - it is how the
+  # defect was found - but only in some orderings, and it would quietly stop
+  # testing anything the day nixpkgs changes the test disk.
+  nodes.bootfail =
+    { pkgs, lib, ... }:
+    {
+      imports = [ ../modules/nixos/upgrade-verify.nix ];
+
+      system.autoUpgrade = {
+        enable = true;
+        flake = "/dev/null#nothing";
+      };
+
+      systemd.timers.nixos-upgrade.wantedBy = lib.mkForce [ ];
+      systemd.timers.nixos-upgrade-verify.wantedBy = lib.mkForce [ ];
+
+      boot.loader.grub.enable = lib.mkForce false;
+      system.build.installBootLoader = lib.mkForce (
+        pkgs.writeShellScript "cg-failing-bootloader-install" ''
+          echo "Failed to install bootloader" >&2
+          exit 1
+        ''
+      );
+
+      cg.upgrade-verify = {
+        enable = true;
+        rollback.enable = true;
+        settleSeconds = 1;
+        settleTimeoutSeconds = 10;
+        recheckSchedule = null;
+      };
+
+      systemd.services.cg-verify-canary = {
+        description = "Deliberately failing unit, to give verification something to find";
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.coreutils}/bin/false";
+        };
+      };
+
+      specialisation.alt.configuration = {
+        environment.etc."cg-alt-generation".text = "second generation";
+      };
+    };
+
   testScript = ''
     STATE = "/var/lib/nixos-deploy"
     METRICS = "/var/lib/prometheus-node-exporter/nixos_verify.prom"
@@ -344,6 +396,7 @@
         rollback.succeed("test ! -e /etc/cg-alt-generation")
 
         assert metric("nixos_verify_rolled_back", node=rollback) == "1"
+        assert metric("nixos_verify_rollback_failed", node=rollback) == "0"
         assert metric("nixos_verify_result", node=rollback) == "0"
         assert metric("nixos_verify_manual_generation", node=rollback) == "0"
         rollback.succeed("test -e {}/last-rollback".format(STATE))
@@ -365,5 +418,42 @@
         assert metric("nixos_verify_manual_generation", node=rollback) == "1"
         assert metric("nixos_verify_rolled_back", node=rollback) == "0"
         assert rollback.succeed("cat {}/verified-system".format(STATE)).strip() == gen1
+
+    with subtest("a rollback that cannot activate says so instead of claiming success"):
+        # nix-env --rollback moves the profile, then switch-to-configuration
+        # installs the bootloader *before* activating. When that install fails
+        # it exits early, so the profile has moved and nothing else has. The
+        # old code read the moved profile as proof and reported a successful
+        # rollback while the failed generation kept running.
+        bootfail.wait_for_unit("multi-user.target")
+        running = bootfail.succeed("readlink -f /run/current-system").strip()
+        alt = bootfail.succeed("readlink -f /run/current-system/specialisation/alt").strip()
+        assert alt != running, (alt, running)
+
+        # Generations built through the profile rather than by activating,
+        # because activating is precisely what does not work on this node.
+        # Leaves the profile on what is running, with somewhere to roll back to.
+        bootfail.succeed("nix-env -p /nix/var/nix/profiles/system --set {}".format(alt))
+        bootfail.succeed("nix-env -p /nix/var/nix/profiles/system --set {}".format(running))
+
+        # ...and give verification a reason to want the rollback.
+        bootfail.fail("systemctl start cg-verify-canary.service")
+
+        journal = arm(staged=running, node=bootfail)
+
+        # The fault injector really fired, rather than the rollback failing
+        # for some unrelated reason that would make the rest vacuous.
+        assert "Failed to install bootloader" in journal, journal
+
+        assert "ROLLBACK DID NOT TAKE" in journal, journal
+        assert bootfail.succeed("readlink -f /run/current-system").strip() == running
+        assert bootfail.succeed("readlink -f /nix/var/nix/profiles/system").strip() == alt
+
+        assert metric("nixos_verify_rollback_failed", node=bootfail) == "1"
+        assert metric("nixos_verify_rolled_back", node=bootfail) == "0"
+        assert metric("nixos_verify_result", node=bootfail) == "0"
+
+        # No stamp: nothing moved, so nothing should be held off by a cooldown.
+        bootfail.succeed("test ! -e {}/last-rollback".format(STATE))
   '';
 }

--- a/modules/nixos/upgrade-verify.nix
+++ b/modules/nixos/upgrade-verify.nix
@@ -123,6 +123,15 @@
 # (`deploy-rs` with magicRollback, which waits for the *deployer* to reconnect)
 # and is not addressed here.
 #
+# A rollback is judged by what ends up running, not by what
+# switch-to-configuration returned. That script installs the bootloader before
+# it activates anything, so a bootloader failure leaves the profile moved and
+# nothing else - and its exit code is useless as a success signal in the other
+# direction too, since it returns non-zero whenever a unit is failing after
+# activation, which is the state every rollback starts from by definition.
+# `nixos_verify_rollback_failed` carries the difference between "the old
+# generation is running again" and "the profile moved and nothing happened".
+#
 # The rollback is deliberately services-only: the previous generation is made
 # current and made the boot default, but nothing reboots. After a kernel-
 # changing upgrade that means the new kernel keeps running under the old
@@ -177,6 +186,10 @@ let
     set -uo pipefail
 
     mkdir -p "${stateDir}" "${metricsDir}"
+
+    # Set only by the rollback path below, but written on every run so the
+    # gauge is never stale from a previous verification.
+    rollback_failed=0
 
     current="$(readlink -f /run/current-system)"
 
@@ -253,6 +266,9 @@ let
     # HELP nixos_verify_manual_generation Whether the verified generation was applied by hand rather than staged by nixos-upgrade (1=manual, and so exempt from rollback)
     # TYPE nixos_verify_manual_generation gauge
     nixos_verify_manual_generation{host="${host}"} $manual
+    # HELP nixos_verify_rollback_failed Whether a rollback was attempted and did not fully take effect (1=yes)
+    # TYPE nixos_verify_rollback_failed gauge
+    nixos_verify_rollback_failed{host="${host}"} $rollback_failed
     EOF
       if [ -r "${rollbackStamp}" ]; then
         cat >> "$tmp" <<EOF
@@ -326,15 +342,54 @@ let
 
           echo "Rolling back to the previous generation."
           ${pkgs.nix}/bin/nix-env -p /nix/var/nix/profiles/system --rollback
+          target="$(readlink -f /nix/var/nix/profiles/system)"
 
           # The rolled-back profile's own script, not /run/current-system's -
           # that one belongs to the generation being abandoned. `boot` first so
           # the bootloader default reverts even if `switch` then has trouble;
           # no reboot, for the reason in the header.
-          /nix/var/nix/profiles/system/bin/switch-to-configuration boot
-          /nix/var/nix/profiles/system/bin/switch-to-configuration switch
+          boot_ok=1
+          /nix/var/nix/profiles/system/bin/switch-to-configuration boot || boot_ok=0
+          /nix/var/nix/profiles/system/bin/switch-to-configuration switch || true
 
+          # ------------------------------------------------------------------
+          # Judged on what is running, never on what switch-to-configuration
+          # returned.
+          #
+          # Its exit code cannot be used here. It exits non-zero whenever any
+          # unit is failing once activation has finished - which is the state
+          # this host is in by definition, since that is what verification just
+          # found - so a non-zero return says nothing about whether the
+          # rollback took. The symlink does.
+          #
+          # The other direction is what made this check necessary: bootloader
+          # installation happens *before* activation, so when it fails,
+          # switch-to-configuration exits without activating anything. The
+          # profile has already moved by then, and the old code took that as
+          # proof of a rollback and reported success while the broken
+          # generation kept running.
+          # ------------------------------------------------------------------
+          running="$(readlink -f /run/current-system)"
+
+          if [ "$running" != "$target" ]; then
+            rollback_failed=1
+            write_metrics 0 0
+            echo "ROLLBACK DID NOT TAKE. The profile was moved to $target, but $running is still running, so activation never happened - most likely switch-to-configuration failed before it got that far. This host is still on the generation that failed verification and needs hands on it now." >&2
+            exit 1
+          fi
+
+          # A real move happened, so the cooldown applies whatever else went
+          # wrong: the point of the stamp is that a re-offered bad revision
+          # flaps once a night rather than in a loop.
           echo "$now" > "${rollbackStamp}"
+
+          if [ "$boot_ok" -eq 0 ]; then
+            rollback_failed=1
+            write_metrics 0 1
+            echo "Rolled back, but the bootloader was not updated. Services are on $target now; the next reboot will return to the generation that failed verification. Fix the bootloader before rebooting." >&2
+            exit 1
+          fi
+
           write_metrics 0 1
           echo "Rolled back. The host is no longer tracking the promoted ref - fix forward and check it takes the next revision." >&2
           exit 1

--- a/modules/services/monitoring/alert-rules.yml
+++ b/modules/services/monitoring/alert-rules.yml
@@ -339,6 +339,22 @@ groups:
           summary: "{{ $labels.host }} activated a generation that did not come up healthy"
           description: "Verification found units failing that were not failing before the upgrade. If nixos_verify_manual_generation is 1 this generation was applied by hand and will not be rolled back automatically — it is yours to fix or revert. Check: journalctl -u nixos-upgrade-verify.service"
 
+      # Distinct from NixosVerifyFailed, which says a generation came up
+      # unhealthy. This says the thing that was supposed to rescue it did not,
+      # and the two want opposite responses: a successful rollback means the
+      # host is on the old generation and can be fixed forward at leisure,
+      # while this means either the broken generation is still running or it
+      # will be again at the next reboot. Both are in the message, because
+      # which one it is decides how fast you have to move.
+      - alert: NixosRollbackFailed
+        expr: nixos_verify_rollback_failed == 1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.host }} attempted a rollback that did not fully take effect"
+          description: "Verification decided to revert this generation and could not finish the job. If nixos_verify_rolled_back is 0 the failed generation is still running and needs hands on it now; if it is 1 the services reverted but the bootloader did not, so the next reboot returns to the failed generation. Check: journalctl -u nixos-upgrade-verify.service"
+
       # The silence problem, applied to the safety net itself. NixosVerifyFailed
       # only speaks when verification runs and fails; if it stopped running —
       # timer broken, module disabled, unit masked — nixos_verify_result would


### PR DESCRIPTION
Fixes the defect #43 found, and closes the last of the four claims underpinning the decision to arm `cg.upgrade-verify.rollback.enable`.

## The defect

`switch-to-configuration` installs the bootloader **before** it activates anything, so when that install fails it exits without activating. The profile has already moved by then, and the old code took the moved profile as proof — it wrote the stamp, set `nixos_verify_rolled_back` to 1, and logged "Rolled back" while the generation that had just failed verification kept running.

The metric said the safety net caught you when it had not.

## Why the fix is not "check the exit codes"

It cannot be. `switch` returns non-zero whenever any unit is failing once activation has finished — which is the state every rollback starts from **by definition**, since that is what verification just found. A non-zero return therefore says nothing about whether the rollback took, and treating it as failure would make the metric lie in the other direction. It would misfire on exactly the situation from #39.

So the rollback is judged on outcome: compare `/run/current-system` to the profile target and let the symlink settle it.

## Three outcomes, not one

| State | `rolled_back` | `rollback_failed` | Stamp |
|---|---|---|---|
| Activated, bootloader updated | 1 | 0 | yes |
| Activated, bootloader not updated | 1 | **1** | yes |
| Nothing activated | 0 | **1** | **no** |

The middle row was not in my original description of this fix. Services revert but the boot default does not, so the next reboot silently returns to the broken generation — worth its own signal rather than being folded into success.

The stamp rule follows from what the cooldown is for. It exists to stop a flap; nothing moved in the third row, so nothing should be held off, and the next attempt should be free to retry.

## Alerting

New gauge `nixos_verify_rollback_failed`, with a critical `NixosRollbackFailed`. A gauge nothing watches would be the same silent lie in a new place.

Deliberately separate from `NixosVerifyFailed`, because the responses differ: a rollback that worked means the host is on the old generation and can be fixed forward at leisure; this means either the broken generation is live now, or it will be at the next reboot. The description keys on `nixos_verify_rolled_back` to say which.

## Test

Ninth subtest, on a node where installing the bootloader always fails:

```
ROLLBACK DID NOT TAKE. The profile was moved to /nix/store/hw4jk…, but
/nix/store/x6lr5… is still running, so activation never happened — most
likely switch-to-configuration failed before it got that far. This host is
still on the generation that failed verification and needs hands on it now.
```

The failure is injected directly rather than by leaving grub enabled and letting the VM's `grub-install` fail on its ext2 disk. That is how the defect was found, but **the first version of this subtest passed for the wrong reason** — `grub-install` only runs in some orderings, and on that node it never ran at all, so the rollback succeeded and the test proved nothing. A harness accident makes a bad fault injector.

**Mutation-checked**: forcing the success path unconditionally, which is the old behaviour, makes the subtest fail.

## Verification

`nix flake check` passes (all 9 subtests), homelab01 and homelab02 both build.