### PR TITLE
fix(checks): wait for a TLS handshake, not just for port 443

### DIFF
--- a/checks/reverse-proxy.nix
+++ b/checks/reverse-proxy.nix
@@ -142,6 +142,21 @@
         machine.wait_for_unit("caddy.service")
         machine.wait_for_open_port(443)
 
+        # An open 443 does not mean a certificate exists. `tls internal` has
+        # Caddy issue one per vhost from its own CA, and that happens after the
+        # listener comes up - so a request sent in between fails the handshake
+        # with curl exit 35, several subtests before anything about routing is
+        # actually wrong. Waiting on a real handshake is the readiness signal;
+        # the port is only the start of one.
+        #
+        # Both vhosts, because Caddy issues their certificates independently
+        # and either one can be the straggler.
+        #
+        # Without -f, so this waits on TLS alone and does not quietly double as
+        # an assertion about the response.
+        for host in ["internal.gyarmathy.co", "public.gyarmathy.co"]:
+            machine.wait_until_succeeds(curl(host, "-o /dev/null"), timeout=60)
+
     with subtest("a LAN-only service routes to its backend"):
         body = get("internal.gyarmathy.co", "/some/path")
         assert body["path"] == "/some/path", body


### PR DESCRIPTION
Unrelated to the digital garden work, but it is what failed CI on #52.

The reverse-proxy test went from `wait_for_open_port(443)` straight to an HTTPS request. An open listener is not a served site here: `tls internal` has Caddy issue a certificate per vhost from its own CA, and that happens *after* the listener comes up. A request sent in the gap fails the handshake with curl exit 35.

It failed exactly that way on a loaded runner today, in **"a LAN-only service routes to its backend"** — a subtest about routing, reporting a certificate that did not exist yet. Caddy's own log said so three lines earlier:

```
caddy: failed to install root certificate: failed to execute tee: exit status 1
tls.obtain: Obtain: saving assets: failed to create temp file:
  .../certificates/local/internal.gyarmathy.co/2807750916: no such file or directory
  retrying_in: 60
```

Waiting on a real handshake is the readiness signal; the port is only the start of one.

- **Both vhosts**, because their certificates are issued independently and either one can be the straggler.
- **Without `-f`**, so the probe waits on TLS alone rather than quietly doubling as an assertion about the response — the same trap the `headers_of` comment in this file already warns about.

**Not a new failure.** The race has been there since the test landed; every green run has been the fast path. Worth fixing rather than re-running, because a gate that fails for a reason unrelated to what it is testing teaches you to ignore it — and this one names the wrong subtest while doing it.

`checks.x86_64-linux.reverse-proxy` passes.