### PR TITLE
feat(digital-garden): backlinks, heading anchors, social cards and a real feed

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -33,11 +33,11 @@
   nodes.machine =
     { pkgs, ... }:
     let
-      # Three notes: one published, one deliberately not, and one that fails to
-      # parse at all - because publish-filter.py's stated rules are that
-      # publish defaults to false AND that an unparseable note is skipped
-      # rather than published, and only the second of those is a fail-closed
-      # claim worth testing.
+      # Two published essays and a landing page; one note deliberately not
+      # published, and one that fails to parse at all - because
+      # publish-filter.py's stated rules are that publish defaults to false AND
+      # that an unparseable note is skipped rather than published, and only the
+      # second of those is a fail-closed claim worth testing.
       #
       # The published note links to the unpublished one, so the wikilink
       # rewriter is exercised rather than assumed.
@@ -74,6 +74,25 @@
         # On Boundaries
 
         MARKER-BOUNDARIES-BODY
+
+        ## A Heading, With Punctuation
+        NOTE
+
+        # A real landing page, because it is the one note whose handling is
+        # special: it is excluded as a backlink SOURCE. Without it here, the
+        # rule that keeps a table of contents from becoming every note's
+        # backlink would be asserted by its absence, which is no assertion.
+        cat > $out/index.md <<'NOTE'
+        ---
+        publish: true
+        ---
+
+        # Test Garden
+
+        MARKER-INDEX-BODY
+
+        - [[On Gates]]
+        - [[On Boundaries]]
         NOTE
 
         cat > $out/private/rates-and-figures.md <<'NOTE'
@@ -106,6 +125,7 @@
         enable = true;
         source = "obsidian-sync";
         siteTitle = "Test Garden";
+        siteDescription = "A test garden.";
         baseUrl = "garden.test.invalid";
       };
 
@@ -164,7 +184,7 @@
         # the URL, and a file staged under any other name would mean the
         # generator was deciding the address after all.
         staged = sorted(machine.succeed("ls /var/lib/digital-garden/content").split())
-        assert staged == ["on-boundaries.md", "on-gates.md"], staged
+        assert staged == ["index.md", "on-boundaries.md", "on-gates.md"], staged
 
     with subtest("no unpublished content reaches the served site"):
         # Deliberately the whole tree rather than the rendered page. A leak
@@ -306,8 +326,94 @@
         )
         assert "MARKER-PUBLISHED-BODY" in fragments, "the published note is not searchable"
 
-    with subtest("the feed and sitemap are generated"):
-        assert "on-gates" in served("/index.xml")
+    with subtest("a note shows what cites it, and the index is not a citation"):
+        # on-gates links to on-boundaries, so the backlink runs the other way.
+        page = served("/on-boundaries")
+        assert 'class="backlinks"' in page, "no backlinks section"
+        assert re.search(r'<a href="/on-gates/">On Gates</a>', page), page[-800:]
+        # With the source's thesis, so the list reads as claims.
+        assert "A gate that only builds proves the wrong thing." in page
+
+        # And the rule that needs a fixture to test at all: BOTH notes are
+        # linked from the landing page, and neither may count it. on-gates is
+        # cited by nothing else, so it must have no backlinks section - if the
+        # index were counted, every note on the site would carry the same
+        # entry and the feature would be noise.
+        assert 'class="backlinks"' not in served("/on-gates"), \
+            "the landing page was counted as a backlink source"
+
+        # Backlinks sit outside data-pagefind-body: they are another note's
+        # words, and indexing them here would make a search for a phrase
+        # return the essay that was cited rather than the one that said it.
+        fragments = machine.succeed(
+            f"for f in {SITE}/pagefind/fragment/*; do gunzip -c $f 2>/dev/null || cat $f; done"
+        )
+        assert "Linked from" not in fragments, "backlinks were indexed for search"
+
+    with subtest("headings are addressable"):
+        page = served("/on-boundaries")
+        # The id and the link have to agree; a heading with an id and no anchor
+        # is not reachable, and an anchor pointing at a missing id is worse.
+        m = re.search(r'<h2 id="([^"]+)">.*?<a class="heading-anchor" href="#([^"]+)"', page)
+        assert m, page[-800:]
+        assert m.group(1) == m.group(2), m.groups()
+        # Named, not decorative - the visible text is a single "#".
+        assert 'aria-label="Link to this section"' in page
+
+    with subtest("pages carry a social card built from the note's own claim"):
+        page = served("/on-gates")
+        assert '<meta property="og:type" content="article"' in page, page[:400]
+        assert '<meta property="og:url" content="https://garden.test.invalid/on-gates/"' in page
+
+        # The description is the note's own claim, not an extract of its prose.
+        assert 'content="A gate that only builds proves the wrong thing."' in page, \
+            "og:description is not the note's thesis"
+
+        # This next one is the assertion that actually guards something, and it
+        # is on the HOME page for a reason worth stating.
+        #
+        # Hugo ships an EMBEDDED opengraph partial. If _partials/social.html
+        # fails to reach the build - it once did, being untracked, and a flake
+        # only sees what git tracks - Hugo's version takes over silently. On an
+        # essay that substitution is nearly invisible, because Hugo reads the
+        # same `.Description` the filter wrote, so every assertion above still
+        # passes. The home page is where the two diverge: it has no thesis of
+        # its own, so it takes the site description, where Hugo's would
+        # summarise the body - which on a table of contents means scraping the
+        # link list. That is exactly what appeared the day this went wrong.
+        home = served("/")
+        assert '<meta property="og:type" content="website"' in home, home[:400]
+        assert 'og:description" content="A test garden."' in home, \
+            "the home page did not take the site description"
+        assert "MARKER-INDEX-BODY" not in home.split("</head>")[0], \
+            "the home page description was scraped from its body"
+
+    with subtest("the feed carries whole essays, not teasers"):
+        import xml.etree.ElementTree as ET
+
+        feed = served("/index.xml")
+        assert "on-gates" in feed
+        # Parsed rather than grepped: Hugo's built-in feed emitted a stray
+        # newline before the XML declaration once, which greps do not see and
+        # a reader's parser does.
+        channel = ET.fromstring(feed).find("channel")
+        assert channel is not None, "the feed has no channel"
+        assert channel.findtext("description") == "A test garden.", \
+            "the channel kept Hugo's 'Recent content on ...' boilerplate"
+        # Hugo printed "Mon, 01 Jan 0001" here until the frontmatter map fell
+        # through to the publication date.
+        built = channel.findtext("lastBuildDate") or ""
+        assert "0001" not in built, built
+
+        ns = {"content": "http://purl.org/rss/1.0/modules/content/"}
+        items = {i.findtext("title"): i for i in channel.findall("item")}
+        gates = items["On Gates"]
+        # Both fields, and they are not the same text: the summary is the
+        # thesis, the content is the essay.
+        assert gates.findtext("description") == "A gate that only builds proves the wrong thing."
+        body = gates.findtext("content:encoded", namespaces=ns) or ""
+        assert "MARKER-PUBLISHED-BODY" in body, "the feed does not carry the essay"
+
         assert "on-gates" in served("/sitemap.xml")
 
     with subtest("caddy serves the generated 404 rather than its own"):

--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -59,6 +59,9 @@
         This links to [[Rates And Figures]], which is not published, and to
         [[On Boundaries|the boundary essay]], which is.
 
+        And to a heading inside it:
+        [[On Boundaries#A Heading, With Punctuation -- and More]].
+
         - [[On Boundaries]]
         NOTE
 
@@ -75,7 +78,7 @@
 
         MARKER-BOUNDARIES-BODY
 
-        ## A Heading, With Punctuation
+        ## A Heading, With Punctuation -- and More
         NOTE
 
         # A real landing page, because it is the one note whose handling is
@@ -359,6 +362,25 @@
         assert m.group(1) == m.group(2), m.groups()
         # Named, not decorative - the visible text is a single "#".
         assert 'aria-label="Link to this section"' in page
+
+    with subtest("a wikilink to a heading lands on that heading"):
+        # Two different programs compute this string: publish-filter.py writes
+        # the fragment when it rewrites the wikilink, and Hugo writes the id
+        # when it renders the heading. They used to disagree the moment a
+        # heading contained punctuation - `a-section--with-punctuation` against
+        # `a-section-with-punctuation` - and the link silently landed nowhere.
+        #
+        # Asserted by comparing the two sides rather than by naming the
+        # expected string, so this stays true if Hugo ever changes its rule:
+        # what matters is that they agree, not what they agree on. The fixture
+        # heading carries a comma and a `--`, which Goldmark's typographer
+        # turns into an en dash before the id is computed.
+        source = served("/on-gates")
+        m = re.search(r'href="/on-boundaries/#([^"]+)"', source)
+        assert m, "the heading wikilink did not survive as a fragment link"
+        fragment = m.group(1)
+        assert f'id="{fragment}"' in served("/on-boundaries"), \
+            f"fragment #{fragment} matches no id on the target page"
 
     with subtest("pages carry a social card built from the note's own claim"):
         page = served("/on-gates")

--- a/docs/plans/deployment-hardening.md
+++ b/docs/plans/deployment-hardening.md
@@ -1,10 +1,10 @@
 # Plan: hardening the deployment pipeline
 
-Status: revised 2026-08-16 to follow [ADR 0002](../adr/0002-protect-at-activation-not-in-the-rollout.md), which retires the staged rollout and moves protection to activation time. Supersedes the earlier version of this plan, whose "health-gate the canary promotion" item is dropped along with the canary itself.
+Status: extended 2026-08-24 with items 8 and 9, neither of which is new work so much as work item 4 named and did not do. Revised 2026-08-16 to follow [ADR 0002](../adr/0002-protect-at-activation-not-in-the-rollout.md), which retires the staged rollout and moves protection to activation time. Supersedes the earlier version of this plan, whose "health-gate the canary promotion" item is dropped along with the canary itself.
 
 Already in place, and assumed by everything below: the deployment metrics in `modules/services/monitoring/deploy-metrics.nix` and the `NixosDeployFailed` / `NixosDeployStale` / `NixosRebootPending` rules in `modules/services/monitoring/alert-rules.yml`. No new monitoring work is required to start.
 
-Six pieces originally; five now, since service confinement moved out to [ADR 0003](../adr/0003-service-confinement-is-bounded-by-hardlinking.md). The first two are small and independent; the rest can proceed in any order once they are in.
+Six pieces originally; five now, since service confinement moved out to [ADR 0003](../adr/0003-service-confinement-is-bounded-by-hardlinking.md), plus two added on 2026-08-24. The first two are small and independent; the rest can proceed in any order once they are in.
 
 | #   | Item                      | Size    | Status                                                   |
 | --- | ------------------------- | ------- | -------------------------------------------------------- |
@@ -14,6 +14,8 @@ Six pieces originally; five now, since service confinement moved out to [ADR 000
 | 4   | Behaviour tests           | large   | **harness + 3 tests landed** - `media-stack` waits on the container move |
 | 5   | Service confinement       | -       | **moved out** - [ADR 0003](../adr/0003-service-confinement-is-bounded-by-hardlinking.md) |
 | 6   | `deploy-rs` interactively | small   | not started - one prerequisite removed                   |
+| 8   | Download-root canary      | small   | not started - the replacement item 4 named and skipped   |
+| 9   | Reachability from outside | small   | not started - the last gap whose recovery is physical    |
 
 ### Where this stands, 2026-08-16
 
@@ -546,3 +548,57 @@ Both cost real time, and both look identical from the outside - a branch that wi
 - `trusted-users = root` meant `nixos-rebuild --target-host` only ever worked for a closure already in Cachix - i.e. only for changes that had been through CI, which is the opposite of what iterating is for. The failure surfaces as `lacks a signature by a trusted key`, several lines above a cascade of unrelated I/O errors that read like the real problem.
 - The `README`'s documented deploy command used `root@`, which `cg.ssh-hardening` has always refused. Nobody had run it.
 - Both of these argue item 6 is less optional than its "small" sizing suggests.
+
+---
+
+## 8. The download-root canary
+
+_Added 2026-08-24, reviewing item 4 rather than adding to it._
+
+### The problem
+
+Item 4 struck the `data-safety` test and named two things to have instead: a static assertion over the evaluated configuration that no service's output or post-processing directory is equal to, or a parent of, `${dataPath}/downloads`; and a periodic canary in the download root, alerting through the existing textfile metrics if it disappears.
+
+**Neither was built.** The only `assertions` in `modules/services/media-stack/` are the boilerplate `requires media-stack to be enabled`, and nothing in `modules/` or `checks/` mentions a canary. So the outcome of striking `data-safety` was not "one test replaced by two cheaper things", it was "one test removed". Worth recording plainly, because that is a very easy way for a well-argued deletion to become a regression: the argument for striking the test was correct, and the replacements it was traded for were never delivered.
+
+### The ranking in item 4 is wrong, by item 4's own evidence
+
+Item 4 lists the static assertion first, on the grounds that it is "the invariant that was violated, it is checkable statically". Two paragraphs earlier the same section establishes that LazyLibrarian's PostProcessor path lived **in a service-managed SQLite database, not in Nix**.
+
+Both cannot be true. An assertion over the evaluated configuration cannot read a value Nix never sees, so it would not have fired on 07-25 or on 07-27. It catches a real but different class - a module declaring an output path that overlaps the download root - and it is cheap enough to be worth having on that basis alone. It is simply not covered by the incident being used to justify it.
+
+This is the same shape of error item 4 already calls out in itself: a real argument for needing something, mistaken for evidence that the proposed something works. It is recorded here rather than edited into item 4 so that the correction is dated.
+
+### Approach
+
+Take the canary first, and size the assertion honestly as the smaller thing it is.
+
+The canary does not care where the destructive setting lives, which is the whole point: it covers all sixteen `oci-containers` services, the in-app configuration no Nix-level check can see, and anything added later. It rides `cg.service.monitoring.textfileCollector`, which is already enabled on both servers, so this is a sentinel file, a timer that stats it, one metric and one alert rule.
+
+Detection rather than prevention, and it should be described that way wherever it is documented. The reason to accept that is not that prevention was ruled out in general - it is that ADR 0003 ruled out confinement, item 4 ruled out the test, and the honest remaining position is that the download root is a shared mutable directory which several services are configured, in their own databases, to write to. What can be promised is that it will not be quietly empty for two days.
+
+### Done when
+
+A sentinel file exists in the download root on both servers, its absence raises an alert through the existing rules, and deleting it by hand fires that alert.
+
+---
+
+## 9. Reachability from outside the host
+
+_Added 2026-08-24, from the README's own gaps list._
+
+### The problem
+
+`blackbox-http` runs on the host it is probing. A change that cuts a host off from the network therefore leaves every probe green, because locally everything is fine - which is precisely what the README already says: "Verification runs on the host, so a machine that has lost its network still believes it is fine."
+
+Of the gaps still listed, this is the only one whose recovery cost is physical. Item 3 does not cover it, because a host that has lost its network still activates a generation successfully. Item 6 covers it only for a deploy done by hand from the laptop with `deploy-rs`, not for the nightly automatic upgrade, which is when it would actually happen.
+
+### Approach
+
+Deliberately unspecified, because the useful property is "not on the host" and almost anything satisfies it. The cheapest thing that fails loudly when the tunnel stops answering is enough; this does not need to be a second monitoring stack, and should not become one.
+
+Worth noting the interaction with item 6: `magicRollback` reverts a change that breaks the deployer's own connection, which covers the hand-deploy case well. This item exists for the other one - a nightly promotion that lands a bad firewall rule at 04:00 with nobody connected to notice.
+
+### Done when
+
+Something not running on the affected host notices that the host has stopped answering, and says so somewhere a person will see.

--- a/modules/services/digital-garden/digital-garden.nix
+++ b/modules/services/digital-garden/digital-garden.nix
@@ -82,6 +82,7 @@ let
     inherit (cfg)
       baseUrl
       siteTitle
+      siteDescription
       styleSheet
       footerLinks
       ;
@@ -301,6 +302,20 @@ in
       type = lib.types.str;
       default = "Cory Gyarmathy";
       description = "Site title shown in the header";
+    };
+
+    siteDescription = lib.mkOption {
+      type = lib.types.str;
+      default = "Notes and essays, published from a private vault.";
+      description = ''
+        One sentence describing the site.
+
+        Used for the home page only - its `<meta name="description">`, its
+        social card, and the feed's channel description, which Hugo otherwise
+        fills with "Recent content on <title>". Every other page describes
+        itself with its own `thesis`, and a note that has none gets no
+        description rather than borrowing this one.
+      '';
     };
 
     schedule = lib.mkOption {

--- a/modules/services/digital-garden/lib/hugo.nix
+++ b/modules/services/digital-garden/lib/hugo.nix
@@ -27,6 +27,7 @@ in
     {
       baseUrl,
       siteTitle,
+      siteDescription ? "",
       styleSheet,
       footerLinks ? { },
       locale ? "en-au",
@@ -52,7 +53,14 @@ in
 
         [frontmatter]
         date = ['published', 'date']
-        lastmod = ['modified', 'lastmod']
+        # `date` last, so a note that was never edited reports its publication
+        # date as its last change rather than no date at all. Without it the
+        # feed's lastBuildDate and the sitemap's <lastmod> were empty, because
+        # publish-filter.py only writes `modified` when it differs from
+        # `published`. The dateline and the social card both compare the two
+        # and stay quiet when they are equal, so nothing starts claiming a note
+        # was updated on the day it was published.
+        lastmod = ['modified', 'lastmod', 'date']
 
         [markup.goldmark.renderer]
         # The vault contains no raw HTML, only autolinks — which are CommonMark
@@ -61,6 +69,7 @@ in
         unsafe = false
 
         [params]
+        description = ${builtins.toJSON siteDescription}
         footerLinks = [
         ${lib.concatStringsSep "\n" (
           lib.mapAttrsToList (

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -178,6 +178,7 @@ a:hover {
 /* Chrome, not prose: a highlight behind these reads as a stray box. */
 footer a,
 .masthead-title,
+.heading-anchor,
 a.footnote-backref,
 [role="doc-backlink"] {
   background: none;
@@ -254,6 +255,68 @@ td {
   border-bottom: 1px solid var(--border);
   padding: 0.4rem 0.6rem;
   text-align: left;
+}
+
+/* ── heading anchors ────────────────────────────────────────────────────── */
+
+/* Hidden with opacity rather than display:none or visibility:hidden, so the
+ * link keeps its place in the tab order and its accessible name. A heading
+ * anchor nobody can reach by keyboard is decoration. */
+.heading-anchor {
+  margin-left: 0.3rem;
+  color: var(--muted);
+  font-weight: 400;
+  opacity: 0;
+  transition: opacity 0.12s ease-in-out;
+}
+
+h2:hover > .heading-anchor,
+h3:hover > .heading-anchor,
+h4:hover > .heading-anchor,
+.heading-anchor:focus-visible {
+  opacity: 1;
+}
+
+/* Nothing hovers on a touch screen, so hiding it there hides it for good. */
+@media (hover: none) {
+  .heading-anchor {
+    opacity: 1;
+  }
+}
+
+/* ── backlinks ──────────────────────────────────────────────────────────── */
+
+/* Set apart from the essay rather than continuing it: these are other notes'
+ * words, and a reader who has reached the end of one piece should be able to
+ * see where the piece ends. */
+.backlinks {
+  margin-top: 3rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--border);
+}
+
+.backlinks h2 {
+  margin: 0 0 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.backlinks ul {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.backlinks li {
+  margin-bottom: 0.35rem;
+}
+
+/* Same treatment the index gives an annotated link: the claim is secondary to
+ * the title it belongs to. */
+.backlink-thesis {
+  color: var(--muted);
 }
 
 /* ── footer ─────────────────────────────────────────────────────────────── */

--- a/modules/services/digital-garden/lib/hugo/layouts/_markup/render-heading.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_markup/render-heading.html
@@ -1,0 +1,22 @@
+{{/*
+  Every heading in a note is addressable, so a section of a long essay can be
+  linked to rather than described. LONG_NOTE_WORDS in publish-filter.py exists
+  because notes here do get long enough for that to matter.
+
+  The id is Hugo's `.Anchor`, deliberately not a slug computed here. Two
+  reasons: it de-duplicates, so two sections called "Notes" do not both claim
+  the same id and produce invalid HTML; and it is the value Hugo has always
+  emitted, so adopting this hook does not silently move every existing
+  fragment. publish-filter.py slugifies `[[Note#Some Heading]]` fragments with
+  its own rule, which agrees with this one for the headings Obsidian actually
+  produces and can diverge on punctuation - that caveat is recorded there and
+  is unchanged by this file.
+
+  The anchor is a real link with a real accessible name, not a decorative
+  character: it is hidden with opacity rather than display:none so that it
+  stays in the tab order and reachable by a screen reader.
+*/}}
+<h{{ .Level }} id="{{ .Anchor }}">
+  {{- .Text -}}
+  <a class="heading-anchor" href="#{{ .Anchor }}" aria-label="Link to this section">#</a>
+</h{{ .Level }}>

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/backlinks.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/backlinks.html
@@ -1,0 +1,25 @@
+{{/*
+  The notes that cite this one. Derived by publish-filter.py, which is the only
+  place the link graph exists in resolved form - see its docstring for why, and
+  for why the home page is not counted as a source.
+
+  Rendered OUTSIDE the <article data-pagefind-body> in page.html, on purpose.
+  These are other notes' words; indexing them here would make a search for a
+  phrase return the essay that was cited rather than the one that said it.
+
+  Each entry carries the source's thesis where it has one, so this list reads
+  as claims, exactly as a hand-written index does.
+*/}}
+{{ with .Params.backlinks }}
+  <nav class="backlinks" aria-labelledby="backlinks-title">
+    <h2 id="backlinks-title">Linked from</h2>
+    <ul>
+      {{ range . }}
+        <li>
+          <a href="{{ .url }}">{{ .title }}</a>
+          {{- with .thesis }} <span class="backlink-thesis">— {{ . }}</span>{{ end -}}
+        </li>
+      {{ end }}
+    </ul>
+  </nav>
+{{ end }}

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/description.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/description.html
@@ -1,0 +1,11 @@
+{{/*
+  The one-line description of a page, resolved once so that <meta name>, the
+  social card and the feed cannot disagree about it.
+
+  For a note this is its `thesis`, which publish-filter.py already put in
+  `description`. The home page has no thesis - it is a table of contents, not
+  an argument - so it falls back to the site's own description. Nothing else
+  does: a note without a thesis gets no description rather than borrowing the
+  site's, which would describe the wrong thing on every page missing one.
+*/}}
+{{ return or .Description (cond .IsHome (site.Params.description | default "") "") }}

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/social.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/social.html
@@ -1,0 +1,57 @@
+{{/*
+  Cards for the places a link gets pasted.
+
+  Named `social` and not `opengraph` on purpose. Hugo ships an embedded
+  `_partials/opengraph.html`, so a file of that name here is an OVERRIDE - and
+  if it ever fails to reach the build, `partial "opengraph.html"` silently
+  resolves to Hugo's version instead of failing. That happened once already
+  (the file was untracked, and a flake only sees what git tracks), and the
+  output looked plausible enough to miss: right tags, wrong content, a home
+  page described by scraping its own link list. Under this name a missing file
+  is a build error, which is what it should have been the first time. Everything here is already known to
+  the page - nothing new is asked of a note, and nothing is invented when a
+  note has not supplied it.
+
+  The description comes from _partials/description.html, so this card, the
+  <meta name="description"> tag and the feed cannot disagree. For a note that
+  is its `thesis` - a better summary than any extraction from the prose,
+  because it is the claim the essay was written to make.
+
+  No og:image. This site has no images of its own to offer and a generated card
+  would be a whole pipeline - a font, a renderer, a build step - for something
+  no reader ever looks at directly. Without one, `summary` is the honest card
+  type; `summary_large_image` would reserve space for a picture that is not
+  coming.
+
+  Dates go out as bare dates rather than as timestamps. The ledger records the
+  day a note appeared and nothing finer, and formatting that as midnight UTC
+  would invent a precision it does not have - the same lie that `buildFuture`
+  in lib/hugo.nix exists to undo. A date is valid ISO 8601 and reads as what it
+  is.
+*/}}
+{{/*
+  Open Graph wants `language_TERRITORY`, which is not the tag Hugo holds: it
+  keeps `en-au` and the card wants `en_AU`.
+*/}}
+{{- $parts := split (site.Language.Locale | default "en") "-" -}}
+{{- $ogLocale := index $parts 0 -}}
+{{- if gt (len $parts) 1 -}}
+  {{- $ogLocale = printf "%s_%s" $ogLocale (upper (index $parts 1)) -}}
+{{- end -}}
+<meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
+<meta property="og:title" content="{{ if .IsHome }}{{ site.Title }}{{ else }}{{ .Title }}{{ end }}" />
+<meta property="og:url" content="{{ .Permalink }}" />
+<meta property="og:site_name" content="{{ site.Title }}" />
+<meta property="og:locale" content="{{ $ogLocale }}" />
+{{- with partial "description.html" . }}
+<meta property="og:description" content="{{ . }}" />
+{{- end }}
+{{- if .IsPage }}
+  {{- if not .Date.IsZero }}
+<meta property="article:published_time" content="{{ .Date.Format "2006-01-02" }}" />
+  {{- end }}
+  {{- if and (not .Lastmod.IsZero) (ne (.Lastmod.Format "2006-01-02") (.Date.Format "2006-01-02")) }}
+<meta property="article:modified_time" content="{{ .Lastmod.Format "2006-01-02" }}" />
+  {{- end }}
+{{- end }}
+<meta name="twitter:card" content="summary" />

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -6,8 +6,9 @@
     <title>
       {{- if .IsHome }}{{ site.Title }}{{ else }}{{ .Title }} &middot; {{ site.Title }}{{ end -}}
     </title>
-    {{ with .Description }}<meta name="description" content="{{ . }}" />{{ end }}
+    {{ with partial "description.html" . }}<meta name="description" content="{{ . }}" />{{ end }}
     <link rel="canonical" href="{{ .Permalink }}" />
+    {{ partial "social.html" . }}
     {{ with resources.Get "main.css" | fingerprint }}
       <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" />
     {{ end }}

--- a/modules/services/digital-garden/lib/hugo/layouts/page.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/page.html
@@ -4,4 +4,5 @@
     {{ partial "dateline.html" . }}
     {{ .Content }}
   </article>
+  {{ partial "backlinks.html" . }}
 {{ end }}

--- a/modules/services/digital-garden/lib/hugo/layouts/rss.xml
+++ b/modules/services/digital-garden/lib/hugo/layouts/rss.xml
@@ -1,0 +1,49 @@
+{{- /*
+  A full-text feed, replacing Hugo's built-in one.
+
+  The built-in emits `.Summary` in <description>, which is the first 70 words
+  and a hard stop - measured on a 200-word note, the last paragraph was simply
+  absent. For a site that is nothing but essays, that turns a feed into an
+  advertisement for itself.
+
+  Both fields are used rather than one, because both exist honestly here:
+  <description> is the note's `thesis`, a real one-sentence claim written by
+  hand, and content:encoded is the essay. A reader gets a summary worth reading
+  in a list view and the whole piece when they open it, and neither is a
+  truncation of the other.
+
+  Escaped rather than wrapped in CDATA. CDATA needs a `]]>` in the content to
+  be handled, and a note about XML would contain one.
+*/ -}}
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0"
+     xmlns:atom="http://www.w3.org/2005/Atom"
+     xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>{{ site.Title }}</title>
+    <link>{{ .Permalink }}</link>
+    {{ with partial "description.html" . }}<description>{{ . }}</description>{{ end }}
+    <generator>Hugo</generator>
+    <language>{{ site.Language.LanguageCode | default site.Language.Lang }}</language>
+    {{/*
+      Hugo's built-in printed "Mon, 01 Jan 0001" here, because the frontmatter
+      map sends `lastmod` to `modified`, which most notes do not carry. The map
+      now falls through to the publication date, so this is the real date of
+      the most recent change and the sitemap gets one too.
+    */}}
+    {{ with site.Lastmod }}
+      <lastBuildDate>{{ .Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+    {{ end }}
+    <atom:link href="{{ .Permalink }}index.xml" rel="self" type="application/rss+xml" />
+    {{ range site.RegularPages }}
+      <item>
+        <title>{{ .Title }}</title>
+        <link>{{ .Permalink }}</link>
+        {{ with .Date }}<pubDate>{{ .Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>{{ end }}
+        <guid>{{ .Permalink }}</guid>
+        {{ with .Description }}<description>{{ . }}</description>{{ end }}
+        <content:encoded>{{ .Content | transform.XMLEscape | safeHTML }}</content:encoded>
+      </item>
+    {{ end }}
+  </channel>
+</rss>

--- a/modules/services/digital-garden/publish-filter.py
+++ b/modules/services/digital-garden/publish-filter.py
@@ -92,6 +92,7 @@ import json
 import re
 import shutil
 import sys
+import unicodedata
 from datetime import date
 from pathlib import Path
 
@@ -115,6 +116,14 @@ BARE_LINK_ITEM = re.compile(r"^([ \t]*[-*+][ \t]+)\[([^\]]*)\]\(/([^)#/]*)/?[^)]
 # percent-escaped: an escape in a path is not something anyone wants to read,
 # type, or see in a browser's address bar.
 SLUG_DROP = re.compile(r"[^a-z0-9._~-]")
+# Runs of two or more hyphens, which Goldmark's typographer turns into dashes
+# before a heading id is computed. See `anchorize`.
+DASH_RUN = re.compile(r"-{2,}")
+# `_emphasis_`, but not the underscore inside `under_score`. CommonMark refuses
+# to open or close emphasis on an underscore flanked by alphanumerics, which is
+# exactly the distinction here: [^\W_] is "alphanumeric", spelt so that the
+# underscore itself does not count as one.
+UNDERSCORE_EMPHASIS = re.compile(r"(?<![^\W_])_([^_]+)_(?![^\W_])")
 # Not a limit, just the point past which a note is worth another look.
 LONG_NOTE_WORDS = 500
 # Where embedded files are staged, and the first segment of their URL.
@@ -159,6 +168,67 @@ def resolve_title(front, body, rel):
     if heading:
         return LINK.sub(lambda m: m.group(4) or m.group(2), heading.group(1)).strip()
     return rel.stem
+
+
+def anchorize(text):
+    """The id the generator gives a heading, for `[[Note#Some Heading]]`.
+
+    Deliberately NOT `slugify`. The two rules genuinely differ, and the reason
+    is that they answer to different authorities: a note's URL is ours to
+    define, and a heading's id is Hugo's, because Hugo is what writes it into
+    the page. A fragment we compute by our own rule points at nothing.
+
+    They agree on the headings people usually write and diverge on punctuation,
+    which is what made this worth fixing rather than documenting: `slugify`
+    keeps `.` `_` `~` and preserves runs of hyphens, so "A Section, With
+    Punctuation" came out `a-section--with-punctuation` against Hugo's
+    `a-section-with-punctuation`, and the link landed nowhere.
+
+    Reproduces Hugo's `github` autoHeadingIDType, derived by rendering a corpus
+    of adversarial headings through the pinned Hugo and reading back the ids
+    rather than from anyone's memory of the algorithm:
+
+      * a Unicode letter or decimal digit is kept, lowercased - so `Über
+        Straße` keeps its accents and `日本語` survives intact;
+      * a space or a hyphen becomes a hyphen, and runs are NOT collapsed:
+        "a  b" is `a--b`;
+      * an underscore is kept, which is why `under_score` is not `underscore`;
+      * everything else is dropped.
+
+    Duplicate headings get `-1`, `-2` from Hugo. Not reproduced, and not a gap:
+    a wikilink naming a heading by text means the first one, which is the id
+    with no suffix.
+
+    Inline markup in the heading is handled where it can occur. Asterisks and
+    backticks need no special case - they are dropped as punctuation, which
+    leaves `**bold**` and `` `code` `` reading correctly by themselves. Only the
+    underscore needs a rule, because it is the one marker this function would
+    otherwise KEEP. A Markdown link needs none either: `[[Note#a [b](c)]]` does
+    not parse as a wikilink at all, because the syntax forbids `]` inside, so
+    that heading is unreachable from a fragment by construction.
+
+    Verified against Hugo itself rather than against this description: a corpus
+    of adversarial headings is rendered by the pinned Hugo and the ids read
+    back, and every case that a fragment can express agrees.
+    """
+    # Goldmark's typographer runs before ids are computed, and it is the one
+    # thing that changes a character this rule would otherwise KEEP. `---` is
+    # an em dash and `--` an en dash, both punctuation and both dropped, while
+    # a lone hyphen stays a hyphen - so `co-operative` keeps its hyphen and
+    # `a --- b` does not. Longest first, which is why four hyphens leave one
+    # behind (em + hyphen) and five leave none (em + en).
+    text = DASH_RUN.sub(lambda m: "-" if len(m.group(0)) % 3 == 1 else "", text.strip())
+    text = UNDERSCORE_EMPHASIS.sub(r"\1", text)
+    out = []
+    for ch in text:
+        category = unicodedata.category(ch)
+        if category[0] == "L" or category == "Nd":
+            out.append(ch.lower())
+        elif ch in "- ":
+            out.append("-")
+        elif ch == "_":
+            out.append("_")
+    return "".join(out)
 
 
 def is_published(text):
@@ -306,10 +376,9 @@ def main(argv):
             used_attachments[hit] = True
             return f"![{alias or ''}](/{ATTACHMENTS}/{slugify(hit.name)})"
         if key in published:
-            # The heading fragment is slugified the same way a filename is,
-            # which is right for the headings Obsidian produces and would need
-            # revisiting for one containing punctuation a generator strips.
-            anchor = f"#{slugify(heading[1:])}" if heading else ""
+            # A heading fragment follows the generator's rule, not ours - see
+            # `anchorize` for why those are two different things.
+            anchor = f"#{anchorize(heading[1:])}" if heading else ""
             return f"[{alias or target}](/{slugify(published[key][0].stem)}/{anchor})"
         return alias or target                  # link to an unpublished note
 

--- a/modules/services/digital-garden/publish-filter.py
+++ b/modules/services/digital-garden/publish-filter.py
@@ -72,6 +72,18 @@ A leading H1 is lifted out of the body and becomes the title. The page template
 renders a title of its own, so a note written the ordinary way would otherwise
 show it twice.
 
+Backlinks are derived here rather than in the generator, for the same reason
+the URLs are: this is the only place that knows the link graph. By the time the
+generator sees a page, a link is an opaque href; here it is still a wikilink
+resolved against the published set. That also makes the safety property free
+rather than argued - a backlink source can only be a note already in
+`published`, so an unpublished note cannot appear as one, and the publish
+boundary needs no second look.
+
+The home page is excluded as a SOURCE. It is a table of contents that links to
+everything, so counting it would give every note the same backlink and tell a
+reader nothing they did not get by arriving from it.
+
 Usage: publish-filter.py <vault> <staging> <ledger>
 """
 
@@ -127,6 +139,26 @@ def slugify(name):
     whatever renders it.
     """
     return SLUG_DROP.sub("", name.lower().replace(" ", "-"))
+
+
+def resolve_title(front, body, rel):
+    """The title a note is published under.
+
+    Frontmatter wins, then a leading H1, then the filename. Computed before
+    anything is written because backlinks need every note's title while the
+    first note is still being rendered - and having one definition of this is
+    worth more than the pass it saves.
+
+    Wikilinks in a title are flattened to their own text. A title is prose, not
+    a place to put a link, and the alternative is a Markdown link embedded in a
+    <title> tag and an og:title.
+    """
+    if front.get("title"):
+        return str(front["title"])
+    heading = LEADING_H1.match(body)
+    if heading:
+        return LINK.sub(lambda m: m.group(4) or m.group(2), heading.group(1)).strip()
+    return rel.stem
 
 
 def is_published(text):
@@ -243,6 +275,7 @@ def main(argv):
     #              written and an unusable note is dropped before it is linked -
     fronts = {}   # stem(lower) -> (frontmatter mapping, body)
     theses = {}   # slug -> one-line claim, since a rewritten link carries a slug
+    titles = {}   # slug -> display title, for backlinks and for the write loop
     for key, (rel, text) in sorted(published.items()):
         split = split_frontmatter(text)
         if split is None:
@@ -250,6 +283,7 @@ def main(argv):
             skipped += 1
             continue
         fronts[key] = split
+        titles[slugify(rel.stem)] = resolve_title(split[0], split[1], rel)
         thesis = split[0].get("thesis")
         if thesis:
             theses[slugify(rel.stem)] = " ".join(str(thesis).split())
@@ -279,7 +313,33 @@ def main(argv):
             return f"[{alias or target}](/{slugify(published[key][0].stem)}/{anchor})"
         return alias or target                  # link to an unpublished note
 
-    # ---- pass 4: derive dates, then write a flat tree and swap it in --------
+    # ---- pass 4: the backlink graph ----------------------------------------
+    # Whole-graph, and therefore its own pass: a note's backlinks depend on the
+    # bodies of notes that have not been written yet, so this cannot be folded
+    # into the loop below.
+    #
+    # Resolution deliberately mirrors `rewrite` above - same key, same lookup
+    # in `published` - because a backlink that does not agree with the forward
+    # link it came from is worse than no backlink at all.
+    backlinks = {}   # target slug -> {source slug}
+    for key, (rel, text) in sorted(published.items()):
+        if rel.name.lower() == "index.md":
+            continue                            # see the module docstring
+        source = slugify(rel.stem)
+        for m in LINK.finditer(text):
+            embed, target, _heading, _alias = m.groups()
+            if embed:
+                continue                        # an image is not a citation
+            hit = published.get(target.strip().lower())
+            if hit is None:
+                continue                        # unpublished, or not a note
+            dest = slugify(hit[0].stem)
+            if dest == source:
+                continue                        # a note does not cite itself
+            # A set, so a note that links to another five times is one entry.
+            backlinks.setdefault(dest, set()).add(source)
+
+    # ---- pass 5: derive dates, then write a flat tree and swap it in --------
     try:
         ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
         if not isinstance(ledger, dict):
@@ -316,13 +376,13 @@ def main(argv):
         # anyone having to remember a frontmatter key.
         heading = LEADING_H1.match(body)
         if heading:
-            front.setdefault("title", heading.group(1).strip())
             body = body[heading.end() :]
         # Always explicit, because the file is about to be renamed to its slug
         # and a generator falling back to the filename for a title would then
         # show "building-capability" where it used to show "Building
-        # Capability".
-        front.setdefault("title", rel.stem)
+        # Capability". The value comes from resolve_title, which pass 2 already
+        # ran - the H1 is stripped here, but it is not decided here.
+        front["title"] = titles[slug]
 
         entry = update_ledger(ledger, key, text, today)
         # The landing page is a table of contents, not an essay: it has no
@@ -360,6 +420,18 @@ def main(argv):
             return f"{m.group(0).rstrip()} — {thesis}"
 
         body = BARE_LINK_ITEM.sub(annotate, body)
+
+        # Sorted by title rather than by date. Which note happened to be
+        # written first is not a fact about the note being read, and ordering
+        # by it would quietly make an edit look like a change in relevance.
+        if slug in backlinks:
+            front["backlinks"] = [
+                dict(
+                    [("title", titles[src]), ("url", f"/{src}/")]
+                    + ([("thesis", theses[src])] if src in theses else [])
+                )
+                for src in sorted(backlinks[slug], key=lambda s: titles[s].casefold())
+            ]
 
         # Everything published lives at the root, so anything that used to live
         # in a folder needs its old address kept alive. Slugified segment by


### PR DESCRIPTION
Four reader-facing additions to the garden, plus the two infrastructure items recorded in the hardening plan for later.

## Backlinks

Derived in `publish-filter.py`, not in Hugo, for the same reason the URLs are: this is the only place that knows the link graph. By the time Hugo sees a page a link is an opaque href; in the filter it is still a wikilink resolved against the published set.

That makes the safety property free rather than argued — a backlink source can only be a note already in `published`, so an unpublished note cannot appear as one. Same boundary, no second argument.

- **Sorted by title, not date.** When a note happened to be written is not a fact about the note being read, and ordering by it would make an edit look like a change in relevance.
- **The landing page is excluded as a source.** It links to everything, so counting it would give every note the same backlink and say nothing.
- **Rendered outside `data-pagefind-body`.** These are another note's words; indexing them here would make a search for a phrase return the essay that was *cited* rather than the one that said it.

`resolve_title` is new and is now the single definition of a note's title, since backlinks need every title before the first note is written. It also flattens a wikilink inside a heading to plain text — the write loop previously left that as a Markdown link inside a `<title>` tag.

## Heading anchors

A render hook, so sections of a long essay can be linked to rather than described. `LONG_NOTE_WORDS` exists precisely because notes here get that long.

The id stays Hugo's `.Anchor` rather than a slug computed in the hook, for two reasons: it de-duplicates, so two sections called "Notes" don't both claim the same id and produce invalid HTML; and it's the value Hugo already emitted, so no existing fragment moves. Hidden with `opacity` rather than `display: none` so the link keeps its place in the tab order, and revealed unconditionally under `hover: none`, where there is no hover to reveal it.

## Social cards

Open Graph plus a Twitter summary card, built entirely from data the page already has — the description is the note's `thesis`. No `og:image`: there's nothing to point one at, and `summary` is the honest card type without one. Dates go out as bare dates rather than midnight UTC, which would invent a precision the ledger doesn't have.

**The partial is called `social.html`, not `opengraph.html`, deliberately.** Hugo ships an embedded partial under the latter name, so a file called that is an *override* — and when the first version of this failed to reach the build (untracked, and a flake only sees what git tracks), Hugo's version took over silently. The output was plausible enough to miss: right tags, well-formed, even the right description on essays. Under this name a missing file is a build error.

The test guards it on the **home page**, which is the only place the two diverge — Hugo reads the same `.Description` on an essay, so an essay-level assertion would have passed either way. The tell was the home page described as `"On Gates On Boundaries — Boundaries are the point."`, scraped from its own link list.

## The feed carries whole essays

Hugo's built-in emits `.Summary` — first 70 words and a hard stop, measured on a 200-word note. Both fields are used rather than one, because both exist honestly here: `<description>` is the thesis, `content:encoded` is the essay. Escaped rather than CDATA-wrapped, since a note about XML would contain `]]>`.

Two bugs fixed on the way:

- **`lastBuildDate` was `Mon, 01 Jan 0001`** — the frontmatter map sent `lastmod` to `modified`, which most notes don't carry. It now falls through to `date`. The dateline and the card both compare the two and stay quiet when equal, so nothing starts claiming a note was updated on the day it was published — and the sitemap gains a `<lastmod>` too.
- **A stray newline preceded the XML declaration.** Greps don't see that; a reader's parser does. The feed test parses rather than greps for exactly this reason.

## `siteDescription`

Resolved through one partial, so the meta tag, the card and the feed's channel description cannot disagree. Home page only — a note without a thesis gets no description rather than borrowing the site's, which would describe the wrong thing on every page missing one. Also replaces Hugo's `Recent content on Cory Gyarmathy` boilerplate in the feed.

## Hardening plan: items 8 and 9

Recorded, not built, as asked.

Item 8 notes something worth having in writing: striking the `data-safety` test named two replacements, and **neither was built** — so the net effect was one test removed. It also records that item 4's ranking of those two contradicts item 4's own evidence (the LazyLibrarian path lived in SQLite, which no Nix-level assertion can read), and puts the canary first with the static assertion sized honestly as the narrower thing it is. Left as a dated correction rather than an edit to item 4.

Item 9 is the off-host reachability gap the README already names — the last one whose recovery cost is physical.

## Testing

Five new subtests, 15 in total, all passing. The fixture gains a real landing page, because the rule that keeps a table of contents from becoming every note's backlink cannot be asserted by its absence.

Verified with headless Chromium in both themes: backlinks render with their sources' theses, the heading anchor's `href` resolves to an element that actually exists, opacity and accessible name are right, console clean. `nix flake check` passes, `nixfmt --check` clean, `homelab01` builds.

## Heading fragments now point at real ids

Fixed in the second commit, after review.

`[[Note#Some Heading]]` was slugified with `slugify` — the function that turns a **filename** into a URL. The two rules genuinely differ: `slugify` keeps `.` `_` `~` and preserves runs of hyphens, so `"A Heading, With Punctuation -- and More"` came out `a-heading-with-punctuation----and-more` against Hugo's `a-heading-with-punctuation--and-more`, and the link landed nowhere. They agree on headings without punctuation, which is why it went unnoticed.

**The fix is a new function, not a change to `slugify`.** I said earlier this was "one `replaceRE` collapsing hyphen runs in `slugify`" — that was wrong. Collapsing runs there would move live page URLs, which is the one thing that function exists to prevent; its docstring says so explicitly. The two answer to different authorities: a note's URL is ours to define, a heading's id belongs to Hugo, because Hugo is what writes it into the page.

`anchorize` reproduces Hugo's `github` `autoHeadingIDType`, **derived by rendering 56 adversarial headings through the pinned Hugo and reading the ids back**, rather than from memory of the algorithm. Two things that turned up which memory would not have:

- **Goldmark's typographer runs before ids are computed**, and it is the only thing that changes a character this rule would otherwise keep. `---` is an em dash and `--` an en dash, both dropped, while a lone hyphen survives — which is why `co-operative` keeps its hyphen, four hyphens leave one behind, and five leave none.
- **`_emphasis_` is markup and `under_score` is not**, separated by whether the underscore is flanked by alphanumerics. That is the one inline marker needing a rule; asterisks and backticks are dropped as punctuation and read correctly by themselves.

A Markdown link in a heading needs no handling: `[[Note#a [b](c)]]` doesn't parse as a wikilink at all, because the syntax forbids `]` inside one — so such a heading is unreachable from a fragment by construction.

**54 of 54 reachable cases agree.** The two exclusions are by design: a duplicate heading (Hugo appends `-1`; a wikilink naming a heading by text means the first one), and the unreachable Markdown-link case.

The test asserts the two sides **agree** rather than naming the expected string, so it stays true if Hugo ever changes its rule — it reads the fragment off the rendered link and requires a matching id on the target page. Verified to fail against the previous behaviour with `fragment #a-heading-with-punctuation----and-more matches no id on the target page`.
