### PR TITLE
feat(digital-garden): clear what the Hugo migration left behind

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -1,18 +1,13 @@
 # The garden builds a real vault, publishes only what is marked, and serves it.
 #
-# The build gate is weak evidence here, and used to be actively misleading.
-# Under Quartz the failure mode was a build that *succeeded*: a plugin it could
-# not instantiate left an undefined in the component list, and a plugin index
-# regenerated without dist/ yielded a featureless site - green CI, clean
-# activation, service exits 0, and the site is empty or unstyled.
+# The build gate is weak evidence here. A template that does not resolve is a
+# build error and there are no plugins to resolve, so most of what could go
+# wrong does go loudly - but one thing does not: a *missing* template is not an
+# error. Hugo skips the pages it would have rendered and reports success. The
+# first Hugo build of this site emitted the home page and nothing else, and
+# said "Total in 40 ms" while doing it.
 #
-# Hugo removes most of that class. A template that does not resolve is a build
-# error, and there are no plugins to resolve at all. What remains is that a
-# *missing* template is not an error: Hugo skips the pages it would have
-# rendered and reports success. The first Hugo build of this site emitted the
-# home page and nothing else, and said "Total in 40 ms" while doing it.
-#
-# Two properties are therefore still worth more than "it built".
+# Two properties are therefore worth more than "it built".
 #
 # The publish boundary is the important one, and the only property in this
 # repository whose failure has consequences outside it. A test that only
@@ -128,11 +123,10 @@
         "C+ /var/lib/digital-garden/vault 0755 digital-garden digital-garden - ${vault}"
       ];
 
-      # The 4096/8192 this used to ask for was sized for a Quartz build: an
-      # esbuild pass over a ~19MB Node tree. Hugo and Pagefind are two static
-      # binaries rendering sixteen notes, so the headroom went with the reason
-      # for it. Still above what the run needs, because a test that fails by
-      # running out of memory does not say so clearly.
+      # Hugo and Pagefind are two static binaries rendering a handful of
+      # notes, so this needs very little. Still well above what the run uses,
+      # because a test that fails by running out of memory does not say so
+      # clearly.
       virtualisation.memorySize = 2048;
       virtualisation.diskSize = 4096;
     };
@@ -164,7 +158,7 @@
     with subtest("only published notes are in the staging tree"):
         # The boundary is publish-filter.py, and it works by never copying an
         # unpublished note - so the check that matches the design is on what
-        # the staging tree Quartz is pointed at contains, not on what renders.
+        # the staging tree contains, not on what renders.
         #
         # The names are the slugs, not the vault's filenames: the filter owns
         # the URL, and a file staged under any other name would mean the
@@ -174,7 +168,7 @@
 
     with subtest("no unpublished content reaches the served site"):
         # Deliberately the whole tree rather than the rendered page. A leak
-        # would most plausibly surface in static/contentIndex.json (the search
+        # would most plausibly surface in the Pagefind fragments (the search
         # index) or index.xml (the feed), neither of which anyone looks at.
         for marker in ["MARKER-PRIVATE-BODY", "MARKER-UNPARSEABLE-BODY"]:
             machine.fail(f"grep -r --quiet {marker} {SITE}")
@@ -194,11 +188,13 @@
 
     with subtest("a link to a published note is a real link"):
         page = served("/on-gates")
-        # Matched loosely on the form of the href, because whether it comes out
-        # absolute or relative is the generator's business; that it is a link
-        # to the right page is not.
-        assert re.search(r'href="\.?/on-boundaries/?"', page), \
-            "published link did not survive as a link"
+        # The trailing slash is asserted, not tolerated. Both forms are served
+        # directly, so this is not about reachability - it is that the filter
+        # writes links in the same string Hugo publishes in rel=canonical, the
+        # sitemap and the feed, and a page addressed two ways is a page that
+        # gets counted, cached and linked two ways.
+        assert re.search(r'href="\.?/on-boundaries/"', page), \
+            "published link did not survive as a link, with its trailing slash"
         # The alias is what the reader sees, not the filename.
         assert "the boundary essay" in page
 
@@ -225,11 +221,21 @@
         # reorganising the vault cannot break a URL, and injects an alias for
         # the old path. Both halves matter: the flat URL is the address, and
         # the vault-shaped one still resolves.
-        # The redirect target is matched loosely: Quartz wrote it relative and
-        # Hugo writes it absolute against baseURL. Which one is not the point;
-        # that the old address still leads to the new one is.
+        # The redirect target is matched loosely - absolute or relative is the
+        # generator's business. That the old address still leads to the new one
+        # is not.
         redirect = served("/essays/on-gates")
-        assert re.search(r"url=\S*/on-gates", redirect), redirect[:300]
+        assert re.search(r"url=\S*/on-gates/", redirect), redirect[:300]
+
+        # The alias has to be the URL that was SERVED, not the vault path it
+        # was derived from. "essays/On Boundaries.md" was reachable at
+        # /essays/on-boundaries; an alias built from the raw path instead
+        # publishes /essays/On%20Boundaries and leaves the real old address a
+        # 404 - which is the whole promise of flattening, broken silently.
+        # This fixture is named with a space and a capital for exactly this.
+        redirect = served("/essays/on-boundaries")
+        assert re.search(r"url=\S*/on-boundaries/", redirect), redirect[:300]
+        machine.fail("curl -sf 'http://localhost:8086/essays/On%20Boundaries'")
 
     with subtest("every published note became a page"):
         # The silent-failure mode this test now exists for. A missing template
@@ -262,8 +268,26 @@
         href = re.search(r'href="([^"]*main\.[^"]*\.css)"', served("/"))
         assert href, "no fingerprinted stylesheet linked from the home page"
         css = served(href.group(1))
-        for selector in [".masthead", ".page", "--pagefind-ui-border"]:
+        for selector in [".masthead", ".page", "--pf-border"]:
             assert selector in css, f"{selector} missing from the stylesheet"
+
+    with subtest("search costs a reading page nothing until it is asked for"):
+        # The bundle is ~46KB gzipped that a reader who never searches never
+        # needs, so the page carries its URLs and fetches it on first use. The
+        # failure this guards is a template edit that quietly puts either file
+        # back into <head>, which nothing else would notice.
+        page = served("/on-gates")
+        assert not re.search(r'<script[^>]*\bsrc="[^"]*pagefind', page), \
+            "the pagefind bundle is loaded on every page again"
+        assert not re.search(r'<link[^>]*\bhref="[^"]*pagefind', page), \
+            "the pagefind stylesheet is loaded on every page again"
+        # And the other half: the URLs the page defers to have to be real, or
+        # the search button is a button that does nothing.
+        assert 'data-js="/pagefind/pagefind-component-ui.js"' in page, page[:400]
+        for asset in ["pagefind-component-ui.js", "pagefind-component-ui.css"]:
+            machine.succeed(
+                f"curl -sf -o /dev/null http://localhost:8086/pagefind/{asset}"
+            )
 
     with subtest("search is built and covers the published set"):
         # Pagefind indexes the rendered HTML, so an index that exists but is

--- a/modules/services/digital-garden/digital-garden.nix
+++ b/modules/services/digital-garden/digital-garden.nix
@@ -37,17 +37,18 @@
 # default change can expose it.
 #
 # The builder then RE-CHECKS the marker on every staged note before rendering,
-# and refuses to build if one is missing. That second layer used to be Quartz's
-# explicit-publish plugin, and it earned its place: when the filter was once
-# broken deliberately, the plugin is what caught the leak. Hugo has no
-# equivalent, so the check lives in the builder now — which is a better home
-# anyway, because it no longer depends on which program renders the tree.
+# and refuses to build if one is missing. That second layer has already earned
+# its keep once: when the filter was deliberately broken to see what would
+# happen, it is what caught the leak. It lives in the builder rather than in
+# the generator so that it does not depend on which program renders the tree —
+# and rather than in publish-filter.py, because a check inside the thing being
+# checked is worth less.
 #
 # Known residual leak: a published note that writes [[Some Private Note]] in
 # prose still renders the words "Some Private Note" (as plain text, not a
 # link). Titles you type into published notes are published.
 #
-# The filter also FLATTENS published notes to the root, so a URL is /some-essay
+# The filter also FLATTENS published notes to the root, so a URL is /some-essay/
 # and stays that way when the vault is reorganised, and derives `published:`
 # dates from a ledger at ${stateDir}/dates.json rather than asking for them to
 # be written by hand. Both are explained in publish-filter.py.
@@ -149,9 +150,10 @@ let
       }
 
       # ---- 2. skip early if nothing could possibly have changed --------------
-      # Two gates, cheapest first. The render is no longer the expensive step -
-      # Hugo takes ~240ms where Quartz took ~3.8s - but the filter still walks
-      # the whole vault, and most vault changes touch unpublished notes.
+      # Two gates, cheapest first. The render itself is not the expensive step
+      # — Hugo and Pagefind finish the whole site in a few hundred milliseconds
+      # — but the filter walks the entire vault, and most vault changes touch
+      # unpublished notes.
       #
       # Gate one is a stat-only walk: no file is opened, so this stays cheap
       # enough to run every minute. Dotfiles are excluded to match the filter,
@@ -178,11 +180,9 @@ let
         "${stateDir}/dates.json"
 
       # Defence in depth, and the reason it is here rather than in the
-      # generator. Quartz had an explicit-publish plugin that re-checked the
-      # marker, and when publish-filter.py was once broken deliberately, that
-      # second layer is what held. Hugo has no equivalent and should not need
-      # one — so the check moves here, where it guards the staging tree itself
-      # and does not depend on which program renders it.
+      # generator: this guards the staging tree itself, so it holds no matter
+      # what renders it. The one time publish-filter.py was deliberately
+      # broken, a second layer like this is what stopped the leak.
       #
       # Cheap enough to be unconditional: the staging tree is the published
       # set, not the vault. If anything in it lost its marker on the way
@@ -421,8 +421,8 @@ in
         );
         ExecStart = lib.getExe buildScript;
 
-        # Hardening: this pulls a private repo and runs a Node build, so it gets
-        # network and nothing else.
+        # Hardening: this clones a private repo, so it gets network and
+        # nothing else.
         NoNewPrivileges = true;
         PrivateTmp = true;
         PrivateDevices = true;
@@ -435,7 +435,11 @@ in
         RestrictNamespaces = true;
         RestrictRealtime = true;
         LockPersonality = true;
-        MemoryDenyWriteExecute = false; # V8 JIT needs W^X off
+        # Nothing here JITs: the filter is CPython, and Hugo and Pagefind are
+        # a Go and a Rust binary. This was off when the site was rendered by a
+        # Node toolchain that needed writable-executable pages; that toolchain
+        # is gone and the exemption went with it.
+        MemoryDenyWriteExecute = true;
         SystemCallFilter = [ "@system-service" ];
         SystemCallArchitectures = "native";
         RestrictAddressFamilies = [

--- a/modules/services/digital-garden/lib/hugo.nix
+++ b/modules/services/digital-garden/lib/hugo.nix
@@ -2,20 +2,19 @@
 #
 #   digital-garden-render-hugo <content-dir> <output-dir> [stylesheet]
 #
-# Why Hugo. The site was built with Quartz until 2026-08-24, which cost 562
-# lines of Nix and a tree of ~42 hash-pinned npm plugins, because Quartz v5
-# resolves its own plugins by cloning them at build time. The decisive problem
-# was not the size of that but that it could not be updated: a wrong bump
-# produces a build that SUCCEEDS and a site that is silently featureless, so
-# the version was pinned and stayed pinned. Hugo is one Go binary in nixpkgs
-# and Pagefind is one Rust binary; both ride flake.lock, and neither fetches
-# anything at build time or in the reader's browser.
+# The property to preserve here is that the whole toolchain is two static
+# binaries from nixpkgs — Hugo in Go, Pagefind in Rust — both riding
+# flake.lock, neither fetching anything at build time or in the reader's
+# browser. A generator that resolves plugins over the network at build time
+# fails in the one way a CI gate cannot see: the build succeeds and the site is
+# quietly missing features. Anything added below should be weighed against
+# that, not against convenience. See docs/adr/ for how this was arrived at.
 #
-# What made this cheap is that publish-filter.py already owns the hard parts.
-# The staging tree is plain CommonMark whose links carry finished URLs, so this
-# renderer does not have to understand Obsidian, resolve a wikilink, or decide
-# what a page is called. It supplies a layout and a stylesheet and gets out of
-# the way. Everything Hugo-specific is in this file and lib/hugo/.
+# What keeps this file short is that publish-filter.py already owns the hard
+# parts. The staging tree is plain CommonMark whose links carry finished URLs,
+# so this renderer does not have to understand Obsidian, resolve a wikilink, or
+# decide what a page is called. It supplies a layout and a stylesheet and gets
+# out of the way. Everything Hugo-specific is in this file and lib/hugo/.
 {
   pkgs,
   lib,

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -1,25 +1,25 @@
 /* Digital garden stylesheet — the whole design, with no theme underneath.
  *
- * The palette is inherited value-for-value from the site's previous generator,
- * so that changing how the site is built was not also a redesign. That is also
- * why `--light` names the BACKGROUND in both themes rather than a light colour:
- * the names came with the values, and renaming them later is a change worth
- * making on its own rather than smuggling into a migration.
+ * The tokens are named for the ROLE a colour plays, not for the colour it is,
+ * because the two themes disagree about the colour and agree about the role:
+ * `--bg` is the page behind the text in both, and `--text` is the text on it.
+ * The values are unchanged from what the site has always shipped; only the
+ * names are, and only so that the dark block below stops reading as a
+ * contradiction.
  *
- * Fonts are the system stack, which is what the site already rendered in — the
- * previous generator asked for Schibsted Grotesk and Source Sans Pro but never
- * shipped them, so every visitor fell through to system-ui anyway.
+ * Fonts are the system stack. Asking for a webfont and not shipping it is the
+ * same as this with extra steps, and shipping one is a request this site has
+ * no reason to make of a reader.
  */
 
 :root {
-  --light: #faf8f8;
-  --lightgray: #e5e5e5;
-  --gray: #b8b8b8;
-  --darkgray: #4e4e4e;
-  --dark: #2b2b2b;
-  --secondary: #284b63;
-  --tertiary: #84a59d;
-  --highlight: rgba(143, 159, 169, 0.15);
+  --bg: #faf8f8;
+  --surface: rgba(143, 159, 169, 0.15);
+  --border: #e5e5e5;
+  --muted: #b8b8b8;
+  --text: #4e4e4e;
+  --strong: #2b2b2b;
+  --accent: #284b63;
 
   --body-font:
     system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
@@ -29,13 +29,14 @@
 }
 
 :root[data-theme="dark"] {
-  --light: #161618;
-  --lightgray: #393639;
-  --gray: #646464;
-  --darkgray: #d4d4d4;
-  --dark: #ebebec;
-  --secondary: #7b97aa;
-  --tertiary: #84a59d;
+  --bg: #161618;
+  --border: #393639;
+  --muted: #646464;
+  --text: #d4d4d4;
+  --strong: #ebebec;
+  --accent: #7b97aa;
+  /* --surface is deliberately not redefined: it is a translucent tint, so the
+   * one value reads correctly over either background. */
   color-scheme: dark;
 }
 
@@ -47,8 +48,8 @@
 
 body {
   margin: 0;
-  background: var(--light);
-  color: var(--darkgray);
+  background: var(--bg);
+  color: var(--text);
   font-family: var(--body-font);
   font-size: 1rem;
   line-height: 1.6;
@@ -77,14 +78,14 @@ body {
   gap: 0.5rem;
   padding-bottom: 0.75rem;
   margin-bottom: 2rem;
-  border-bottom: 1px solid var(--lightgray);
+  border-bottom: 1px solid var(--border);
 }
 
 .masthead-title {
   flex-grow: 1;
   font-size: 1.1rem;
   font-weight: 600;
-  color: var(--secondary);
+  color: var(--accent);
   text-decoration: none;
   white-space: nowrap;
 }
@@ -93,9 +94,9 @@ body {
   text-decoration: underline;
 }
 
-/* The controls are buttons, not boxes. Quartz drew search as a bordered field
- * containing the word "Search", which reads as an input you can type into — it
- * is not, it opens a dialog. */
+/* The controls are buttons, not boxes. A bordered field containing the word
+ * "Search" reads as an input you can type into; this one is not, it opens a
+ * dialog, and an icon says so without claiming otherwise. */
 .icon-button {
   display: flex;
   align-items: center;
@@ -106,16 +107,16 @@ body {
   border: none;
   border-radius: 4px;
   background: none;
-  color: var(--darkgray);
+  color: var(--text);
   cursor: pointer;
 }
 
 .icon-button:hover {
-  background: var(--highlight);
+  background: var(--surface);
 }
 
 .icon-button:focus-visible {
-  outline: 2px solid var(--secondary);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -130,7 +131,7 @@ h1,
 h2,
 h3,
 h4 {
-  color: var(--dark);
+  color: var(--strong);
   font-weight: 600;
   line-height: 1.25;
   margin: 2rem 0 0.75rem;
@@ -156,18 +157,18 @@ blockquote {
 
 .dateline {
   margin: -0.25rem 0 1.5rem;
-  color: var(--gray);
+  color: var(--muted);
   font-size: 0.875rem;
 }
 
 a {
-  color: var(--secondary);
+  color: var(--accent);
   text-decoration: none;
   /* Underlined on hover rather than always: at this link density a permanently
    * underlined page is harder to read than an undecorated one. */
   border-radius: 3px;
   padding: 0 0.1em;
-  background: var(--highlight);
+  background: var(--surface);
 }
 
 a:hover {
@@ -198,10 +199,10 @@ footer a::after {
 }
 
 blockquote {
-  border-left: 3px solid var(--lightgray);
+  border-left: 3px solid var(--border);
   padding-left: 1rem;
   margin-left: 0;
-  color: var(--gray);
+  color: var(--muted);
 }
 
 img {
@@ -213,14 +214,14 @@ img {
 
 hr {
   border: none;
-  border-top: 1px solid var(--lightgray);
+  border-top: 1px solid var(--border);
   margin: 2rem 0 0;
 }
 
 code {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.9em;
-  background: var(--highlight);
+  background: var(--surface);
   border-radius: 3px;
   padding: 0.1em 0.3em;
 }
@@ -229,7 +230,7 @@ pre {
   overflow-x: auto;
   padding: 1rem;
   border-radius: 5px;
-  background: var(--highlight);
+  background: var(--surface);
 }
 
 pre code {
@@ -250,7 +251,7 @@ table {
 
 th,
 td {
-  border-bottom: 1px solid var(--lightgray);
+  border-bottom: 1px solid var(--border);
   padding: 0.4rem 0.6rem;
   text-align: left;
 }
@@ -259,7 +260,7 @@ td {
 
 footer {
   margin-top: 3rem;
-  color: var(--gray);
+  color: var(--muted);
   font-size: 0.875rem;
 }
 
@@ -277,46 +278,46 @@ footer ul {
 
 /* ── search ─────────────────────────────────────────────────────────────── */
 
-#search-dialog {
-  width: min(38rem, calc(100vw - 2rem));
-  max-height: 70vh;
-  margin-top: 8vh;
-  padding: 1rem;
-  border: 1px solid var(--lightgray);
-  border-radius: 8px;
-  background: var(--light);
-  color: var(--darkgray);
-  overflow-y: auto;
-}
-
-#search-dialog::backdrop {
-  background: rgba(0, 0, 0, 0.4);
-}
-
-/* Pagefind ships its own stylesheet; these map its variables onto the palette
- * above so the dialog does not arrive in someone else's colours. */
-#search-ui {
-  --pagefind-ui-primary: var(--dark);
-  --pagefind-ui-text: var(--darkgray);
-  --pagefind-ui-background: var(--light);
-  --pagefind-ui-border: var(--lightgray);
-  --pagefind-ui-tag: var(--highlight);
-  --pagefind-ui-border-width: 1px;
-  --pagefind-ui-border-radius: 5px;
-  --pagefind-ui-font: var(--body-font);
+/* The search dialog is Pagefind's Component UI, which arrives with a complete
+ * stylesheet of its own. Nothing here restyles it; this maps its tokens onto
+ * the palette above so it shows up in the site's colours rather than in its
+ * own, and follows the theme toggle for free because the values on the right
+ * are the ones that change.
+ *
+ * Declared on the element and not on :root, which matters: the Component UI
+ * defines its defaults on :root too, and its stylesheet is injected at first
+ * search — LATER in the cascade than this file, so an equally specific rule
+ * here would lose. A custom property set on a nearer ancestor wins regardless
+ * of where either rule was written, and everything Pagefind draws lives inside
+ * this element. ::backdrop inherits from the <dialog> in it, so the backdrop
+ * follows as well.
+ *
+ * Only the tokens the site actually has an opinion about are listed. The rest
+ * of Pagefind's defaults — spacing, shadows, the modal's geometry — are fine
+ * and are left alone. */
+pagefind-modal {
+  --pf-background: var(--bg);
+  --pf-text: var(--strong);
+  --pf-text-secondary: var(--text);
+  --pf-text-muted: var(--muted);
+  --pf-border: var(--border);
+  --pf-border-focus: var(--accent);
+  --pf-hover: var(--surface);
+  --pf-mark: var(--strong);
+  --pf-skeleton: var(--surface);
+  --pf-skeleton-shine: var(--border);
+  /* Matched to the masthead buttons, so focus looks deliberate rather than
+   * like a rendering fault. */
+  --pf-outline-focus: var(--accent);
+  --pf-font: var(--body-font);
+  /* Sized to the prose measure rather than to Pagefind's default, so the
+   * dialog reads as part of this page. */
+  --pf-modal-max-width: min(38rem, calc(100vw - 2rem));
+  --pf-modal-top: 8dvh;
 }
 
 @media (max-width: 700px) {
   .page {
     padding-top: 1.5rem;
   }
-}
-
-/* Pagefind's input takes the browser's default focus ring, which on a dark
- * background is a stark white box. Matched to the one the masthead buttons
- * use, so focus looks deliberate rather than like a rendering fault. */
-#search-ui input:focus-visible,
-#search-ui button:focus-visible {
-  outline: 2px solid var(--secondary);
-  outline-offset: 2px;
 }

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -14,7 +14,6 @@
     {{ with site.Home.OutputFormats.Get "rss" }}
       <link rel="alternate" type="application/rss+xml" title="{{ site.Title }}" href="{{ .Permalink }}" />
     {{ end }}
-    <link rel="stylesheet" href="{{ "pagefind/pagefind-ui.css" | relURL }}" />
     {{/*
       Applied before first paint, so a reader who chose dark does not get a
       white flash on every navigation. Inline for the same reason: an external
@@ -65,17 +64,24 @@
     </div>
 
     {{/*
-      Hidden until asked for. Pagefind's own bundle is ~40KB of JS that nothing
-      on a reading page needs, so it is fetched on the first search rather than
-      on every page load.
+      Pagefind's Component UI. Empty on purpose: the element builds its own
+      <dialog> with an input, a result list and a footer of keyboard hints, and
+      owns Escape, backdrop clicks, focus and the top layer. That is the whole
+      reason it is here rather than a dialog of ours — those are the parts of a
+      modal that are easy to write and hard to write correctly.
+
+      Neither the script nor the stylesheet is referenced from <head>. They are
+      ~46KB gzipped that nothing on a reading page needs, so they are fetched on
+      the first search; until then this is an unknown element with no children
+      and no box. Both URLs are resolved by Hugo here rather than assembled in
+      the script, so a change to how the bundle is addressed is a template
+      change and not a string concatenation somewhere below.
     */}}
-    <dialog
+    <pagefind-modal
       id="search-dialog"
-      aria-label="Search"
-      data-pagefind-ui="{{ "pagefind/pagefind-ui.js" | relURL }}"
-    >
-      <div id="search-ui"></div>
-    </dialog>
+      data-js="{{ "pagefind/pagefind-component-ui.js" | relURL }}"
+      data-css="{{ "pagefind/pagefind-component-ui.css" | relURL }}"
+    ></pagefind-modal>
 
     <script>
       (function () {
@@ -88,28 +94,44 @@
           } catch (e) {}
         });
 
-        var dialog = document.getElementById("search-dialog");
-        var loaded = false;
+        // Everything below is deferred loading. Opening, closing, focus and
+        // the keyboard hints belong to <pagefind-modal>; the only thing left
+        // for this page to decide is when its bundle is worth fetching.
+        //
+        // The stylesheet is awaited alongside the script so the dialog is not
+        // painted before it is styled — it is the script that takes the time,
+        // but a first open that flashes unstyled is the failure this avoids.
+        var modal = document.getElementById("search-dialog");
+        var ready = null;
+        function load() {
+          if (ready) return ready;
+          var css = document.createElement("link");
+          css.rel = "stylesheet";
+          css.href = modal.dataset.css;
+          var js = document.createElement("script");
+          js.src = modal.dataset.js;
+          ready = Promise.all([
+            // Resolved on error too: a missing stylesheet should still leave a
+            // working search rather than a button that does nothing.
+            new Promise(function (done) {
+              css.onload = css.onerror = done;
+            }),
+            new Promise(function (done) {
+              js.onload = done;
+            }),
+          ]).then(function () {
+            // The element upgrades when the script defines it, and open() only
+            // exists after that.
+            return customElements.whenDefined("pagefind-modal");
+          });
+          document.head.appendChild(css);
+          document.body.appendChild(js);
+          return ready;
+        }
         function open() {
-          if (!loaded) {
-            loaded = true;
-            var s = document.createElement("script");
-            s.src = dialog.dataset.pagefindUi;
-            s.onload = function () {
-              new PagefindUI({
-                element: "#search-ui",
-                showImages: false,
-                showSubResults: true,
-                resetStyles: false,
-              });
-              var input = dialog.querySelector("input");
-              if (input) input.focus();
-            };
-            document.body.appendChild(s);
-          }
-          dialog.showModal();
-          var input = dialog.querySelector("input");
-          if (input) input.focus();
+          load().then(function () {
+            modal.open();
+          });
         }
         document.getElementById("search-open").addEventListener("click", open);
         document.addEventListener("keydown", function (e) {
@@ -117,10 +139,6 @@
             e.preventDefault();
             open();
           }
-        });
-        // A click on the backdrop lands on the dialog element itself.
-        dialog.addEventListener("click", function (e) {
-          if (e.target === dialog) dialog.close();
         });
       })();
     </script>

--- a/modules/services/digital-garden/lib/preview.nix
+++ b/modules/services/digital-garden/lib/preview.nix
@@ -177,10 +177,10 @@ pkgs.writeShellApplication {
     inotifywait -q -m -r -e modify,create,delete,move,close_write \
       --exclude '/\.' --format '%w%f' "$vault/" "$cssdir/" \
       | while read -r changed; do
-        # The stylesheet's neighbours in hosts/ are watched only because they
-        # share its directory. Changing them means changing Nix, which this
-        # loop cannot pick up anyway, so re-rendering for them would only
-        # suggest it had.
+        # The watch is on the stylesheet's directory rather than the file (see
+        # above), so it also fires for the editor's own scratch files - swap
+        # files, backups, the numbered file vim writes to test the directory.
+        # Re-rendering for those would report work that did not happen.
         case "$changed" in
           "$css" | "$vault"/*) ;;
           *) continue ;;

--- a/modules/services/digital-garden/lib/serve.nix
+++ b/modules/services/digital-garden/lib/serve.nix
@@ -1,33 +1,35 @@
 # How a generated site is served, shared by the NixOS service and the local
 # preview so that a routing fix lands in both.
 #
-# This was lib/site.nix, which also held the Quartz rendering pass; that half
-# left with Quartz, and rendering now lives in lib/hugo.nix. Serving stays
-# separate from it because it is a property of the output tree, not of the
-# program that produced the tree — which is exactly what let the two generators
-# be compared under identical routing while the choice was open.
+# Kept apart from lib/hugo.nix on purpose: serving is a property of the output
+# tree, not of the program that produced it. A site that has been rendered to
+# HTML has no remaining opinion about who rendered it, and routing that has to
+# be reasoned about alongside a generator's internals is routing nobody can
+# check.
 { lib }:
 {
   # Serving config for a generated site rooted at `root`.
   #
-  # The try_files line is not boilerplate. Hugo emits `<slug>/index.html` and
-  # links to `<slug>`, so getting this wrong either 404s every internal link or
-  # spends a redirect on each one.
+  # The try_files line is not boilerplate. Hugo emits `<slug>/index.html`, and
+  # getting this wrong spends a redirect on requests that should be answered
+  # directly.
   caddyConfig = root: ''
     root * ${root}
     encode gzip zstd
     # The index INSIDE a directory is tried before the directory itself,
-    # because file_server answers a request for a directory with a 308 to its
-    # trailing-slash form. Naming index.html directly serves the page on the
-    # first request instead, which is what turns every internal link from two
-    # round trips into one.
+    # because file_server answers a request for a bare directory with a 308 to
+    # its trailing-slash form. Naming index.html directly serves the page on
+    # the first request instead.
     #
-    # After that: the literal path, for assets; then the same slug with a .html
-    # extension, which is the shape a generator that emits `<slug>.html` rather
-    # than `<slug>/index.html` produces. Keeping that third case costs nothing
-    # and means the served URLs do not depend on which generator built the
-    # tree.
-    try_files {path}/index.html {path} {path}.html
+    # The site's own links carry the slash (publish-filter.py writes them that
+    # way, to match what Hugo puts in rel=canonical), so this is not what makes
+    # the common case fast — it is what keeps the SLASHLESS form a first-class
+    # address rather than a redirect. Old links and typed URLs take that form,
+    # and they are the ones with nothing to fall back on.
+    #
+    # Then the literal path, which is how every asset — the stylesheet, the
+    # feed, the search bundle — is answered.
+    try_files {path}/index.html {path}
     file_server
     # Hugo generates a styled 404 page; without this Caddy answers with its own
     # empty one.

--- a/modules/services/digital-garden/publish-filter.py
+++ b/modules/services/digital-garden/publish-filter.py
@@ -33,11 +33,20 @@ served as, pointing at each other by those names, so swapping one generator for
 another cannot silently move a page. See `slugify`.
 
 Published notes are FLATTENED to the root of the staging tree, so the site's
-URLs are `/some-essay` rather than `/whatever-folder/some-essay`. The vault's
+URLs are `/some-essay/` rather than `/whatever-folder/some-essay/`. The vault's
 folder names are private working vocabulary, and reorganising the vault must
 not break a published URL. A note that moves keeps its address; a note's old
-address keeps working via an injected `aliases:` entry, which the
-alias-redirects plugin turns into a redirect page.
+address keeps working via an injected `aliases:` entry, which the generator
+turns into a redirect page. That entry is slugified segment by segment, because
+the address being kept alive is the one that was *served*, not the vault path
+it was derived from — `essays/On Boundaries.md` was reachable at
+`/essays/on-boundaries/`, and an alias naming the raw path publishes a URL with
+a space in it while leaving the real old address a 404.
+
+Links carry a trailing slash, which is the form the generator itself publishes
+in `rel=canonical`, the sitemap, the feed and the search index. Both forms are
+served directly, so this is not about reachability: it is so that one page is
+one string everywhere it is written down.
 
 Flattening makes filenames the global namespace, which the link rewriter below
 already assumed (it resolves wikilinks by stem). Two published notes sharing a
@@ -87,8 +96,9 @@ LEADING_H1 = re.compile(r"\A\s*#[ \t]+(.+?)[ \t]*\n+")
 # A list item that is nothing but a link to another published note — the shape
 # an index or hub entry takes before its thesis is filled in. Matched after the
 # wikilinks have already become Markdown links, so there is one link syntax to
-# recognise here rather than two.
-BARE_LINK_ITEM = re.compile(r"^([ \t]*[-*+][ \t]+)\[([^\]]*)\]\(/([^)#]*)[^)]*\)[ \t]*$", re.M)
+# recognise here rather than two. The trailing slash is captured OUTSIDE the
+# slug so that the lookup key matches the one `theses` is built with.
+BARE_LINK_ITEM = re.compile(r"^([ \t]*[-*+][ \t]+)\[([^\]]*)\]\(/([^)#/]*)/?[^)]*\)[ \t]*$", re.M)
 # Unreserved URL characters (RFC 3986). Anything else is dropped rather than
 # percent-escaped: an escape in a path is not something anyone wants to read,
 # type, or see in a browser's address bar.
@@ -266,7 +276,7 @@ def main(argv):
             # which is right for the headings Obsidian produces and would need
             # revisiting for one containing punctuation a generator strips.
             anchor = f"#{slugify(heading[1:])}" if heading else ""
-            return f"[{alias or target}](/{slugify(published[key][0].stem)}{anchor})"
+            return f"[{alias or target}](/{slugify(published[key][0].stem)}/{anchor})"
         return alias or target                  # link to an unpublished note
 
     # ---- pass 4: derive dates, then write a flat tree and swap it in --------
@@ -352,8 +362,11 @@ def main(argv):
         body = BARE_LINK_ITEM.sub(annotate, body)
 
         # Everything published lives at the root, so anything that used to live
-        # in a folder needs its old address kept alive.
-        old_url = str(rel.with_suffix(""))
+        # in a folder needs its old address kept alive. Slugified segment by
+        # segment: the address to keep alive is the one that was served, and
+        # the vault path it came from is not that string — "essays/On
+        # Boundaries" was served at /essays/on-boundaries/.
+        old_url = "/".join(slugify(part) for part in rel.with_suffix("").parts)
         if rel.parent != Path("."):
             aliases = coalesce_aliases(front)
             if old_url not in aliases:


### PR DESCRIPTION
The four items left open after the Hugo migration, plus a bug found while doing them.

## Search is Pagefind's Component UI

Pagefind 1.5.2 ships custom elements. An empty `<pagefind-modal>` builds its own `<dialog>` with an input, results and a footer of keyboard hints, and owns Escape, backdrop clicks, focus and the top layer — the parts of a modal that are easy to write and hard to write correctly. ~46 lines of hand-wired dialog JS became ~12 lines of deferred loading.

Neither the script nor the stylesheet is referenced from `<head>` any more. A reading page now costs **nothing** for search, where it previously carried 2.6KB gzipped of Pagefind CSS whether or not anyone searched. The bundle is ~46KB gz and arrives on first use; reopening refetches nothing.

## One page is one URL

`publish-filter.py` writes links with a trailing slash, which is what Hugo already published in `rel=canonical`, the sitemap, the feed and the search index. Both forms serve directly, so this was never about reachability — a page addressed two ways is a page counted, cached and linked two ways.

`serve.nix` now states that keeping the slashless form a first-class address, rather than a redirect, is what its `try_files` ordering is *for*: old links and typed URLs take that form and have nothing to fall back on.

## The palette is named for what each colour does

The names came value-for-value from the previous generator, which is why `--light` was the background in both themes and the dark block read as a contradiction. Values untouched; only the names moved. `--tertiary` was defined in both themes and used nowhere — deleted.

The Pagefind mapping is declared on `pagefind-modal` rather than `:root`, which matters: the Component UI defines its defaults on `:root` too, and its stylesheet is injected *after* this file, so an equally specific rule here would lose. A custom property on a nearer ancestor wins regardless of source order.

## :bug: An alias kept the wrong address alive

`old_url` was built from the raw vault path, so `essays/On Boundaries.md` injected the alias `essays/On Boundaries` — publishing `/essays/On%20Boundaries/` while the address that was actually live, `/essays/on-boundaries`, returned **404**. The whole promise of flattening, broken silently.

The old address is the one that was *served*, so it is now slugified segment by segment. The existing test only exercised `on-gates`, which was already slug-shaped; the fixture note with a space and a capital is now asserted on, and the space-URL asserted absent.

## Stale code, not only stale comments

- **`MemoryDenyWriteExecute` is re-armed.** It was off because a Node toolchain needed writable-executable pages. That toolchain is gone — CPython, Go and Rust do not JIT — so the exemption goes with it. The VM test confirms the builder completes under it.
- **`try_files` lost a dead case.** The third entry existed only so two generators could be compared under identical routing while the choice was open. There is one generator.
- **Comments describing Quartz** — its plugins, its output layout, its build cost — are rewritten to state the property that still holds. The history stays in `docs/adr/` and `docs/plans/`, where it is dated and belongs.

## Verification

`nix flake check` passes and `homelab01` builds. Beyond the gate, headless Chromium against the real Caddy config, in both themes:

- dialog opens from the button and from `mod+k`; focus lands on the input
- Escape closes it; backdrop click closes it; reopening triggers 0 extra requests
- result hrefs carry the trailing slash, matching links and canonical
- **0** Pagefind requests before first interaction; console clean

New assertions in `checks/digital-garden.nix` cover the lazy bundle (and that its URLs are real), the trailing-slash link form, and the alias fix.

## One thing to watch after promotion

`MemoryDenyWriteExecute = true` is exercised by the VM test against the same two binaries, but on a 4-note fixture rather than the real vault. If `digital-garden-build` fails after this reaches the host, that is the first thing to check.
