### PR TITLE
feat(digital-garden): add a Hugo renderer to preview beside Quartz

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ sudo nixos-rebuild switch --flake .#xps15
 
 # See the digital garden as it will be published, without publishing it
 nix run .#garden-preview
+
+# The same notes rendered by the candidate replacement for Quartz
+nix run .#garden-preview -- --generator hugo --port 8088
 ```
 
 `garden-preview` renders the published subset of the local Obsidian vault with the
@@ -52,6 +55,11 @@ same renderer and serves it with the same Caddy config the server uses, then
 re-renders whenever a note or `hosts/homelab01/digital-garden.scss` changes.
 Before it existed, seeing a CSS change meant a full PR -> gate -> merge -> promote
 -> upgrade round trip, which is minutes; the render itself is about five seconds.
+
+`--generator hugo` renders the same filtered notes with Hugo and Pagefind instead
+of Quartz, so the two can be run side by side on different ports and compared.
+Quartz is still what the server builds with — the Hugo path is a candidate under
+evaluation, not a second deployment target.
 
 `coryg@`, not `root@` — `cg.ssh-hardening` sets `PermitRootLogin = "no"` and `AllowUsers = [ "coryg" ]`, so root SSH is refused on both servers. `--elevate=sudo` is what then runs the activation as root, and `--ask-elevate-password` is needed because `wheelNeedsPassword` is on. That command is long enough to discourage the iteration it exists for, which is [item 6](docs/plans/deployment-hardening.md) of the hardening plan.
 

--- a/flake.nix
+++ b/flake.nix
@@ -249,12 +249,30 @@
             inherit (nixpkgs) lib;
             quartz = self.packages.${system}.quartz;
           };
+          hugo = import ./modules/services/digital-garden/lib/hugo.nix {
+            inherit pkgs;
+            inherit (nixpkgs) lib;
+          };
+          hugoRenderer = hugo.mkRenderer {
+            inherit (garden) baseUrl siteTitle footerLinks;
+            styleSheet = ./modules/services/digital-garden/lib/hugo/assets/main.css;
+          };
           preview = import ./modules/services/digital-garden/lib/preview.nix {
             inherit pkgs site;
             inherit (nixpkgs) lib;
-            renderer = garden.renderer;
             filter = ./modules/services/digital-garden/publish-filter.py;
-            defaultStyleSheet = garden.styleSheet;
+            generators = {
+              quartz = {
+                renderer = garden.renderer;
+                styleSheet = garden.styleSheet;
+                workingTreeStyleSheet = "hosts/homelab01/digital-garden.scss";
+              };
+              hugo = {
+                renderer = hugoRenderer;
+                styleSheet = ./modules/services/digital-garden/lib/hugo/assets/main.css;
+                workingTreeStyleSheet = "modules/services/digital-garden/lib/hugo/assets/main.css";
+              };
+            };
           };
         in
         {

--- a/modules/services/digital-garden/lib/hugo.nix
+++ b/modules/services/digital-garden/lib/hugo.nix
@@ -1,0 +1,127 @@
+# Hugo renderer for the digital garden — an alternative to lib/site.nix's
+# Quartz one, offered on the same contract so the two can be compared:
+#
+#   digital-garden-render <content-dir> <output-dir> [stylesheet]
+#
+# Why this exists. Packaging Quartz costs 562 lines of Nix and a pinned tree of
+# ~42 npm plugins, because Quartz v5 resolves its own plugins by cloning them
+# at build time and cannot be updated without risking a build that succeeds and
+# a site that is silently featureless. Hugo is one Go binary in nixpkgs, Pagefind
+# is one Rust binary, and neither fetches anything at build time or at runtime.
+#
+# What made this cheap is that publish-filter.py already owns the hard parts.
+# The staging tree is plain CommonMark whose links carry finished URLs, so this
+# renderer does not have to understand Obsidian, resolve a wikilink, or decide
+# what a page is called. It supplies a layout and a stylesheet and gets out of
+# the way. Everything Hugo-specific is in this file and lib/hugo/.
+{
+  pkgs,
+  lib,
+}:
+let
+  theme = ./hugo;
+in
+{
+  mkRenderer =
+    {
+      baseUrl,
+      siteTitle,
+      styleSheet,
+      footerLinks ? { },
+      locale ? "en-au",
+    }:
+    let
+      config = pkgs.writeText "hugo.toml" ''
+        baseURL = 'https://${baseUrl}/'
+        locale = '${locale}'
+        title = ${builtins.toJSON siteTitle}
+        enableRobotsTXT = true
+
+        # publish-filter.py derives dates from its ledger as bare local dates,
+        # and Hugo reads a bare date as midnight UTC. Anywhere behind UTC that
+        # puts a note published "today" up to a day in the future, and Hugo
+        # omits future content by default — which silently cost 15 of 16 pages
+        # the first time this was built. There is no scheduled publishing here:
+        # a date is metadata about a note, not an embargo on it.
+        buildFuture = true
+
+        # Nothing here is organised by tag, and an empty taxonomy listing is
+        # just another URL that has to be explained.
+        disableKinds = ['taxonomy', 'term']
+
+        [frontmatter]
+        date = ['published', 'date']
+        lastmod = ['modified', 'lastmod']
+
+        [markup.goldmark.renderer]
+        # The vault contains no raw HTML, only autolinks — which are CommonMark
+        # and unaffected by this. Left off so a note cannot put markup, or a
+        # script, onto a public page.
+        unsafe = false
+
+        [params]
+        footerLinks = [
+        ${lib.concatStringsSep "\n" (
+          lib.mapAttrsToList (
+            name: url: "  { name = ${builtins.toJSON name}, url = ${builtins.toJSON url} },"
+          ) footerLinks
+        )}
+        ]
+      '';
+    in
+    pkgs.writeShellApplication {
+      name = "digital-garden-render-hugo";
+      runtimeInputs = [
+        pkgs.hugo
+        pkgs.pagefind
+        pkgs.coreutils
+      ];
+      text = ''
+        if [ $# -lt 2 ] || [ $# -gt 3 ]; then
+          echo "usage: digital-garden-render-hugo <content-dir> <output-dir> [stylesheet]" >&2
+          exit 2
+        fi
+        content=$(realpath "$1")
+        outdir=$2
+        css=$(realpath "''${3:-${styleSheet}}")
+
+        if [ ! -d "$content" ]; then
+          echo "no such content directory: $content" >&2
+          exit 1
+        fi
+        rm -rf "$outdir"
+        mkdir -p "$outdir"
+        outdir=$(realpath "$outdir")
+
+        # Hugo wants a site directory. Assembled per run rather than kept,
+        # because every input is either in the store or handed in as an
+        # argument, so there is nothing here worth preserving between builds.
+        work=$(mktemp -d --tmpdir digital-garden-hugo.XXXXXX)
+        trap 'rm -rf "$work"' EXIT
+
+        cp -r ${theme}/layouts "$work/layouts"
+        mkdir -p "$work/assets"
+        cp "$css" "$work/assets/main.css"
+        cp ${config} "$work/hugo.toml"
+        chmod -R u+w "$work"
+
+        mkdir -p "$work/content"
+        cp -r "$content/." "$work/content/"
+        chmod -R u+w "$work/content"
+        # Hugo's home page comes from `_index.md`; a plain `index.md` at the
+        # content root would make the whole site one leaf bundle instead. The
+        # filter has no business knowing that, so the rename happens here.
+        if [ -f "$work/content/index.md" ]; then
+          mv "$work/content/index.md" "$work/content/_index.md"
+        fi
+
+        hugo --quiet --source "$work" --destination "$outdir"
+
+        # Search index, built from the rendered HTML rather than from the
+        # markdown, so what is searchable is exactly what is readable. Runs
+        # here rather than as a separate step because a site whose index does
+        # not match its pages is worse than one with no search at all.
+        pagefind --site "$outdir" --quiet
+      '';
+    };
+}

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -1,0 +1,323 @@
+/* Digital garden stylesheet.
+ *
+ * The palette is Quartz's own default, value for value, so that moving between
+ * the two generators is not also a redesign. The names are Quartz's too, which
+ * read oddly in dark mode — `--light` is the BACKGROUND in both themes, not a
+ * light colour — but keeping them means the two stylesheets can be compared
+ * without a translation table.
+ *
+ * Fonts are the system stack. Quartz's config asks for Schibsted Grotesk and
+ * Source Sans Pro with `fontOrigin: local`, which means it never ships them and
+ * every visitor already falls through to system-ui. Naming the fallback
+ * directly is the same result without the pretence.
+ */
+
+:root {
+  --light: #faf8f8;
+  --lightgray: #e5e5e5;
+  --gray: #b8b8b8;
+  --darkgray: #4e4e4e;
+  --dark: #2b2b2b;
+  --secondary: #284b63;
+  --tertiary: #84a59d;
+  --highlight: rgba(143, 159, 169, 0.15);
+
+  --body-font:
+    system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji";
+  --measure: 40rem;
+  color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+  --light: #161618;
+  --lightgray: #393639;
+  --gray: #646464;
+  --darkgray: #d4d4d4;
+  --dark: #ebebec;
+  --secondary: #7b97aa;
+  --tertiary: #84a59d;
+  color-scheme: dark;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--light);
+  color: var(--darkgray);
+  font-family: var(--body-font);
+  font-size: 1rem;
+  line-height: 1.6;
+  /* Off by default in most browsers; the difference is visible in body text at
+   * this measure, in ligatures and in the spacing of numerals. */
+  text-rendering: optimizeLegibility;
+}
+
+/* One column, capped. "No sidebars" is not the same as "prose should span a 27
+ * inch monitor" — line length is a legibility function. */
+.page {
+  width: 100%;
+  /* The cap is on the TEXT, so the gutter has to be added to it rather than
+   * taken out of it - box-sizing: border-box would otherwise make the measure
+   * 3rem narrower than it says. */
+  max-width: calc(var(--measure) + 3rem);
+  margin: 0 auto;
+  padding: 4rem 1.5rem 3rem;
+}
+
+/* ── masthead ───────────────────────────────────────────────────────────── */
+
+.masthead {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-bottom: 0.75rem;
+  margin-bottom: 2rem;
+  border-bottom: 1px solid var(--lightgray);
+}
+
+.masthead-title {
+  flex-grow: 1;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--secondary);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.masthead-title:hover {
+  text-decoration: underline;
+}
+
+/* The controls are buttons, not boxes. Quartz drew search as a bordered field
+ * containing the word "Search", which reads as an input you can type into — it
+ * is not, it opens a dialog. */
+.icon-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: none;
+  color: var(--darkgray);
+  cursor: pointer;
+}
+
+.icon-button:hover {
+  background: var(--highlight);
+}
+
+.icon-button:focus-visible {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
+}
+
+:root[data-theme="dark"] .icon-sun,
+:root[data-theme="light"] .icon-moon {
+  display: none;
+}
+
+/* ── prose ──────────────────────────────────────────────────────────────── */
+
+h1,
+h2,
+h3,
+h4 {
+  color: var(--dark);
+  font-weight: 600;
+  line-height: 1.25;
+  margin: 2rem 0 0.75rem;
+}
+
+h1 {
+  font-size: 1.75rem;
+  margin-top: 0;
+}
+h2 {
+  font-size: 1.35rem;
+}
+h3 {
+  font-size: 1.15rem;
+}
+
+p,
+ul,
+ol,
+blockquote {
+  margin: 0 0 1rem;
+}
+
+.dateline {
+  margin: -0.25rem 0 1.5rem;
+  color: var(--gray);
+  font-size: 0.875rem;
+}
+
+a {
+  color: var(--secondary);
+  text-decoration: none;
+  /* Underlined on hover rather than always: at this link density a permanently
+   * underlined page is harder to read than an undecorated one. */
+  border-radius: 3px;
+  padding: 0 0.1em;
+  background: var(--highlight);
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Chrome, not prose: a highlight behind these reads as a stray box. */
+footer a,
+.masthead-title,
+a.footnote-backref,
+[role="doc-backlink"] {
+  background: none;
+  padding: 0;
+}
+
+/* An external link says so, rather than being discovered by following it.
+ * Marked in CSS on the protocol, so nothing has to annotate the markdown. */
+a[href^="http://"]::after,
+a[href^="https://"]::after {
+  content: "↗";
+  font-size: 0.8em;
+  margin-left: 0.15em;
+  vertical-align: baseline;
+}
+
+footer a::after {
+  content: none;
+}
+
+blockquote {
+  border-left: 3px solid var(--lightgray);
+  padding-left: 1rem;
+  margin-left: 0;
+  color: var(--gray);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 5px;
+  margin: 1rem 0;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--lightgray);
+  margin: 2rem 0 0;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9em;
+  background: var(--highlight);
+  border-radius: 3px;
+  padding: 0.1em 0.3em;
+}
+
+pre {
+  overflow-x: auto;
+  padding: 1rem;
+  border-radius: 5px;
+  background: var(--highlight);
+}
+
+pre code {
+  background: none;
+  padding: 0;
+}
+
+/* Wide content must scroll inside its own box rather than making the page
+ * scroll sideways. */
+.table-container {
+  overflow-x: auto;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+th,
+td {
+  border-bottom: 1px solid var(--lightgray);
+  padding: 0.4rem 0.6rem;
+  text-align: left;
+}
+
+/* ── footer ─────────────────────────────────────────────────────────────── */
+
+footer {
+  margin-top: 3rem;
+  color: var(--gray);
+  font-size: 0.875rem;
+}
+
+footer p {
+  margin: 1rem 0 0.25rem;
+}
+
+footer ul {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+/* ── search ─────────────────────────────────────────────────────────────── */
+
+#search-dialog {
+  width: min(38rem, calc(100vw - 2rem));
+  max-height: 70vh;
+  margin-top: 8vh;
+  padding: 1rem;
+  border: 1px solid var(--lightgray);
+  border-radius: 8px;
+  background: var(--light);
+  color: var(--darkgray);
+  overflow-y: auto;
+}
+
+#search-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+/* Pagefind ships its own stylesheet; these map its variables onto the palette
+ * above so the dialog does not arrive in someone else's colours. */
+#search-ui {
+  --pagefind-ui-primary: var(--dark);
+  --pagefind-ui-text: var(--darkgray);
+  --pagefind-ui-background: var(--light);
+  --pagefind-ui-border: var(--lightgray);
+  --pagefind-ui-tag: var(--highlight);
+  --pagefind-ui-border-width: 1px;
+  --pagefind-ui-border-radius: 5px;
+  --pagefind-ui-font: var(--body-font);
+}
+
+@media (max-width: 700px) {
+  .page {
+    padding-top: 1.5rem;
+  }
+}
+
+/* Pagefind's input takes the browser's default focus ring, which on a dark
+ * background is a stark white box. Matched to the one the masthead buttons
+ * use, so focus looks deliberate rather than like a rendering fault. */
+#search-ui input:focus-visible,
+#search-ui button:focus-visible {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
+}

--- a/modules/services/digital-garden/lib/hugo/layouts/404.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/404.html
@@ -1,0 +1,6 @@
+{{ define "main" }}
+  <article>
+    <h1>Not found</h1>
+    <p>There is no page at this address. Try the <a href="{{ "/" | relURL }}">index</a>.</p>
+  </article>
+{{ end }}

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/dateline.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/dateline.html
@@ -1,0 +1,13 @@
+{{/*
+  The publication date, and the last edit only when it is a different day —
+  "published and modified on the same date" is noise on an essay.
+*/}}
+{{ if not .Date.IsZero }}
+  <p class="dateline">
+    <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "2 Jan 2006" }}</time>
+    {{ if and (not .Lastmod.IsZero) (ne (.Lastmod.Format "2006-01-02") (.Date.Format "2006-01-02")) }}
+      &middot; updated
+      <time datetime="{{ .Lastmod.Format "2006-01-02" }}">{{ .Lastmod.Format "2 Jan 2006" }}</time>
+    {{ end }}
+  </p>
+{{ end }}

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/icon-search.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/icon-search.html
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+  <circle cx="10.5" cy="10.5" r="6.5" /><path d="M15.5 15.5 21 21" />
+</svg>

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/icon-theme.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/icon-theme.html
@@ -1,0 +1,8 @@
+{{/* Both glyphs ship; CSS shows whichever the current theme does not use. */}}
+<svg class="icon-sun" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+  <circle cx="12" cy="12" r="4.5" />
+  <path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4" />
+</svg>
+<svg class="icon-moon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" aria-hidden="true">
+  <path d="M20 14.5A8.5 8.5 0 0 1 9.5 4a8.5 8.5 0 1 0 10.5 10.5Z" />
+</svg>

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="{{ site.Language.Locale | default "en" }}">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      {{- if .IsHome }}{{ site.Title }}{{ else }}{{ .Title }} &middot; {{ site.Title }}{{ end -}}
+    </title>
+    {{ with .Description }}<meta name="description" content="{{ . }}" />{{ end }}
+    <link rel="canonical" href="{{ .Permalink }}" />
+    {{ with resources.Get "main.css" | fingerprint }}
+      <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" />
+    {{ end }}
+    {{ with site.Home.OutputFormats.Get "rss" }}
+      <link rel="alternate" type="application/rss+xml" title="{{ site.Title }}" href="{{ .Permalink }}" />
+    {{ end }}
+    <link rel="stylesheet" href="{{ "pagefind/pagefind-ui.css" | relURL }}" />
+    {{/*
+      Applied before first paint, so a reader who chose dark does not get a
+      white flash on every navigation. Inline for the same reason: an external
+      file would be fetched after the document starts rendering.
+    */}}
+    <script>
+      (function () {
+        var saved = null;
+        try {
+          saved = localStorage.getItem("theme");
+        } catch (e) {}
+        var dark = saved
+          ? saved === "dark"
+          : window.matchMedia("(prefers-color-scheme: dark)").matches;
+        document.documentElement.dataset.theme = dark ? "dark" : "light";
+      })();
+    </script>
+  </head>
+  <body>
+    <div class="page">
+      <header class="masthead">
+        <a class="masthead-title" href="{{ "/" | relURL }}">{{ site.Title }}</a>
+        <button
+          class="icon-button"
+          id="search-open"
+          aria-label="Search"
+          aria-haspopup="dialog"
+        >
+          {{ partial "icon-search.html" . }}
+        </button>
+        <button class="icon-button" id="theme-toggle" aria-label="Toggle dark mode">
+          {{ partial "icon-theme.html" . }}
+        </button>
+      </header>
+
+      <main>{{ block "main" . }}{{ end }}</main>
+
+      <footer>
+        <hr />
+        <p>&copy; {{ now.Year }} {{ site.Title }}</p>
+        <ul>
+          {{ range site.Params.footerLinks }}
+            <li><a href="{{ .url }}">{{ .name }}</a></li>
+          {{ end }}
+          {{ with site.Home.OutputFormats.Get "rss" }}<li><a href="{{ .Permalink }}">RSS</a></li>{{ end }}
+        </ul>
+      </footer>
+    </div>
+
+    {{/*
+      Hidden until asked for. Pagefind's own bundle is ~40KB of JS that nothing
+      on a reading page needs, so it is fetched on the first search rather than
+      on every page load.
+    */}}
+    <dialog
+      id="search-dialog"
+      aria-label="Search"
+      data-pagefind-ui="{{ "pagefind/pagefind-ui.js" | relURL }}"
+    >
+      <div id="search-ui"></div>
+    </dialog>
+
+    <script>
+      (function () {
+        var root = document.documentElement;
+        document.getElementById("theme-toggle").addEventListener("click", function () {
+          var next = root.dataset.theme === "dark" ? "light" : "dark";
+          root.dataset.theme = next;
+          try {
+            localStorage.setItem("theme", next);
+          } catch (e) {}
+        });
+
+        var dialog = document.getElementById("search-dialog");
+        var loaded = false;
+        function open() {
+          if (!loaded) {
+            loaded = true;
+            var s = document.createElement("script");
+            s.src = dialog.dataset.pagefindUi;
+            s.onload = function () {
+              new PagefindUI({
+                element: "#search-ui",
+                showImages: false,
+                showSubResults: true,
+                resetStyles: false,
+              });
+              var input = dialog.querySelector("input");
+              if (input) input.focus();
+            };
+            document.body.appendChild(s);
+          }
+          dialog.showModal();
+          var input = dialog.querySelector("input");
+          if (input) input.focus();
+        }
+        document.getElementById("search-open").addEventListener("click", open);
+        document.addEventListener("keydown", function (e) {
+          if ((e.ctrlKey || e.metaKey) && e.key === "k") {
+            e.preventDefault();
+            open();
+          }
+        });
+        // A click on the backdrop lands on the dialog element itself.
+        dialog.addEventListener("click", function (e) {
+          if (e.target === dialog) dialog.close();
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/modules/services/digital-garden/lib/hugo/layouts/home.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/home.html
@@ -1,0 +1,11 @@
+{{ define "main" }}
+  {{/*
+    The landing page is a hand-written table of contents, not a generated list:
+    publish-filter.py has already annotated each bare link with the target's
+    thesis, so what is authored is what should be shown.
+  */}}
+  <article data-pagefind-body>
+    <h1>{{ .Title }}</h1>
+    {{ .Content }}
+  </article>
+{{ end }}

--- a/modules/services/digital-garden/lib/hugo/layouts/page.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/page.html
@@ -1,0 +1,7 @@
+{{ define "main" }}
+  <article data-pagefind-body>
+    <h1>{{ .Title }}</h1>
+    {{ partial "dateline.html" . }}
+    {{ .Content }}
+  </article>
+{{ end }}

--- a/modules/services/digital-garden/lib/preview.nix
+++ b/modules/services/digital-garden/lib/preview.nix
@@ -18,16 +18,18 @@
   pkgs,
   lib,
   site,
-  renderer,
   filter,
-  defaultStyleSheet,
+  # name -> { renderer; styleSheet; workingTreeStyleSheet; } for every generator
+  # this can preview. More than one exists so that a candidate replacement for
+  # Quartz can be looked at beside it rather than argued about.
+  generators,
+  defaultGenerator ? "quartz",
   defaultVault ? "$HOME/git/personal-notes",
 }:
 pkgs.writeShellApplication {
   name = "garden-preview";
   runtimeInputs = [
     (pkgs.python3.withPackages (ps: [ ps.pyyaml ]))
-    renderer
     pkgs.caddy
     pkgs.inotify-tools
     pkgs.coreutils
@@ -37,10 +39,12 @@ pkgs.writeShellApplication {
     port=8087
     once=false
     css=
+    generator=${defaultGenerator}
 
     while [ $# -gt 0 ]; do
       case $1 in
         --vault) vault=$2; shift 2 ;;
+        --generator) generator=$2; shift 2 ;;
         --css) css=$2; shift 2 ;;
         --port) port=$2; shift 2 ;;
         --once) once=true; shift ;;
@@ -50,6 +54,10 @@ pkgs.writeShellApplication {
 
       --vault PATH   Obsidian vault to publish from
                      (default: $GARDEN_VAULT, else ${defaultVault})
+      --generator G  which site generator to render with:
+                     ${lib.concatStringsSep ", " (lib.attrNames generators)}
+                     (default: ${defaultGenerator}). Run two at once on
+                     different ports to compare them.
       --css PATH     stylesheet to render with. Defaults to the working-tree
                      copy if you are sitting in the dotfiles repo, so that
                      editing it re-renders without a Nix evaluation.
@@ -65,15 +73,30 @@ pkgs.writeShellApplication {
       esac
     done
 
-    # Prefer the stylesheet in the working tree when there is one, because
-    # that is the file you are about to edit. The store copy baked into the
-    # renderer is only reachable through a fresh evaluation of the host, which
-    # is the loop this command exists to avoid.
+    # Each generator has its own renderer and its own stylesheet; they are
+    # written against different markup and are not interchangeable.
+    case $generator in
+    ${lib.concatStringsSep "
+    " (
+      lib.mapAttrsToList (name: g: ''
+        ${name})
+            render_with=${lib.getExe g.renderer}
+            store_css=${g.styleSheet}
+            tree_css=${g.workingTreeStyleSheet}
+            ;;'') generators
+    )}
+      *) echo "unknown generator: $generator (have: ${lib.concatStringsSep ", " (lib.attrNames generators)})" >&2; exit 2 ;;
+    esac
+
+    # Prefer the stylesheet in the working tree when there is one, because that
+    # is the file you are about to edit. The store copy baked into the renderer
+    # is only reachable through a fresh evaluation of the host, which is the
+    # loop this command exists to avoid.
     if [ -z "$css" ]; then
-      if [ -f hosts/homelab01/digital-garden.scss ]; then
-        css=hosts/homelab01/digital-garden.scss
+      if [ -f "$tree_css" ]; then
+        css=$tree_css
       else
-        css=${defaultStyleSheet}
+        css=$store_css
         echo "note: using the stylesheet baked into the renderer." >&2
         echo "      run from the dotfiles repo root, or pass --css, to edit it live." >&2
       fi
@@ -107,7 +130,7 @@ pkgs.writeShellApplication {
       started=$(date +%s%N)
       # Same filter, same arguments, same boundary as the service.
       python3 ${filter} "$vault" "$state/content" "$cache/dates.json" || return 1
-      digital-garden-render "$state/content" "$state/public.new" "$css" \
+      "$render_with" "$state/content" "$state/public.new" "$css" \
         > "$state/render.log" 2>&1 || {
           echo "render failed:" >&2
           tail -30 "$state/render.log" >&2
@@ -132,22 +155,31 @@ pkgs.writeShellApplication {
       exit 0
     fi
 
-    cat > "$state/Caddyfile" <<CADDY
+    # A QUOTED heredoc, so nothing in the shared Caddy config is evaluated on
+    # its way through the shell. It is prose meant for a Caddyfile, and it
+    # contains backticks; an unquoted heredoc would run them.
+    #
+    # The two values that do vary are passed as environment variables, which
+    # Caddyfile reads natively as {$NAME}. That keeps the config text identical
+    # to the one the server uses instead of introducing placeholders here.
+    cat > "$state/Caddyfile" <<'CADDY'
     {
       auto_https off
       admin off
     }
-    :$port {
-    ${site.caddyConfig "$state/public"}
+    :{$GARDEN_PORT} {
+    ${site.caddyConfig "{$GARDEN_ROOT}"}
     }
     CADDY
 
-    caddy run --config "$state/Caddyfile" --adapter caddyfile \
+    GARDEN_PORT=$port GARDEN_ROOT=$state/public \
+      caddy run --config "$state/Caddyfile" --adapter caddyfile \
       > "$state/caddy.log" 2>&1 &
     caddy_pid=$!
 
     echo
     echo "  garden-preview  http://localhost:$port"
+    echo "  generator       $generator"
     echo "  vault           $vault"
     echo "  stylesheet      $css"
     echo "  watching for changes — ctrl-c to stop"

--- a/modules/services/digital-garden/lib/site.nix
+++ b/modules/services/digital-garden/lib/site.nix
@@ -156,10 +156,17 @@ in
   caddyConfig = root: ''
     root * ${root}
     encode gzip zstd
-    # Try the literal path first (assets, and the folder pages that emit as
-    # directories), then the directory index, then the extension the page was
-    # actually written as.
-    try_files {path} {path}/ {path}.html
+    # The index INSIDE a directory is tried before the directory itself,
+    # because file_server answers a request for a directory with a 308 to its
+    # trailing-slash form. Naming index.html directly serves the page on the
+    # first request instead, which is what turns every internal link from two
+    # round trips into one.
+    #
+    # After that: the literal path, for assets; then the extension the page was
+    # actually written as, for a generator that emits `<slug>.html` rather than
+    # `<slug>/index.html`. Both shapes are served without a redirect, so the
+    # URLs do not depend on which generator produced the tree.
+    try_files {path}/index.html {path} {path}.html
     file_server
     # Quartz also generates a styled 404 page; without this Caddy answers with
     # its own empty one.


### PR DESCRIPTION
Follows #49 and #50. **A spike, not a switch** — the service still builds with Quartz. This makes the alternative something you can look at rather than argue about:

```bash
nix run .#garden-preview                                  # Quartz, as deployed
nix run .#garden-preview -- --generator hugo --port 8088  # the candidate
```

Run both at once and compare them side by side.

## Why it was a day and not a project

`publish-filter.py` already owns the hard parts. The staging tree is plain CommonMark whose links carry finished URLs, so the renderer never has to understand Obsidian, resolve a wikilink, or decide what a page is called. Everything Hugo-specific is `lib/hugo.nix` plus `lib/hugo/` — four templates, three partials, one stylesheet.

## What each option costs

| | Quartz | Hugo |
|---|---|---|
| packaging | 562 lines of Nix, 42 hash-pinned npm plugins | one Go binary from nixpkgs |
| search | built in | Pagefind, one Rust binary |
| fetches at build time | plugins, unless vendored | none |
| fetches in the browser | mermaid/d3/pixi, unless vendored | none |
| upgradable | no — `update.sh` deliberately never bumps Quartz | `nix flake update` |

That last row is the one that matters. The failure mode of a bad Quartz bump is a build that **succeeds** and a site that is silently featureless, which is why it is pinned to 5.0.0 indefinitely on a public-facing site.

## Speed

Real vault, three runs each, whole pipeline:

```
quartz  4883ms  4246ms  4469ms
hugo     949ms   920ms   971ms
```

The filter is ~700ms of each, so the render step is **~3830ms against ~240ms** — and the Hugo number *includes* building the search index. The slowest part of publishing is now the Python, which is a better problem to have.

## Search

Pagefind indexes the rendered HTML rather than the markdown, so what is searchable is exactly what is readable. 42ms for the whole site. Its ~40KB of JS is fetched on first search, not on every page load. Verified by running a real query in a browser — `career` returns the four right pages.

## Three things this turned up

**Hugo silently dropped 15 of 16 pages.** It reads a bare date as midnight UTC and omits future-dated content by default; the filter writes *local* dates, and from UTC+8 that makes everything published today "future". Quartz never cared. `buildFuture = true`, because a date here is metadata about a note, not an embargo on it.

**Every internal link cost two round trips.** Hugo emits `<slug>/index.html` where Quartz emits `<slug>.html`, and Caddy answers a directory request with a 308 to its trailing-slash form. `try_files` now names `index.html` before the directory, so both shapes serve directly. **Quartz's routing is unaffected** — every status code is identical before and after, and the VM check passes.

**The preview would have executed a comment.** It wrote its Caddyfile through an unquoted heredoc, harmless until the shared config gained a comment containing backticks. Now a quoted heredoc, with root and port passed as environment variables that Caddyfile reads natively as `{$NAME}`. Caught by shellcheck in `writeShellApplication`.

## Verified

- rendered pages compared against Quartz at 1280px: same masthead, palette, measure, dark theme, footnotes, images, aliases, RSS, styled 404
- routing identical across both generators for every URL tested
- search returns correct results from a real browser query
- `checks.x86_64-linux.digital-garden` passes

## Not done, and deliberately

The service is untouched — there is no `generator` option on the module and nothing deploys Hugo. Wiring that up is the decision this PR exists to inform, not part of it. Also unchanged: the publish boundary, and every published URL.

## What is still open if you adopt it

- the Quartz stylesheet (`hosts/homelab01/digital-garden.scss`, 115 lines) becomes dead, replaced by `lib/hugo/assets/main.css`
- Hugo's canonical URLs carry a trailing slash (`/getting-good/`) while the filter's links do not (`/getting-good`); both serve directly, and `<link rel=canonical>` resolves it, but they are not the same string
- Pagefind ships a newer Component UI with a built-in accessible modal; this uses the older Default UI, which is supported but hand-wired here