### PR TITLE
build(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -185,11 +185,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787176219,
-        "narHash": "sha256-djoRr6jBpe35q/0JwAvXpFXg1Ktf+X54NU2RLR7wnHw=",
+        "lastModified": 1787487906,
+        "narHash": "sha256-zIdM+8teujHm5hc5MIPDnV7k2UeOOT/pFyFtWjOCwsY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c53d643b3737e2fcd04e6cb3b3580ef50b2087a0",
+        "rev": "cfba7ad5886b342b8dd63ba74354b3853ea4cfc9",
         "type": "github"
       },
       "original": {
@@ -213,11 +213,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1787101114,
-        "narHash": "sha256-gwrPcFf/rDjHPaVflbDZ040ZDmBTRj/7+s8ZmE2SaIM=",
+        "lastModified": 1787414105,
+        "narHash": "sha256-WncT27+3BOkgTaJZLnCsf3LcYf9RXMuR9ONSN4rzQ7s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b18a4b905f8d028dc4476412e6d6891728695379",
+        "rev": "a9e6d84f9c2f9012f5fe7d964a7851352300e61a",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1787234702,
-        "narHash": "sha256-kvsnFCG4T5dmUj7BMcmpuPZjZNSjOZfhXUdjiBQG2xk=",
+        "lastModified": 1787441254,
+        "narHash": "sha256-/7oA/UPfrk0ubngvJjDleROuiNdA7y4d+5qNcDeQuCA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5cca3a89405eb65d2adb43754c2af8dac7b6f2e1",
+        "rev": "ae9396d21aa0dcfe9419f6bdc3bf415eba30a8b7",
         "type": "github"
       },
       "original": {
@@ -245,11 +245,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1787135253,
-        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "lastModified": 1787360063,
+        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `flake.lock` update.

The per-host deltas below are recorded in the commit body so they
land in `git log` on merge (ADR 0001).

Each host was built at the current lock and at the updated one, and
the closures compared. All three builds passing is a precondition of
this PR existing at all — but the `nixos ci` gate still has to pass
before it can merge, and merging is what promotes `deploy`.

### homelab01

bcachefs-tools: 1.39.1 → 1.39.2, -9.6 KiB
dotnet-aspnetcore-runtime: 10.0.10, 9.0.18 → 10.0.11, 9.0.19
dotnet-aspnetcore-runtime-wrapped: 10.0.10, 9.0.18 → 10.0.11, 9.0.19
dotnet-runtime: 10.0.10, 8.0.29, 9.0.18 → 10.0.11, 8.0.30, 9.0.19
dotnet-runtime-wrapped: 10.0.10, 8.0.29, 9.0.18 → 10.0.11, 8.0.30, 9.0.19
dotnet-sdk: 10.0.110 → 10.0.111, 37.7 KiB
dotnet-sdk-wrapped: 10.0.110 → 10.0.111
dotnet-vmr: 10.0.10 → 10.0.11
gh: 2.97.0 → 2.98.0, 223.1 KiB
golangci-lint: 2.12.2 → 2.13.1, 582.9 KiB
gopls: -41.5 KiB
grafana: 13.1.3 → 13.1.4
initrd-linux: 6.18.44 → 6.18.45, -10.0 KiB
intel-compute-runtime: 26.27.39122.11 → 26.31.39395.13, 65.8 KiB
libgit2: 1.9.4 → 1.9.7
linux: 6.18.44 → 6.18.45
mesa: 26.2.0 → 26.2.1, 43.3 KiB
ncdu: 2.11.0 → 2.11.1
nixos-manual: 37.3 KiB
nixos-system-homelab01: 26.11.20260819.ffb3c9b → 26.11.20260822.2c423e0
powershell: 7.6.4 → 7.6.5, -18.9 MiB
prometheus: 3.13.2 → 3.14.0, 3.3 MiB
source: 54.9 KiB

### homelab02

bcachefs-tools: 1.39.1 → 1.39.2, -9.6 KiB
dotnet-runtime: 8.0.29, 9.0.18 → 8.0.30, 9.0.19
dotnet-runtime-wrapped: 8.0.29, 9.0.18 → 8.0.30, 9.0.19
dotnet-sdk: 10.0.110 → 10.0.111, 37.7 KiB
dotnet-sdk-wrapped: 10.0.110 → 10.0.111
dotnet-vmr: 10.0.10 → 10.0.11
gh: 2.97.0 → 2.98.0, 223.1 KiB
golangci-lint: 2.12.2 → 2.13.1, 582.9 KiB
gopls: -41.5 KiB
initrd-linux: 6.18.44 → 6.18.45, 29.0 KiB
intel-compute-runtime: 26.27.39122.11 → 26.31.39395.13, 65.8 KiB
libgit2: 1.9.4 → 1.9.7
linux: 6.18.44 → 6.18.45
mesa: 26.2.0 → 26.2.1, 43.3 KiB
ncdu: 2.11.0 → 2.11.1
nixos-manual: 37.3 KiB
nixos-system-homelab02: 26.11.20260819.ffb3c9b → 26.11.20260822.2c423e0
powershell: 7.6.4 → 7.6.5, -18.9 MiB
prometheus: 3.13.2 → 3.14.0, 3.3 MiB
source: 54.9 KiB
zfs-kernel: 2.4.3-6.18.44 → 2.4.3-6.18.45

### xps15

antlr-runtime-cpp: 4.13.2 added, 4.1 MiB
bcachefs-tools: 1.39.1 → 1.39.2, -9.6 KiB
bruno: 679.9 KiB
claude-code: 2.1.234 → 2.1.238, 10.0 MiB
dotnet-runtime: 8.0.29, 9.0.18 → 8.0.30, 9.0.19
dotnet-runtime-wrapped: 8.0.29, 9.0.18 → 8.0.30, 9.0.19
dotnet-sdk: 10.0.110, 8.0.423 → 10.0.111, 8.0.424, 13.8 KiB
dotnet-sdk-wrapped: 10.0.110, 8.0.423 → 10.0.111, 8.0.424
dotnet-vmr: 10.0.10 → 10.0.11
electron: 41.10.3 → 43.4.1
electron-unwrapped: 41.10.3 → 43.4.1, 40.4 MiB
gh: 2.97.0 → 2.98.0, 223.1 KiB
golangci-lint: 2.12.2 → 2.13.1, 582.9 KiB
google-chrome: 151.0.7922.169 → 151.0.7922.173, -171.2 KiB
gopls: -41.5 KiB
intel-compute-runtime: 26.27.39122.11 → 26.31.39395.13, 65.8 KiB
kdeconnect-kde: 26.04.3 → 26.08.0, 420.3 KiB
ldc: 1.41.0 → 1.42.0, 200.3 KiB
libgit2: 1.9.4 → 1.9.7
liborcus: 0.20.1 → 0.21.0, -30.4 KiB
libreoffice: 25.8.5.2 → 26.2.5.2, 4.8 MiB
libxml2: 1.4 MiB
mesa: 26.2.0 → 26.2.1, 74.6 KiB
nixos-manual: 37.3 KiB
nixos-system-xps15: 26.11.20260819.ffb3c9b → 26.11.20260822.2c423e0
nmap: 7.99 → 7.991, 98.7 KiB
onedrive: 257.7 KiB
osinfo-db: 20251212 → 20260812, 350.5 KiB
powershell: 7.6.4 → 7.6.5, -18.9 MiB
python3.14-afdko: 5.0.1 added, 10.6 MiB
python3.14-booleanoperations: 0.10.0 added, 209.1 KiB
python3.14-defcon: 0.12.2 added, 2.5 MiB
python3.14-fontmath: 0.9.4 added, 555.2 KiB
python3.14-fontparts: 1.0.0 added, 4.8 MiB
python3.14-fontpens: 0.4.0 added, 242.2 KiB
python3.14-mutatormath: 3.0.1 added, 362.5 KiB
python3.14-pyclipper: 1.4.0 added, 376.9 KiB
python3.14-ufonormalizer: 0.6.2 added, 194.9 KiB
python3.14-ufoprocessor: 1.14.1 added, 465.8 KiB
python3.14-unicodedata2: 17.0.1 added, 1.4 MiB
python3.14-zopfli: 0.4.0 added, 68.4 KiB
source: 54.9 KiB
tlp: 1.9.1 → 1.10.2, -29.2 KiB
tuigreet: 0.11.0 → 0.11.1
webkitgtk: 2.52.5+abi=4.1 → 2.52.6+abi=4.1, 37.9 KiB
x86_energy_perf_policy: 6.18.44 → 6.18.45
zellij: 0.44.3 → 0.45.0
zellij-unwrapped: 0.44.3 → 0.45.0, 1.7 MiB
zopfli: 1.0.3 added, 353.5 KiB