### PR TITLE
feat(digital-garden): render Obsidian-flavored markdown, not just links

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -63,6 +63,36 @@
         [[On Boundaries#A Heading, With Punctuation -- and More]].
 
         - [[On Boundaries]]
+
+        > [!warning] Watch the gate
+        > MARKER-CALLOUT-BODY
+
+        > [!note]- Folded away
+        > MARKER-CALLOUT-FOLDED
+
+        > [!tip]+
+        > MARKER-CALLOUT-OPEN
+
+        > [!question] A type with no GitHub equivalent
+        > MARKER-CALLOUT-QUESTION
+
+        Some ==MARKER-HIGHLIGHT== prose.
+
+        %% MARKER-COMMENT-SECRET %%
+
+        A paragraph carrying a block id. ^markerblockid
+
+        A same-note link to [[#Some Section]], and a block-ref to
+        [[On Boundaries#^someblock|the boundary block]].
+
+        ## Some Section
+
+        Euler's identity: $e^{i\pi} + 1 = 0$.
+
+        ```python
+        # %% MARKER-IN-CODE %% - inside a fence, %% is code, not a comment
+        x = 1
+        ```
         NOTE
 
         # Named as Obsidian names things - spaces and capitals - because a
@@ -381,6 +411,63 @@
         fragment = m.group(1)
         assert f'id="{fragment}"' in served("/on-boundaries"), \
             f"fragment #{fragment} matches no id on the target page"
+
+    with subtest("callouts render as callouts, folds and all"):
+        page = served("/on-gates")
+
+        # Title and body survive, and the [!type] marker is gone rather than
+        # left as visible text inside a plain blockquote - which is the way
+        # this was broken, with a build that stayed green throughout.
+        assert 'class="callout callout-warning"' in page, page[:2000]
+        assert "Watch the gate" in page
+        assert "MARKER-CALLOUT-BODY" in page
+        assert "[!" not in page, "a callout marker was left as visible text"
+
+        # Folding follows the sign: '-' starts closed, '+' starts open, and
+        # both are <details> - collapsed in the HTML itself, not by a script.
+        # An untitled callout takes its type as the title, as in Obsidian.
+        assert re.search(r'<details class="callout callout-note">', page), \
+            "the folded callout did not start closed"
+        assert re.search(r'<details class="callout callout-tip" open>', page), \
+            "the open callout lost its open state"
+        assert ">Tip</summary>" in page
+
+        # Obsidian lets a vault define its own types; one Hugo has never heard
+        # of still renders as a callout, under its own name.
+        assert 'class="callout callout-question"' in page
+        assert "A type with no GitHub equivalent" in page
+
+    with subtest("obsidian's internal-only syntax never leaves the vault"):
+        page = served("/on-gates")
+        # %% comments are stripped before staging. Checked on the staging tree
+        # as well as the served site: this is the publish boundary, not
+        # styling, and the place to discover an aside survived is here.
+        machine.fail("grep -rq MARKER-COMMENT-SECRET /var/lib/digital-garden/content")
+        machine.fail(f"grep -rq MARKER-COMMENT-SECRET {SITE}")
+        # But %% inside a code fence is code, not a comment, and survives.
+        assert "MARKER-IN-CODE" in page, "the comment stripper reached into a code fence"
+        # Block ids are stripped with them; a survivor would be a stray
+        # caret on the page.
+        assert "markerblockid" not in page
+
+        # ==highlights== and $...$ maths render as what they mean.
+        assert "<mark>MARKER-HIGHLIGHT</mark>" in page
+        assert 'class="katex"' in page, "inline maths was not rendered"
+
+        # A same-note heading link keeps working, and a block reference drops
+        # the fragment that cannot exist rather than linking nowhere.
+        assert 'href="#some-section"' in page, "same-note heading link was not rewritten"
+        assert "the boundary block" in page
+        assert "#someblock" not in page
+
+    with subtest("maths costs a reading page nothing"):
+        # KaTeX renders at build time, so the only per-page asset is the
+        # stylesheet, and it is linked only where an equation was rendered.
+        assert "katex.min.css" in served("/on-gates"), \
+            "a page with maths did not get the KaTeX stylesheet"
+        assert "katex.min.css" not in served("/"), \
+            "the home page links KaTeX with no maths on it"
+        machine.succeed("curl -sf -o /dev/null http://localhost:8086/katex/katex.min.css")
 
     with subtest("pages carry a social card built from the note's own claim"):
         page = served("/on-gates")

--- a/modules/services/digital-garden/lib/hugo.nix
+++ b/modules/services/digital-garden/lib/hugo.nix
@@ -11,10 +11,19 @@
 # that, not against convenience. See docs/adr/ for how this was arrived at.
 #
 # What keeps this file short is that publish-filter.py already owns the hard
-# parts. The staging tree is plain CommonMark whose links carry finished URLs,
-# so this renderer does not have to understand Obsidian, resolve a wikilink, or
-# decide what a page is called. It supplies a layout and a stylesheet and gets
-# out of the way. Everything Hugo-specific is in this file and lib/hugo/.
+# parts. The staging tree's links carry finished URLs and its files are named
+# what they will be served as, so this renderer does not have to resolve a
+# wikilink or decide what a page is called. It supplies a layout and a
+# stylesheet and gets out of the way. Everything Hugo-specific is in this
+# file and lib/hugo/.
+#
+# Two Obsidian-isms DO reach the renderer, both deliberately, because Hugo's
+# parser understands them natively and any CommonMark renderer degrades them
+# gracefully: callouts (> [!type], rendered by _markup/render-blockquote.html)
+# and $...$ maths (captured by the passthrough extension and rendered to HTML
+# at build time by _markup/render-passthrough.html). KaTeX's stylesheet and
+# fonts are vendored from nixpkgs below, so a page with equations still needs
+# no JavaScript and nothing fetched from anyone else's server.
 {
   pkgs,
   lib,
@@ -68,6 +77,23 @@ in
         # script, onto a public page.
         unsafe = false
 
+        [markup.goldmark.extensions.extras.mark]
+        # Obsidian's ==highlights==. Off by default; without this the markers
+        # render as literal text.
+        enable = true
+
+        [markup.goldmark.extensions.passthrough]
+        # Captures $...$ and $$...$$ verbatim so _markup/render-passthrough.html
+        # can hand them to Hugo's embedded KaTeX instance. The delimiters are
+        # Obsidian's, which is the point: a note reads the same in both places.
+        # The cost of the inline one is Obsidian's too — a literal $ in prose
+        # between two $s is maths to both — so this changes nothing about how
+        # notes are written.
+        enable = true
+        [markup.goldmark.extensions.passthrough.delimiters]
+        block = [['$$', '$$']]
+        inline = [['$', '$']]
+
         [params]
         description = ${builtins.toJSON siteDescription}
         footerLinks = [
@@ -114,6 +140,19 @@ in
         cp "$css" "$work/assets/main.css"
         cp ${config} "$work/hugo.toml"
         chmod -R u+w "$work"
+
+        # KaTeX's stylesheet and fonts, vendored from nixpkgs and served as
+        # ordinary static files. Pages with equations render maths to HTML at
+        # build time (see _markup/render-passthrough.html), so this is ALL the
+        # reader's browser ever sees of KaTeX - no script. baseof.html links
+        # the stylesheet only on pages that used maths, so a reading page
+        # never pays for it.
+        mkdir -p "$work/static/katex"
+        cp ${pkgs.katex}/lib/node_modules/katex/dist/katex.min.css "$work/static/katex/"
+        cp -r ${pkgs.katex}/lib/node_modules/katex/dist/fonts "$work/static/katex/fonts"
+        # Store paths copy out read-only, and the exit trap's rm -rf cannot
+        # remove a read-only directory's contents.
+        chmod -R u+w "$work/static"
 
         mkdir -p "$work/content"
         cp -r "$content/." "$work/content/"

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -206,6 +206,93 @@ blockquote {
   color: var(--muted);
 }
 
+/* ── callouts ───────────────────────────────────────────────────────────── */
+
+/* Obsidian's callout syntax (> [!type], with an optional +/- fold sign and
+ * title) is rendered by layouts/_markup/render-blockquote.html. The shape is
+ * the same for every type — tinted surface, border and label in one hue —
+ * and only the hue changes, which keeps the set readable without turning the
+ * page into a patchwork. Types Obsidian treats as aliases of each other
+ * share a hue; a type this file does not know gets --accent, not an error.
+ *
+ * light-dark() keys off color-scheme, which the theme toggle sets, so each
+ * hue is named once per theme rather than remapped in a separate block. */
+.callout {
+  --callout-accent: var(--accent);
+  margin: 0 0 1rem;
+  padding: 0.6rem 1rem;
+  border-left: 3px solid var(--callout-accent);
+  border-radius: 0 5px 5px 0;
+  background: color-mix(in srgb, var(--callout-accent) 8%, transparent);
+}
+
+.callout-note,
+.callout-info,
+.callout-todo {
+  --callout-accent: light-dark(#38688c, #82a9c9);
+}
+.callout-abstract,
+.callout-summary,
+.callout-tldr {
+  --callout-accent: light-dark(#2f7a72, #6fb3aa);
+}
+.callout-tip,
+.callout-hint,
+.callout-success,
+.callout-check,
+.callout-done {
+  --callout-accent: light-dark(#3d7a44, #7fb383);
+}
+.callout-important,
+.callout-example {
+  --callout-accent: light-dark(#6c5a94, #ab9bce);
+}
+.callout-question,
+.callout-help,
+.callout-faq {
+  --callout-accent: light-dark(#8a6d2f, #c4a55f);
+}
+.callout-warning,
+.callout-caution,
+.callout-attention {
+  --callout-accent: light-dark(#a35a20, #d08a4a);
+}
+.callout-failure,
+.callout-fail,
+.callout-missing,
+.callout-danger,
+.callout-error,
+.callout-bug {
+  --callout-accent: light-dark(#a84040, #cf7a7a);
+}
+.callout-quote,
+.callout-cite {
+  --callout-accent: var(--muted);
+}
+
+/* A padded box, so the paragraph margin that would separate it from a
+ * following element is on the box instead. */
+.callout > :last-child {
+  margin-bottom: 0;
+}
+
+.callout-title {
+  margin: 0 0 0.25rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--callout-accent);
+}
+
+/* Foldable callouts are <details>: the title row is the disclosure control. */
+summary.callout-title {
+  cursor: pointer;
+  margin-bottom: 0;
+}
+
+details[open] > summary.callout-title {
+  margin-bottom: 0.25rem;
+}
+
 img {
   max-width: 100%;
   height: auto;
@@ -239,10 +326,25 @@ pre code {
   padding: 0;
 }
 
+/* Obsidian's ==highlight==, rendered by Goldmark's extras.mark extension. */
+mark {
+  padding: 0 0.1em;
+  border-radius: 2px;
+  background: light-dark(#f9e9a8, #77661f);
+  color: inherit;
+}
+
 /* Wide content must scroll inside its own box rather than making the page
  * scroll sideways. */
 .table-container {
   overflow-x: auto;
+}
+
+/* The same rule, for a display-mode equation wider than the measure. */
+.katex-display {
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 0.2rem 0;
 }
 
 table {

--- a/modules/services/digital-garden/lib/hugo/layouts/_markup/render-blockquote.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_markup/render-blockquote.html
@@ -1,0 +1,37 @@
+{{/*
+  Two kinds of blockquote reach here, and Hugo's parser has already told them
+  apart: an "alert" is the callout syntax Obsidian shares with GitHub -
+  `> [!type]`, an optional `+`/`-` fold sign, an optional title on the same
+  line - and anything else is an ordinary quotation, rendered exactly as it
+  always has been.
+
+  Folding follows Obsidian: no sign means the callout does not fold, `+`
+  means it folds and starts open, `-` means it starts closed. <details>
+  gives all three with no JavaScript, and its content is still plain HTML, so
+  the search index sees a folded callout the same as an open one.
+
+  An untitled callout takes its type as the title, as in Obsidian, so
+  `> [!note]` on its own needs nothing more.
+
+  The type is not validated against a list - Obsidian lets a vault define its
+  own callout types, and an unknown one simply gets the default accent from
+  the stylesheet, with its own name on it.
+*/}}
+{{ if eq .Type "alert" }}
+  {{ $title := .AlertTitle | default (title .AlertType) }}
+  {{ if eq .AlertSign "" }}
+    <div class="callout callout-{{ .AlertType }}">
+      <p class="callout-title">{{ $title }}</p>
+      {{ .Text }}
+    </div>
+  {{ else }}
+    <details class="callout callout-{{ .AlertType }}"{{ if eq .AlertSign "+" }} open{{ end }}>
+      <summary class="callout-title">{{ $title }}</summary>
+      {{ .Text }}
+    </details>
+  {{ end }}
+{{ else }}
+  <blockquote>
+    {{ .Text }}
+  </blockquote>
+{{ end }}

--- a/modules/services/digital-garden/lib/hugo/layouts/_markup/render-passthrough.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_markup/render-passthrough.html
@@ -1,0 +1,20 @@
+{{/*
+  Maths, captured by the passthrough extension ($...$ inline, $$...$$ block)
+  and rendered to HTML at build time by Hugo's embedded KaTeX instance. No
+  JavaScript reaches the reader: htmlAndMathml needs the KaTeX stylesheet,
+  which baseof.html links only on pages where this hook ran - the "hasMath"
+  flag below is what tells it.
+
+  An expression KaTeX cannot parse fails the build rather than printing an
+  error into the page: the last good build keeps serving until the note is
+  fixed, which is the failure posture of the rest of this toolchain.
+*/}}
+{{- $opts := dict "output" "htmlAndMathml" "displayMode" (eq .Type "block") }}
+{{- with try (transform.ToMath .Inner $opts) }}
+  {{- with .Err }}
+    {{- errorf "KaTeX could not render this expression: %s: see %s" . $.Position }}
+  {{- else }}
+    {{- .Value }}
+    {{- $.Page.Store.Set "hasMath" true }}
+  {{- end }}
+{{- end -}}

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -12,6 +12,17 @@
     {{ with resources.Get "main.css" | fingerprint }}
       <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" />
     {{ end }}
+    {{/*
+      KaTeX's stylesheet, only where an equation was rendered. .WordCount is
+      the documented noop: it forces the content - and with it the
+      render-passthrough hook that sets hasMath - to be evaluated before this
+      test, since the head is emitted before the body. Vendored rather than
+      fingerprinted because its font URLs are relative to its own location.
+    */}}
+    {{ $noop := .WordCount }}
+    {{ if .Page.Store.Get "hasMath" }}
+      <link rel="stylesheet" href="{{ "katex/katex.min.css" | relURL }}" />
+    {{ end }}
     {{ with site.Home.OutputFormats.Get "rss" }}
       <link rel="alternate" type="application/rss+xml" title="{{ site.Title }}" href="{{ .Permalink }}" />
     {{ end }}

--- a/modules/services/digital-garden/publish-filter.py
+++ b/modules/services/digital-garden/publish-filter.py
@@ -25,12 +25,21 @@ Fail-closed rules, in order of importance:
   * The staging tree is built fresh and swapped in, so a removed `publish: true`
     always disappears from the next build.
 
-Nothing Obsidian-specific reaches the generator. Wikilinks become ordinary
-Markdown links and embeds become ordinary images, so the staging tree is plain
-CommonMark whose links already carry the finished URL. That is what keeps the
-generator replaceable: it is handed files already named what they will be
-served as, pointing at each other by those names, so swapping one generator for
-another cannot silently move a page. See `slugify`.
+Nothing Obsidian-specific reaches the generator except two things Hugo's own
+parser understands, chosen so any CommonMark renderer degrades them
+gracefully: callouts (> [!type], a blockquote either way) and $...$ maths
+(captured by the passthrough extension). Everything else is rewritten here.
+Wikilinks become ordinary Markdown links and embeds become ordinary images,
+so the staging tree's links already carry the finished URL. That is what
+keeps the generator replaceable: it is handed files already named what they
+will be served as, pointing at each other by those names, so swapping one
+generator for another cannot silently move a page. See `slugify`.
+
+Obsidian's internal-only syntax is stripped rather than rendered: %% comments
+and ^block identifiers never leave the vault. A link to a block
+([[Note#^id]]) drops its fragment, because the id it names does not survive;
+a link to a heading in the same note ([[#Heading]]) is rewritten to an
+ordinary fragment link. See OBSIDIAN_INTERNAL and `rewrite`.
 
 Published notes are FLATTENED to the root of the staging tree, so the site's
 URLs are `/some-essay/` rather than `/whatever-folder/some-essay/`. The vault's
@@ -99,10 +108,25 @@ from pathlib import Path
 import yaml
 
 FRONTMATTER = re.compile(r"\A---\n(.*?)\n---\n", re.S)
-# (?!\() rejects [[1]](url) — pasted Wikipedia prose is full of these
-LINK = re.compile(r"(!?)\[\[([^\]|#]+)(#[^\]|]*)?(?:\|([^\]]*))?\]\](?!\()")
+# (?!\() rejects [[1]](url) — pasted Wikipedia prose is full of these.
+# The target may be empty, which is Obsidian's same-note link: [[#Heading]].
+LINK = re.compile(r"(!?)\[\[([^\]|#]*)(#[^\]|]*)?(?:\|([^\]]*))?\]\](?!\()")
 # deliberately not a YAML parser: we accept exactly one literal spelling
 PUBLISH_TRUE = re.compile(r"^publish:\s*true\s*(?:#.*)?$", re.M | re.I)
+# Obsidian's internal annotations, matched in one alternation so that code
+# wins over everything: a fenced block or an inline span is kept whole, while
+# a %% comment or a trailing ^block-id is dropped. The comment pattern needs
+# its closing %% — an unclosed marker is left alone, because Obsidian's
+# comment-to-end-of-file rule would let one stray keystroke delete half a
+# published note. Fences are backtick-only; tilde fences are rare enough that
+# treating their contents as prose is the acceptable failure.
+OBSIDIAN_INTERNAL = re.compile(
+    r"(^`{3,}[^\n]*\n.*?^`{3,}[ \t]*$)"  # fenced code block — kept
+    r"|(`+[^`\n]*`+)"  # inline code span — kept
+    r"|%%.*?%%"  # comment — dropped
+    r"| ?\^[A-Za-z0-9-]+[ \t]*$",  # block identifier — dropped
+    re.M | re.S,
+)
 # The first thing in the body, if it is an ATX H1. Setext underlining is not
 # matched: Obsidian does not produce it and guessing costs more than it saves.
 LEADING_H1 = re.compile(r"\A\s*#[ \t]+(.+?)[ \t]*\n+")
@@ -375,10 +399,25 @@ def main(argv):
                 return alias or target          # embed of something not shipping
             used_attachments[hit] = True
             return f"![{alias or ''}](/{ATTACHMENTS}/{slugify(hit.name)})"
-        if key in published:
+        # A fragment naming a block rather than a heading points at an id
+        # that is stripped below, so the link drops it rather than landing
+        # nowhere.
+        anchor = ""
+        if heading and not heading[1:].startswith("^"):
             # A heading fragment follows the generator's rule, not ours - see
             # `anchorize` for why those are two different things.
-            anchor = f"#{anchorize(heading[1:])}" if heading else ""
+            anchor = f"#{anchorize(heading[1:])}"
+        if not key:
+            # [[#Heading]] - Obsidian resolves an empty target against the
+            # note holding the link, and a bare fragment does the same here.
+            # A block reference in the same note has nothing left to point
+            # at, so it becomes plain text like any other unshippable target.
+            if not heading:
+                return m.group(0)               # [[]] - not a link at all
+            if anchor:
+                return f"[{alias or heading[1:]}]({anchor})"
+            return alias or heading[1:].lstrip("^")
+        if key in published:
             return f"[{alias or target}](/{slugify(published[key][0].stem)}/{anchor})"
         return alias or target                  # link to an unpublished note
 
@@ -446,6 +485,12 @@ def main(argv):
         heading = LEADING_H1.match(body)
         if heading:
             body = body[heading.end() :]
+
+        # Obsidian's internal annotations - %% comments and ^block ids -
+        # never leave the vault. One pass, so that code (fenced or inline) is
+        # never touched by it.
+        body = OBSIDIAN_INTERNAL.sub(lambda m: m.group(1) or m.group(2) or "", body)
+
         # Always explicit, because the file is about to be renamed to its slug
         # and a generator falling back to the filename for a title would then
         # show "building-capability" where it used to show "Building


### PR DESCRIPTION
## Why

The Hugo migration kept wikilinks and embeds working (publish-filter.py rewrites them) but dropped the rest of the Obsidian surface. On `garden.gyarmathy.co` today:

- **Callouts** render as plain blockquotes with a literal `[!note]` visible on the page
- **`==highlights==`** and **`$maths$`** render as literal text
- **`%% comments %%`** — internal annotations by definition — ship *verbatim to the public site*
- **`^block-ids`** show as stray carets; `[[Note#^id]]` links to a fragment that doesn't exist; same-note `[[#Heading]]` links render as literal brackets

The goal is that published notes are written exactly as internal notes are.

## How

No custom renderer — everything is either a Hugo-native feature or a small filter rewrite:

| Feature | Mechanism |
| --- | --- |
| Callouts | `layouts/_markup/render-blockquote.html` — Hugo's parser natively detects any `[!type]`, the sign-line title, and the `+`/`-` fold sign. Folding maps to `<details>` (matches Obsidian, no JS). Per-type hues via `light-dark()`; unknown types render with their own name and the default accent. |
| `==highlights==` | One config line: Goldmark's `extras.mark` extension. |
| `$…$` / `$$…$$` maths | Goldmark `passthrough` extension + `render-passthrough.html` → `transform.ToMath` renders **at build time** via Hugo's embedded KaTeX. Stylesheet + fonts vendored from `pkgs.katex` into `static/`; `baseof.html` links the CSS only on pages with maths. Zero reader-side JS; nothing fetched from anyone else's server. Unparseable TeX fails the build (old site keeps serving) rather than publishing an error message. |
| `%% comments %%`, `^block-ids` | Stripped in publish-filter.py in a single pass that never reaches into fenced or inline code. An *unclosed* `%%` is deliberately left literal — Obsidian's comment-to-EOF rule would let one stray keystroke silently delete half a published note. |
| `[[Note#^id]]`, `[[#Heading]]` | Block-ref links drop the fragment (the id can't survive); same-note heading links rewrite to fragment links. |

Staging stays honest about its contract: the tree's links and filenames remain generator-independent; callouts and maths are the two deliberate exceptions, both valid CommonMark that any renderer degrades gracefully (docstrings updated accordingly).

## Verification

- `nix build .#checks.x86_64-linux.digital-garden` — VM test extended with fixtures/assertions for all of the above: callout markup + fold states, `[!` absent, `<mark>`, `class="katex"`, comment marker absent from **both** staging tree and served site, `%%` in a code fence survives, KaTeX CSS absent from maths-free pages. **Passed.**
- `nix flake check` — **passed.**
- `nix build .#nixosConfigurations.homelab01.config.system.build.toplevel` — **passed.**
- `nix run .#garden-preview -- --once` against a fixture vault — output inspected by hand.

## Notes for review

- Two new template files are the whole rendering change; the filter diff is ~40 lines.
- Inline `$…$` means a literal `$` between two `$`s in prose is maths — same interpretation as Obsidian, so no change to how notes are written.
- Tilde (`~~~`) fences aren't protected from comment stripping (backtick fences and inline code are); noted in the regex comment.
- RSS carries KaTeX HTML without the stylesheet; feed readers fall back to the embedded MathML.
- Deploy picks this up automatically: the renderer path is in `buildInputsId`, so the next timer tick rebuilds an untouched vault.