### PR TITLE
build(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1786867632,
-        "narHash": "sha256-ez+ubZlA1RtdjCB18a6zJ9M4u8qoPDy08EcnsW5M3Xw=",
+        "lastModified": 1787144466,
+        "narHash": "sha256-HHfv2/HkNSKbbSyU9iD/g8lbP6r4tl33sSw1W4rXCk0=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "ff17823245ab9ff7bcae6acf950bd89cba82c38c",
+        "rev": "0471accf8d0a8210b31d947497d179ecc99e0021",
         "type": "github"
       },
       "original": {
@@ -185,11 +185,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786999651,
-        "narHash": "sha256-MTGMFlLDTklsXhCp4r5GXB4VAVadPdalXLvUjd/K7h0=",
+        "lastModified": 1787152495,
+        "narHash": "sha256-zWjKwcMt0h+FIr0lgn0PWVN/24+IfNf4RhfL6hId2b4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "353742587cbaf079b3caee743115d037bc51fea6",
+        "rev": "3c3ede6ad886a6d9b0938ef19112523118fe62c2",
         "type": "github"
       },
       "original": {
@@ -213,11 +213,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1786943417,
-        "narHash": "sha256-b4qgjdFtlz5TAZ1Hi7DFJeqX3sjaDUnrwr9OO+O1rM0=",
+        "lastModified": 1787101114,
+        "narHash": "sha256-gwrPcFf/rDjHPaVflbDZ040ZDmBTRj/7+s8ZmE2SaIM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0dd31db7e6dbf9ce05697c4545f6fe01accec994",
+        "rev": "b18a4b905f8d028dc4476412e6d6891728695379",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1787056454,
-        "narHash": "sha256-mwSuxTG/BIwFJUHBwhS8ENlq2LJodCPXyk+AG4Dv6yk=",
+        "lastModified": 1787123629,
+        "narHash": "sha256-corWyHQM+/gj5tYRM/wMXKZRDD8UeBh8fth63cak/lU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ced43465ad23b2fdea055be721e79895cbf96c28",
+        "rev": "5987146ff1aa9a709903f827691c660161725ccd",
         "type": "github"
       },
       "original": {
@@ -245,11 +245,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1787001381,
-        "narHash": "sha256-Ue1Yo8gfHdD4TMtNewhA4tkSYeFqXThju0nCyJc3ALo=",
+        "lastModified": 1787070829,
+        "narHash": "sha256-vXNVDVtvfiQuXthP0NHPFdNvvMTkGpx0UP8oddIWbNk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ec2d622de0773551768cf98f3fc50cbcc003b9c5",
+        "rev": "0ae2bc1419c3f345984c2629e72e7a631820fa4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `flake.lock` update.

The per-host deltas below are recorded in the commit body so they
land in `git log` on merge (ADR 0001).

Each host was built at the current lock and at the updated one, and
the closures compared. All three builds passing is a precondition of
this PR existing at all — but the `nixos ci` gate still has to pass
before it can merge, and merging is what promotes `deploy`.

### homelab01

fail2ban: 1.1.0 → 1.1.1, 168.9 KiB
home-configuration-reference: -9.8 KiB
nixos-manual: 14.7 KiB
nixos-system-homelab01: 26.11.20260817.ec2d622 → 26.11.20260818.0ae2bc1
python3.14-autocommand: 2.2.2 removed, -92.8 KiB
python3.14-distutils: 83.0.0 removed, -14.7 KiB
python3.14-jaraco-classes: 3.4.0 removed, -53.7 KiB
python3.14-jaraco-collections: 5.2.1 removed, -116.0 KiB
python3.14-jaraco-context: 6.1.0 removed, -47.8 KiB
python3.14-jaraco-functools: 4.4.0 removed, -79.3 KiB
python3.14-jaraco-text: 4.0.0 removed, -92.0 KiB
source: -34.2 KiB

### homelab02

fail2ban: 1.1.0 → 1.1.1, 168.9 KiB
home-configuration-reference: -9.8 KiB
nixos-manual: 14.7 KiB
nixos-system-homelab02: 26.11.20260817.ec2d622 → 26.11.20260818.0ae2bc1
python3.14-autocommand: 2.2.2 removed, -92.8 KiB
python3.14-distutils: 83.0.0 removed, -14.7 KiB
python3.14-jaraco-classes: 3.4.0 removed, -53.7 KiB
python3.14-jaraco-collections: 5.2.1 removed, -116.0 KiB
python3.14-jaraco-context: 6.1.0 removed, -47.8 KiB
python3.14-jaraco-functools: 4.4.0 removed, -79.3 KiB
python3.14-jaraco-text: 4.0.0 removed, -92.0 KiB
source: -34.2 KiB

### xps15

claude-code: 2.1.233 → 2.1.234, 3.6 MiB
fail2ban: 1.1.0 → 1.1.1, 168.9 KiB
firefox: 153.0.4 → 154.0
firefox-unwrapped: 153.0.4 → 154.0, 4.9 MiB
home-configuration-reference: -9.8 KiB
hyprland: -983.8 KiB
nixos-manual: 14.7 KiB
nixos-system-xps15: 26.11.20260817.ec2d622 → 26.11.20260818.0ae2bc1
python3.14-autocommand: 2.2.2 removed, -92.8 KiB
python3.14-distutils: 83.0.0 removed, -14.7 KiB
python3.14-jaraco-collections: 5.2.1 removed, -116.0 KiB
python3.14-jaraco-text: 4.0.0 removed, -92.0 KiB
source: -34.2 KiB
udis86: 1.7.2-unstable-2022-10-13 added, 992.1 KiB