### PR TITLE
fix(deploy-metrics): time the generation, not the rebuild that found nothing to do

### DIFF
--- a/checks/monitoring.nix
+++ b/checks/monitoring.nix
@@ -136,5 +136,54 @@
             return bool(query("nixos_deploy_revision_info"))
 
         retry(revision_exported, timeout=timedelta(seconds=180))
+
+    with subtest("the staged timestamp tracks the generation, not the last rebuild"):
+        # Read off the file rather than out of Prometheus: this is about what
+        # the script computes, and putting a scrape in the middle would add a
+        # minute of waiting and a race to every assertion below.
+        def staged_ts():
+            machine.succeed("systemctl start nixos-deploy-metrics.service")
+            return int(machine.succeed(
+                "awk '/^nixos_deploy_staged_timestamp_seconds/ {print $NF}' "
+                "/var/lib/prometheus-node-exporter/nixos_deploy.prom"
+            ).strip())
+
+        def profile_mtime():
+            return int(machine.succeed("stat -c %Y /nix/var/nix/profiles/system").strip())
+
+        # The VM boots straight from the store, so the profile starts with no
+        # generations at all. Seed it with what is running, as a host has.
+        running = machine.succeed("readlink -f /run/current-system").strip()
+        machine.succeed("nix-env -p /nix/var/nix/profiles/system --set {}".format(running))
+        first, first_mtime = staged_ts(), profile_mtime()
+
+        # Whole-second mtimes, so a timestamp that moves has to move visibly.
+        machine.succeed("sleep 2")
+
+        # What a nightly rebuild does on a host nothing has changed: the same
+        # store path set again. nix keeps the generation it already has and
+        # re-points the profile symlink at it anyway.
+        machine.succeed("nix-env -p /nix/var/nix/profiles/system --set {}".format(running))
+        second, second_mtime = staged_ts(), profile_mtime()
+
+        # The control. Without it the assertion below would also pass on a day
+        # when nix stopped re-pointing an unchanged profile - green because the
+        # condition under test had gone away, which is the failure a regression
+        # test is least able to survive.
+        assert second_mtime > first_mtime, (
+            "the profile symlink was not re-pointed ({} == {}), so this no longer "
+            "reproduces what a no-change rebuild does and proves nothing"
+            .format(first_mtime, second_mtime)
+        )
+
+        # The claim: re-staging the generation that is already staged is not a
+        # staging event. Reading the profile symlink's own mtime said it was,
+        # which reset NixosRebootPending's 26h window nightly and fired
+        # NixosVerifyStale against a generation verified two days earlier.
+        assert second == first, (
+            "staged timestamp moved ({} -> {}) for a generation that was already "
+            "staged; it is reporting rebuilds rather than generations"
+            .format(first, second)
+        )
   '';
 }

--- a/modules/services/monitoring/alert-rules.yml
+++ b/modules/services/monitoring/alert-rules.yml
@@ -309,7 +309,11 @@ groups:
       #
       # Deliberately not expressed as `for: 26h`: Prometheus restarts on every
       # deploy, which resets a pending alert's timer, so a long `for` would
-      # never mature. The staged timestamp carries the duration instead.
+      # never mature. The staged timestamp carries the duration instead, which
+      # works only because it is the mtime of the generation link and not of
+      # the profile symlink — that one is re-pointed by every nightly rebuild,
+      # including the ones that find nothing to do, and would reset this
+      # window before it could ever mature. See deploy-metrics.nix.
       - alert: NixosRebootPending
         expr: nixos_deploy_pending_reboot == 1 and time() - nixos_deploy_staged_timestamp_seconds > 93600
         for: 30m
@@ -367,6 +371,11 @@ groups:
       # metrics, so on a night where `deploy` did not move the timestamp goes
       # stale for entirely correct reasons. What is wrong is a generation
       # staged well after the last verification — activated, but never checked.
+      #
+      # Which leans entirely on `staged_timestamp` meaning "when this
+      # generation was staged" rather than "when a rebuild last ran". It meant
+      # the latter until 2026-08-23, and both hosts fired this on the second
+      # quiet night for a generation they had verified two days earlier.
       #
       # `pending_reboot == 0` excludes the staged-but-not-yet-activated case,
       # which is NixosRebootPending's business and would otherwise fire here

--- a/modules/services/monitoring/deploy-metrics.nix
+++ b/modules/services/monitoring/deploy-metrics.nix
@@ -71,8 +71,40 @@ let
         PENDING=1
       fi
 
-      # mtime of the profile symlink itself - when this generation was staged.
-      STAGED_TS="$(stat -c %Y /nix/var/nix/profiles/system 2>/dev/null || echo 0)"
+      # The mtime of the *generation* link, not of the profile symlink.
+      #
+      # nixos-rebuild re-points /nix/var/nix/profiles/system on every run,
+      # including the ones where the build came out byte-identical and nix
+      # created no new generation. So the symlink's own mtime answers "when
+      # did a rebuild last run" - which is NixosDeployStale's question, and it
+      # already has a better source for it. Both consumers of this metric ask
+      # something else: when was the generation that is running now staged.
+      #
+      # Neither of them survives a timestamp that moves nightly on a host that
+      # is not changing. NixosRebootPending measures how long a staged
+      # generation has sat unactivated, and its 26h window is reset every
+      # night by the rebuild that finds nothing to do, so it can never mature
+      # - the "sitting on an unactivated kernel indefinitely" case in the
+      # header is exactly what it would fail to report. NixosVerifyStale
+      # compares this against the last verification, which correctly no-ops
+      # while the generation stands still, so a moving timestamp fires it on
+      # the second quiet night. That is how this was found.
+      #
+      # system-NNN-link is written once, when the generation is staged, and is
+      # never touched again. Read with lstat, deliberately: `stat -L` would
+      # follow it into the store, where mtimes are normalised to the epoch.
+      gen_link="$(readlink /nix/var/nix/profiles/system 2>/dev/null || true)"
+      case "$gen_link" in
+        # No profile at all: a host that has never had a generation staged,
+        # which is the same nothing-to-report as the old `|| echo 0`.
+        "") STAGED_TS=0 ;;
+        # nix writes the target relative whenever it is a sibling, which for
+        # the system profile it always is. The absolute branch is here so that
+        # a profile someone re-pointed by hand reports its real age instead of
+        # silently reporting 0.
+        /*) STAGED_TS="$(stat -c %Y "$gen_link" 2>/dev/null || echo 0)" ;;
+        *) STAGED_TS="$(stat -c %Y "/nix/var/nix/profiles/$gen_link" 2>/dev/null || echo 0)" ;;
+      esac
 
       TMP="$METRICS_FILE.tmp"
 


### PR DESCRIPTION
`NixosVerifyStale` fired on both hosts this morning. Neither host had a problem: both were running the generation they verified on 2026-08-21, verification was running hourly and correctly no-opping, and `nixos_verify_manual_generation` was `0` — nothing had been applied by hand.

## What was actually wrong

`nixos_deploy_staged_timestamp_seconds` was the mtime of `/nix/var/nix/profiles/system`. `nixos-rebuild` re-points that symlink on **every** run, including the nightly ones where the build comes out byte-identical and nix creates no new generation. So the metric answered "when did a rebuild last run" while its HELP text — and both alerts reading it — ask when the running generation was staged.

Evidence from homelab01:

| | |
|---|---|
| newest generation link | `system-298-link`, created 08-21 04:10:59 |
| `verified-system` | that same store path, blessed 08-21 04:13:04 |
| profile symlink mtime | **08-23 04:09:02** — last night's no-change rebuild |

`staged − verify` was therefore 48h against a 6h threshold. Reading the generation link instead gives −125s, which is verification recording its verdict two minutes after the generation was staged, exactly as it should.

## The bug the alert did not catch

`NixosRebootPending` failed the other way, silently. Its 26h window was reset 24 hours in by every nightly rebuild, so a host that missed its reboot window and sat on an unactivated kernel could never reach the threshold — the exact case `deploy-metrics.nix` names in its header as the reason the metric exists.

## The fix

Read the mtime of `system-NNN-link`, which nix writes once when the generation is staged and never touches again. lstat rather than `stat -L`, which would follow into the store where mtimes are normalised to the epoch.

## Testing

New subtest in `checks/monitoring.nix` stages the running generation twice and asserts the metric does not move — plus a control asserting the profile symlink's mtime *did*, so the test cannot pass because the condition disappeared. Reverting the fix fails it on the assertion it is named for:

```
!!! Test "the staged timestamp tracks the generation, not the last rebuild" failed with error:
"staged timestamp moved (1787473062 -> 1787473065) for a generation that was already staged;
 it is reporting rebuilds rather than generations"
```

`nix build .#checks.x86_64-linux.monitoring` and `.#checks.x86_64-linux.alert-rules` both pass with the fix in place. The firing alert resolves on its own once this reaches the hosts.