### PR TITLE
feat(digital-garden): stage plain CommonMark, and own the URLs

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -60,7 +60,24 @@
 
         A gate that only proves the Nix evaluates is a gate against typos.
 
-        This links to [[Rates And Figures]], which is not published.
+        This links to [[Rates And Figures]], which is not published, and to
+        [[On Boundaries|the boundary essay]], which is.
+
+        - [[On Boundaries]]
+        NOTE
+
+        # Named as Obsidian names things - spaces and capitals - because a
+        # wikilink resolves by filename, and because the staging tree should
+        # then show it renamed to the slug it is served under.
+        cat > "$out/essays/On Boundaries.md" <<'NOTE'
+        ---
+        publish: true
+        thesis: MARKER-THESIS-BOUNDARIES
+        ---
+
+        # On Boundaries
+
+        MARKER-BOUNDARIES-BODY
         NOTE
 
         cat > $out/private/rates-and-figures.md <<'NOTE'
@@ -134,12 +151,16 @@
         machine.succeed("systemctl start digital-garden-build.service")
         machine.succeed(f"test -f {SITE}/index.css")
 
-    with subtest("only the published note is in the staging tree"):
+    with subtest("only published notes are in the staging tree"):
         # The boundary is publish-filter.py, and it works by never copying an
-        # unpublished note - so the check that matches the design is that the
-        # staging tree Quartz is pointed at contains exactly one file.
-        staged = machine.succeed("ls /var/lib/digital-garden/content").split()
-        assert staged == ["on-gates.md"], staged
+        # unpublished note - so the check that matches the design is on what
+        # the staging tree Quartz is pointed at contains, not on what renders.
+        #
+        # The names are the slugs, not the vault's filenames: the filter owns
+        # the URL, and a file staged under any other name would mean the
+        # generator was deciding the address after all.
+        staged = sorted(machine.succeed("ls /var/lib/digital-garden/content").split())
+        assert staged == ["on-boundaries.md", "on-gates.md"], staged
 
     with subtest("no unpublished content reaches the served site"):
         # Deliberately the whole tree rather than the rendered page. A leak
@@ -151,6 +172,28 @@
         # And the note that fails to parse is skipped rather than published,
         # which is the fail-closed half of the filter's contract.
         machine.fail(f"test -e {SITE}/no-frontmatter-at-all.html")
+
+    with subtest("the staging tree is plain CommonMark"):
+        # The filter converts wikilinks so that the generator never has to
+        # understand Obsidian, which is what makes the generator replaceable.
+        # Asserted on the staging tree AND on the served site: a surviving
+        # wikilink renders as the literal text "[[Some Note]]" on the page,
+        # which is a build that succeeds and a site that is wrong.
+        machine.fail("grep -rq -e '[[' /var/lib/digital-garden/content")
+        machine.fail(f"grep -rq -e '[[' {SITE}")
+
+    with subtest("a link to a published note is a real link"):
+        page = machine.succeed(f"cat {SITE}/on-gates.html")
+        assert 'href="./on-boundaries"' in page, "published link did not survive as a link"
+        # The alias is what the reader sees, not the filename.
+        assert "the boundary essay" in page
+
+        # A list item that is nothing but a link gets the target's thesis
+        # appended, so a hub page reads as claims. This is matched against the
+        # rewritten Markdown link rather than the wikilink it started as, and
+        # if that pattern stopped matching, every index would quietly lose its
+        # annotations while the build stayed green.
+        assert "MARKER-THESIS-BOUNDARIES" in page, "thesis was not appended to the bare link"
 
     with subtest("a link to an unpublished note is not a link"):
         page = machine.succeed(f"cat {SITE}/on-gates.html")
@@ -195,6 +238,7 @@
         assert "MARKER-PUBLISHED-BODY" in served("/static/contentIndex.json")
         assert "on-gates" in served("/index.xml")
         assert "on-gates" in served("/sitemap.xml")
+        assert "MARKER-BOUNDARIES-BODY" in served("/on-boundaries")
 
     with subtest("caddy serves the generated 404 rather than its own"):
         # try_files plus handle_errors in the module's vhost. Quartz emits a

--- a/modules/services/digital-garden/publish-filter.py
+++ b/modules/services/digital-garden/publish-filter.py
@@ -20,6 +20,13 @@ Fail-closed rules, in order of importance:
   * The staging tree is built fresh and swapped in, so a removed `publish: true`
     always disappears from the next build.
 
+Nothing Obsidian-specific reaches the generator. Wikilinks become ordinary
+Markdown links and embeds become ordinary images, so the staging tree is plain
+CommonMark whose links already carry the finished URL. That is what keeps the
+generator replaceable: it is handed files already named what they will be
+served as, pointing at each other by those names, so swapping one generator for
+another cannot silently move a page. See `slugify`.
+
 Published notes are FLATTENED to the root of the staging tree, so the site's
 URLs are `/some-essay` rather than `/whatever-folder/some-essay`. The vault's
 folder names are private working vocabulary, and reorganising the vault must
@@ -29,7 +36,9 @@ alias-redirects plugin turns into a redirect page.
 
 Flattening makes filenames the global namespace, which the link rewriter below
 already assumed (it resolves wikilinks by stem). Two published notes sharing a
-filename is therefore a hard error rather than a silent drop.
+URL is therefore a hard error rather than a silent drop — and the check is on
+the URL, not the filename, because "Some Note" and "some-note" are two files
+and one page.
 
 Dates are derived, not written by hand. `<ledger>` records the first time each
 note appeared in the published set and the last time its text changed, and
@@ -71,14 +80,37 @@ PUBLISH_TRUE = re.compile(r"^publish:\s*true\s*(?:#.*)?$", re.M | re.I)
 # matched: Obsidian does not produce it and guessing costs more than it saves.
 LEADING_H1 = re.compile(r"\A\s*#[ \t]+(.+?)[ \t]*\n+")
 # A list item that is nothing but a link to another published note — the shape
-# an index or hub entry takes before its thesis is filled in.
-BARE_LINK_ITEM = re.compile(r"^([ \t]*[-*+][ \t]+)\[\[([^\]|#]+)(?:\|([^\]]*))?\]\][ \t]*$", re.M)
+# an index or hub entry takes before its thesis is filled in. Matched after the
+# wikilinks have already become Markdown links, so there is one link syntax to
+# recognise here rather than two.
+BARE_LINK_ITEM = re.compile(r"^([ \t]*[-*+][ \t]+)\[([^\]]*)\]\(/([^)#]*)[^)]*\)[ \t]*$", re.M)
+# Unreserved URL characters (RFC 3986). Anything else is dropped rather than
+# percent-escaped: an escape in a path is not something anyone wants to read,
+# type, or see in a browser's address bar.
+SLUG_DROP = re.compile(r"[^a-z0-9._~-]")
 # Not a limit, just the point past which a note is worth another look.
 LONG_NOTE_WORDS = 500
+# Where embedded files are staged, and the first segment of their URL.
+ATTACHMENTS = "attachments"
 ATTACHMENT_SUFFIXES = {
     ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".avif",
     ".pdf", ".mp4", ".webm", ".mp3", ".ogg", ".wav",
 }
+
+
+def slugify(name):
+    """The URL path a note or attachment is published at.
+
+    Deliberately reproduces, character for character, what Quartz was already
+    doing to filenames — lowercase, spaces to hyphens, nothing else touched —
+    because those URLs are live and must not move. Runs of hyphens are NOT
+    collapsed, so "A - B" stays "a---b" exactly as it is served today.
+
+    Owning this here rather than leaving it to the generator is the point: it
+    makes the URL a property of the staging tree instead of a behaviour of
+    whatever renders it.
+    """
+    return SLUG_DROP.sub("", name.lower().replace(" ", "-"))
 
 
 def is_published(text):
@@ -116,20 +148,24 @@ def coalesce_aliases(front):
     return out
 
 
-def update_ledger(ledger, slug, text, today):
+def update_ledger(ledger, key, text, today):
     """First sighting sets `published`; a changed note bumps `modified`.
 
     The hash covers the note as it was READ, not as it is written below, so a
     note's date does not move because some *other* note was published and its
     links here turned back into links.
+
+    Keyed by the note's filename, deliberately not by its URL. The two are
+    nearly the same string, and conflating them would mean that any future
+    change to how a URL is derived silently re-dates every note on the site.
     """
     digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
-    entry = ledger.get(slug)
+    entry = ledger.get(key)
     if not isinstance(entry, dict) or "published" not in entry:
         entry = {"published": today, "modified": today, "hash": digest}
     elif entry.get("hash") != digest:
         entry = {**entry, "modified": today, "hash": digest}
-    ledger[slug] = entry
+    ledger[key] = entry
     return entry
 
 
@@ -149,6 +185,7 @@ def main(argv):
     # ---- pass 1: decide what is published -----------------------------------
     published = {}     # stem(lower) -> (relative path, text)
     attachments = {}   # stem(lower) -> path
+    taken = {}         # slug -> stem(lower), for collision detection
     collisions = []
     skipped = 0
     for path in sorted(vault.rglob("*")):
@@ -167,15 +204,21 @@ def main(argv):
             continue
         if is_published(text):
             rel = path.relative_to(vault)
-            if path.stem.lower() in published:
-                collisions.append((published[path.stem.lower()][0], rel))
-            published[path.stem.lower()] = (rel, text)
+            key = path.stem.lower()
+            # Collide on the URL rather than on the filename: "Some Note" and
+            # "some-note" are different files and one page, and only the slug
+            # sees that.
+            slug = slugify(path.stem)
+            if slug in taken:
+                collisions.append((published[taken[slug]][0], rel))
+            taken[slug] = key
+            published[key] = (rel, text)
 
     # Flattening puts every published note in one namespace, so a duplicate
     # filename would silently publish whichever sorted last — under the URL of
     # the other one. Refuse to build rather than guess which was meant.
     if collisions:
-        print("published notes share a filename; rename one of each pair:", file=sys.stderr)
+        print("published notes share a URL; rename one of each pair:", file=sys.stderr)
         for first, second in collisions:
             print(f"  {first}\n  {second}", file=sys.stderr)
         return 1
@@ -183,36 +226,41 @@ def main(argv):
     # ---- pass 2: read frontmatter, so a thesis is known before anything is
     #              written and an unusable note is dropped before it is linked -
     fronts = {}   # stem(lower) -> (frontmatter mapping, body)
-    theses = {}   # stem(lower) -> one-line claim
-    for slug, (rel, text) in sorted(published.items()):
+    theses = {}   # slug -> one-line claim, since a rewritten link carries a slug
+    for key, (rel, text) in sorted(published.items()):
         split = split_frontmatter(text)
         if split is None:
             print(f"unparseable frontmatter, not publishing: {rel}", file=sys.stderr)
             skipped += 1
             continue
-        fronts[slug] = split
+        fronts[key] = split
         thesis = split[0].get("thesis")
         if thesis:
-            theses[slug] = " ".join(str(thesis).split())
+            theses[slugify(rel.stem)] = " ".join(str(thesis).split())
     # Drop the unusable ones BEFORE the link rewriter runs, or a note that is
     # about to be discarded still reads as published and every wikilink to it
     # survives as a link to a page that will not exist.
-    published = {slug: v for slug, v in published.items() if slug in fronts}
+    published = {key: v for key, v in published.items() if key in fronts}
 
     # ---- pass 3: rewrite links, gather the attachments actually used --------
     used_attachments = {}
 
     def rewrite(m):
-        embed, target, _heading, alias = m.groups()
+        """A wikilink becomes a Markdown link, an image, or plain text."""
+        embed, target, heading, alias = m.groups()
         key = target.strip().lower()
         if embed:
             hit = attachments.get(key)
             if hit is None:
                 return alias or target          # embed of something not shipping
             used_attachments[hit] = True
-            return f"![[{hit.name}]]"
+            return f"![{alias or ''}](/{ATTACHMENTS}/{slugify(hit.name)})"
         if key in published:
-            return m.group(0)
+            # The heading fragment is slugified the same way a filename is,
+            # which is right for the headings Obsidian produces and would need
+            # revisiting for one containing punctuation a generator strips.
+            anchor = f"#{slugify(heading[1:])}" if heading else ""
+            return f"[{alias or target}](/{slugify(published[key][0].stem)}{anchor})"
         return alias or target                  # link to an unpublished note
 
     # ---- pass 4: derive dates, then write a flat tree and swap it in --------
@@ -232,7 +280,8 @@ def main(argv):
     written = 0
     no_thesis = []
     overlong = []
-    for slug, (rel, text) in sorted(published.items()):
+    for key, (rel, text) in sorted(published.items()):
+        slug = slugify(rel.stem)
         # Rewritten as one string, frontmatter included: a wikilink to a private
         # note is just as much of a leak in an `aliases:` list as it is in prose.
         # That rewriting can itself invalidate the YAML, which is why this is
@@ -253,8 +302,13 @@ def main(argv):
         if heading:
             front.setdefault("title", heading.group(1).strip())
             body = body[heading.end() :]
+        # Always explicit, because the file is about to be renamed to its slug
+        # and a generator falling back to the filename for a title would then
+        # show "building-capability" where it used to show "Building
+        # Capability".
+        front.setdefault("title", rel.stem)
 
-        entry = update_ledger(ledger, slug, text, today)
+        entry = update_ledger(ledger, key, text, today)
         # The landing page is a table of contents, not an essay: it has no
         # publication date worth showing and owes nobody a thesis.
         if rel.name.lower() != "index.md":
@@ -281,12 +335,12 @@ def main(argv):
         # the claim itself lives in exactly one place: the essay making it. An
         # item the author has already written prose after is left alone.
         def annotate(m):
-            indent, target, alias = m.groups()
-            thesis = theses.get(target.strip().lower())
+            thesis = theses.get(m.group(3))
             if not thesis:
                 return m.group(0)
-            shown = f"[[{target}|{alias}]]" if alias else f"[[{target}]]"
-            return f"{indent}{shown} — {thesis}"
+            # Appended to the matched line rather than rebuilt from its parts,
+            # so anything the pattern did not capture survives untouched.
+            return f"{m.group(0).rstrip()} — {thesis}"
 
         body = BARE_LINK_ITEM.sub(annotate, body)
 
@@ -309,11 +363,11 @@ def main(argv):
             skipped += 1
             continue
 
-        (tmp / rel.name).write_text(f"---\n{head}---\n{body}", encoding="utf-8")
+        (tmp / f"{slug}.md").write_text(f"---\n{head}---\n{body}", encoding="utf-8")
         written += 1
 
     for src in used_attachments:
-        dest = tmp / "attachments" / src.name
+        dest = tmp / ATTACHMENTS / slugify(src.name)
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dest)
 


### PR DESCRIPTION
Follows #49.

The filter emitted Obsidian. Wikilinks between published notes were left as `[[Some Note]]` and embeds as `![[image.png]]`, for Quartz's `obsidian-flavored-markdown` plugin to resolve, and the generator decided for itself what URL a file called `Some Note.md` was served at. Any generator that could ever replace Quartz would have to be taught the same dialect and make the same guess.

Both halves move into the filter:

- **Wikilinks become Markdown links, embeds become images.** The staging tree is plain CommonMark — nothing Obsidian-shaped reaches the generator.
- **Notes are staged under their slug.** `Building Capability.md` is written as `building-capability.md`, and links point at `/building-capability`. The generator is handed files already named what they will be served as, pointing at each other by those names, so it has nothing left to decide.

That second half is the one that matters for replacing Quartz: the URL becomes a property of the staging tree rather than a behaviour of whatever renders it.

## URLs do not move

`slugify()` reproduces what Quartz was doing to filenames character for character — lowercase, spaces to hyphens, nothing else — because those URLs are live. Verified against the whole vault rather than argued:

- every canonical page still exists, and no new page appeared
- every internal `href` and `src` is unchanged
- surviving pages are **byte-identical** apart from build timestamps, except that `<img>` lost `width="auto" height="auto"` — attributes that were never valid HTML and were ignored
- screenshots of all four image-bearing pages plus the index, rendered headless at 1280px, are **byte-identical** before and after

The fifteen capitalised redirect pages (`Building-Capability.html` and friends) are gone with the capitals. They were never linked from the site, never in `index.xml`, never in `sitemap.xml` — a redirect Quartz invented from the filename, not an address the site ever published. Shout if you would rather keep them; it is one alias per note.

## Two consequences worth naming

**The ledger stays keyed by filename, not URL.** The two are nearly the same string, and conflating them would have re-dated all sixteen notes the moment this landed. The parameter is renamed so the next person does not have to notice.

**`title` is now always set.** It used to be set only when a note opened with an H1; a generator falling back to the filename would otherwise have started showing `building-capability` where it showed `Building Capability`.

Collision detection also moves from the filename to the URL, since `Some Note` and `some-note` are two files and one page.

## Check

The fixture grows a second published note — named `On Boundaries.md`, the way Obsidian names things — so a published-to-published link is exercised rather than assumed, and so the rename to a slug is visible in the staging tree. New assertions:

- no `[[` survives into the staging tree **or** the served site. A surviving wikilink renders as the literal text `[[Some Note]]`: a build that succeeds and a site that is wrong, which is the class of failure this file exists for.
- a link to a published note is a real `href`, with the alias as its text
- the thesis is still appended to a bare-link list item. That pattern now matches the rewritten Markdown link rather than the wikilink it started as, and if it silently stopped matching, every index would lose its annotations while the build stayed green.

`checks.x86_64-linux.digital-garden` passes.