### PR TITLE
feat(digital-garden): event-driven rebuilds and sync-health monitoring

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -46,6 +46,10 @@ in
       '';
 
   digital-garden = testLib.mkTest ./digital-garden.nix;
+  digital-garden-sync-health = import ./digital-garden-sync-health.nix {
+    inherit pkgs;
+    lib = pkgs.lib;
+  };
   monitoring = testLib.mkTest ./monitoring.nix;
   reverse-proxy = testLib.mkTest ./reverse-proxy.nix;
   upgrade-verify = testLib.mkTest ./upgrade-verify.nix;

--- a/checks/digital-garden-sync-health.nix
+++ b/checks/digital-garden-sync-health.nix
@@ -1,0 +1,67 @@
+# The sync-health exporter parses obsidian-headless's sync.log for the last
+# "Fully synced" timestamp. Its whole purpose is a positive signal for "sync is
+# still working", and its characteristic failure is silent: if the log format
+# moves under us (a proprietary, auto-updating package), the exporter finds
+# nothing and quietly stops exporting, and the alert quietly stops firing. This
+# check runs the real script against a fixture, so a change to the format, or a
+# break in the script's parsing, fails here rather than in production.
+{ pkgs, lib }:
+let
+  syncHealth = import ../modules/services/digital-garden/lib/sync-health.nix {
+    inherit pkgs lib;
+    stateDir = "/var/lib/digital-garden";
+    hostName = "test";
+  };
+
+  # The last "Fully synced" line is 2026-08-01T00:00:01Z.
+  logWithSync = pkgs.writeText "sync.log" ''
+    [2026-08-01T00:00:00.000Z] Downloading notes/a.md
+    [2026-08-01T00:00:01.000Z] Fully synced
+    [2026-08-02T00:00:00.000Z] Waiting to connect to server
+  '';
+
+  # Newer than logWithSync, for the "newest vault wins" case.
+  logNewer = pkgs.writeText "sync.log" ''
+    [2026-08-03T00:00:00.000Z] Fully synced
+  '';
+
+  # No "Fully synced" line at all.
+  logNoSync = pkgs.writeText "sync.log" ''
+    [2026-08-01T00:00:00.000Z] Waiting to connect to server
+  '';
+in
+pkgs.runCommand "check-digital-garden-sync-health" {
+  nativeBuildInputs = [ syncHealth ];
+} ''
+  set -euo pipefail
+  fixture=$(mktemp -d)
+  metrics=$(mktemp -d)
+  metric="$metrics/digital_garden_sync.prom"
+
+  # The exporter globs <syncDir>/*/sync.log, mirroring the real layout
+  # <stateDir>/obsidian/obsidian-headless/sync/<vaultId>/sync.log.
+  # Case 1: a "Fully synced" line becomes a metric with the right epoch.
+  mkdir -p "$fixture/sync/vault-abc"
+  cp ${logWithSync} "$fixture/sync/vault-abc/sync.log"
+  DIGITAL_GARDEN_SYNC_DIR="$fixture/sync" DIGITAL_GARDEN_METRICS_DIR="$metrics" digital-garden-sync-health
+  expected=$(date -d '2026-08-01T00:00:01.000Z' +%s)
+  got=$(sed -nE 's/^digital_garden_sync_last_ok_timestamp_seconds\{host="test"\} ([0-9]+)$/\1/p' "$metric")
+  test "$got" = "$expected" || { echo "case 1: expected $expected, got '$got'" >&2; exit 1; }
+
+  # Case 2: the newest "Fully synced" across vaults wins.
+  mkdir -p "$fixture/sync/vault-newer"
+  cp ${logNewer} "$fixture/sync/vault-newer/sync.log"
+  DIGITAL_GARDEN_SYNC_DIR="$fixture/sync" DIGITAL_GARDEN_METRICS_DIR="$metrics" digital-garden-sync-health
+  expected=$(date -d '2026-08-03T00:00:00.000Z' +%s)
+  got=$(sed -nE 's/^digital_garden_sync_last_ok_timestamp_seconds\{host="test"\} ([0-9]+)$/\1/p' "$metric")
+  test "$got" = "$expected" || { echo "case 2: expected $expected, got '$got'" >&2; exit 1; }
+
+  # Case 3: no "Fully synced" line -> fail open, no metric file at all.
+  rm -rf "$fixture" "$metrics"
+  mkdir -p "$fixture/sync/vault-abc"
+  cp ${logNoSync} "$fixture/sync/vault-abc/sync.log"
+  DIGITAL_GARDEN_SYNC_DIR="$fixture/sync" DIGITAL_GARDEN_METRICS_DIR="$metrics" digital-garden-sync-health
+  test ! -e "$metric" || { echo "case 3: expected no metric file" >&2; exit 1; }
+
+  touch "$out"
+''

--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -185,6 +185,7 @@
     };
 
   testScript = ''
+    import datetime as dt
     import json
     import re
 
@@ -199,9 +200,10 @@
     with subtest("the builder runs to completion offline"):
         # Started explicitly rather than waited for: the unit is a
         # Type=oneshot without RemainAfterExit, so it reads inactive the
-        # moment it succeeds, and the minutely timer makes "has it run yet"
-        # a race. This also asserts a *second* run is clean, since the timer
-        # has almost certainly fired once already.
+        # moment it succeeds. The fallback timer is 15 minutes, and the watcher
+        # only fires on a change, so neither is a dependable first trigger here.
+        # This also asserts a *second* run is clean, since the watcher may have
+        # fired once already.
         machine.succeed("systemctl start digital-garden-build.service")
         # index.html, not the stylesheet: Hugo fingerprints its CSS, so the
         # stylesheet has no fixed name to test for. It is checked by URL below,
@@ -530,5 +532,32 @@
         # styled 404; without the handler Caddy answers with an empty one.
         machine.fail("curl -sf http://localhost:8086/no-such-note")
         assert len(machine.succeed("curl -s http://localhost:8086/no-such-note")) > 1000
+
+    with subtest("a change to the vault triggers a rebuild without the timer"):
+        # The inotify watcher, not a timer, is what publishes a change. A new
+        # published note must reach the served site with nobody starting the
+        # builder by hand: the watcher notices the write, the path unit fires
+        # the build, and the 5s debounce collapses the burst.
+        machine.wait_for_unit("digital-garden-watch.service")
+        # Give inotifywait a moment to have its recursive watches established
+        # before writing, so the event is not missed on a cold start.
+        machine.sleep(duration=dt.timedelta(seconds=2))
+
+        machine.succeed(
+            "cat > /var/lib/digital-garden/vault/essays/on-triggers.md <<'NOTE'\n"
+            "---\n"
+            "publish: true\n"
+            "thesis: A note that appears without a timer.\n"
+            "---\n\n"
+            "# On Triggers\n\n"
+            "MARKER-TRIGGERED-BODY\n"
+            "NOTE"
+        )
+
+        # 5s debounce + a couple of seconds to build; 60s is generous for a VM.
+        machine.wait_until_succeeds(
+            "curl -sf http://localhost:8086/on-triggers | grep -q MARKER-TRIGGERED-BODY",
+            timeout=dt.timedelta(seconds=60),
+        )
   '';
 }

--- a/hosts/homelab01/default.nix
+++ b/hosts/homelab01/default.nix
@@ -116,6 +116,12 @@
         "/var/lib/postgresql"
         "/var/lib/kavita"
         "/var/lib/recyclarr"
+
+        # Digital garden publication dates. The vault, staging and built site
+        # all regenerate from Obsidian Sync / the filter, but dates.json records
+        # the first day each note was published and exists nowhere else. Back up
+        # only this file: the deploy-key and sync state must not leave the host.
+        "/var/lib/digital-garden/dates.json"
       ];
 
       extraExclude = [

--- a/modules/services/digital-garden/digital-garden.nix
+++ b/modules/services/digital-garden/digital-garden.nix
@@ -6,8 +6,12 @@
 # - Static output served by Caddy, exposed like any other service
 #
 # Architecture:
-# - Timer -> oneshot builder. The builder obtains the vault, filters it down to
-#   published notes, then runs the site generator over the filtered tree.
+# - An inotify watcher (digital-garden-watch.service) watches the vault and, a
+#   few seconds after the last write, signals the builder through a trigger file
+#   and a path unit. A slow fallback timer stays as a safety net.
+# - The oneshot builder obtains the vault (fetching it only when source = "git"),
+#   filters it down to published notes, then runs the site generator over the
+#   filtered tree.
 # - Serving is plain HTTP on 127.0.0.1:<port>, which lets this slot into
 #   cg.service.reverse-proxy.services (TLS + LAN) and
 #   cg.service.cloudflare-tunnel.services (public) with no special casing.
@@ -20,12 +24,19 @@
 # Either way the whole vault lands on disk and is filtered afterwards, so the
 # publish boundary below is unchanged.
 #
-# The timer fires often (default: minutely) because a run is normally a no-op.
-# Two gates stand in front of the build: a stat-only walk of the vault, and a
-# content hash of the filtered tree. Editing a private note clears the first and
-# stops at the second; touching nothing stops at the first. Both fold in a hash
-# of the build inputs, so a Hugo upgrade or an option change still forces a
-# rebuild of an otherwise untouched vault.
+# The build is triggered by an inotify watcher (digital-garden-watch.service)
+# that watches the vault and, a few seconds after the last write, signals the
+# builder through a trigger file and a path unit. A path unit cannot watch
+# subdirectories recursively, which is why the watcher exists. The fallback
+# timer stays because inotify can drop events on queue overflow, and a change
+# that lands while a build is already running would otherwise be missed - the
+# timer's interval is the worst-case publish latency.
+#
+# A run is normally a no-op. Two gates stand in front of the build: a stat-only
+# walk of the vault, and a content hash of the filtered tree. Editing a private
+# note clears the first and stops at the second; touching nothing stops at the
+# first. Both fold in a hash of the build inputs, so a Hugo upgrade or an option
+# change still forces a rebuild of an otherwise untouched vault.
 #
 # ════════════════════════════════════════════════════════════════════════════
 # The publish boundary
@@ -231,6 +242,40 @@ let
       echo "$vault_id" > "$vault_stamp"
     '';
   };
+
+  watchScript = pkgs.writeShellApplication {
+    name = "digital-garden-watch";
+    runtimeInputs = [
+      pkgs.inotify-tools
+      pkgs.coreutils
+    ];
+    text = ''
+      set -euo pipefail
+
+      # The vault does not exist until digital-garden-vault-setup has run once
+      # and the sync service has fetched it; wait for it rather than fail.
+      while [ ! -d "${vaultDir}" ]; do
+        echo "digital-garden-watch: waiting for ${vaultDir}" >&2
+        sleep 10
+      done
+
+      # Watch the vault only - never the state directory, where the builder
+      # itself writes, or a build would trigger another build forever. Dotfiles
+      # are excluded to match publish-filter.py, so Obsidian's own churn in
+      # .obsidian does not rebuild the site continuously.
+      inotifywait -q -m -r -e modify,create,delete,move,close_write \
+        --exclude '/\.' "${vaultDir}" \
+        | while read -r _; do
+            # A single logical change arrives as several events, and Obsidian
+            # Sync delivers a burst over a few seconds. Wait for the burst to
+            # settle before signalling, so a multi-file edit is built once, not
+            # once per file. Writing a timestamp (rather than touching) makes
+            # sure the path unit's PathModified sees it.
+            while read -r -t 5 _; do :; done
+            date +%s > "${stateDir}/trigger"
+          done
+    '';
+  };
 in
 {
   options.cg.service.digital-garden = {
@@ -320,19 +365,20 @@ in
 
     schedule = lib.mkOption {
       type = lib.types.str;
-      default = "minutely";
+      default = "*:0/15";
       description = ''
-        systemd OnCalendar expression for rebuild checks.
+        systemd OnCalendar expression for the fallback rebuild timer.
 
-        This is a check, not a rebuild: a run whose vault is untouched does a
-        stat-only walk and exits, and one that changed only unpublished notes
-        stops after the filter. Hugo runs only when the published set actually
-        moved, so a short interval costs very little and caps publish latency at
-        roughly one interval.
+        The primary trigger is an inotify watcher (see digital-garden-watch),
+        which rebuilds within seconds of a change. This timer is the safety net
+        for what the watcher can miss: inotify events dropped on queue overflow,
+        and a change that lands while a build is already running. Its interval
+        is the worst case such a change waits to publish.
 
-        A systemd.path unit would be the obvious event-driven alternative, but
-        path units do not watch subdirectories recursively, which is useless for
-        a vault with folders in it.
+        With source = "git" there is no watcher - nothing writes the vault
+        between runs - so this timer is the trigger and its interval is publish
+        latency. Set it back to "minutely" there if you want sub-minute
+        publishing.
       '';
     };
 
@@ -413,7 +459,7 @@ in
 
     systemd.tmpfiles.rules = [
       "d ${stateDir} 0750 digital-garden digital-garden -"
-    ];
+    ] ++ lib.optional (cfg.source == "obsidian-sync") "f ${stateDir}/trigger 0644 digital-garden digital-garden -";
 
     systemd.services.digital-garden-build = {
       description = "Build the digital garden from published vault notes";
@@ -467,7 +513,7 @@ in
     };
 
     systemd.timers.digital-garden-build = {
-      description = "Rebuild the digital garden";
+      description = "Fallback rebuild trigger for the digital garden";
       wantedBy = [ "timers.target" ];
       timerConfig = {
         OnCalendar = cfg.schedule;
@@ -475,6 +521,58 @@ in
         # No RandomizedDelaySec: this is a cheap check that usually exits within
         # a second, and jitter here is just latency between writing a note and
         # seeing it published. There is nothing to spread the load of.
+      };
+    };
+
+    # ── Event-driven trigger (inotify) ──────────────────────────────────────
+    # A path unit cannot watch subdirectories recursively, which is useless for
+    # a vault with folders in it, so the watcher does the recursive part with
+    # inotify and the path unit only watches a single trigger file. The watcher
+    # is unprivileged and cannot start the builder itself; writing the trigger
+    # lets the (root-managed) path unit do that with no polkit rules.
+    systemd.services.digital-garden-watch = lib.mkIf (cfg.source == "obsidian-sync") {
+      description = "Watch the digital garden vault and trigger rebuilds";
+      after = [ "local-fs.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        User = "digital-garden";
+        Group = "digital-garden";
+        StateDirectory = "digital-garden";
+        WorkingDirectory = stateDir;
+        ExecStart = lib.getExe watchScript;
+        Restart = "always";
+        RestartSec = 10;
+
+        # Same hardening as the builder: it reads a private vault, so it gets
+        # the filesystem and nothing else. It watches files and writes one
+        # trigger, so there is no network to allow at all.
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictSUIDSGID = true;
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        SystemCallFilter = [ "@system-service" ];
+        SystemCallArchitectures = "native";
+        RestrictAddressFamilies = [ "AF_UNIX" ];
+        ReadWritePaths = [ stateDir ];
+      };
+    };
+
+    systemd.paths.digital-garden-build = lib.mkIf (cfg.source == "obsidian-sync") {
+      description = "Trigger a digital garden build when the vault changes";
+      wantedBy = [ "paths.target" ];
+      pathConfig = {
+        PathModified = "${stateDir}/trigger";
+        Unit = "digital-garden-build.service";
       };
     };
 

--- a/modules/services/digital-garden/digital-garden.nix
+++ b/modules/services/digital-garden/digital-garden.nix
@@ -102,6 +102,14 @@ let
   stateDir = "/var/lib/digital-garden";
   vaultDir = "${stateDir}/vault";
 
+  # Exports the "is Obsidian Sync still completing cycles?" positive signal for
+  # Prometheus. Lives under ./lib so the check in checks/ can run the same
+  # script against a fixture. See lib/sync-health.nix.
+  syncHealth = import ./lib/sync-health.nix {
+    inherit pkgs lib stateDir;
+    hostName = config.networking.hostName;
+  };
+
   # Identifies everything that can change the generated site other than the
   # notes themselves. Folded into the build stamp so that a Hugo upgrade or a
   # changed option rebuilds even when the vault is untouched — otherwise the
@@ -459,7 +467,8 @@ in
 
     systemd.tmpfiles.rules = [
       "d ${stateDir} 0750 digital-garden digital-garden -"
-    ] ++ lib.optional (cfg.source == "obsidian-sync") "f ${stateDir}/trigger 0644 digital-garden digital-garden -";
+    ] ++ lib.optional (cfg.source == "obsidian-sync") "f ${stateDir}/trigger 0644 digital-garden digital-garden -"
+      ++ lib.optional (cfg.source == "obsidian-sync") "d /var/lib/prometheus-node-exporter 0755 root root -";
 
     systemd.services.digital-garden-build = {
       description = "Build the digital garden from published vault notes";
@@ -573,6 +582,32 @@ in
       pathConfig = {
         PathModified = "${stateDir}/trigger";
         Unit = "digital-garden-build.service";
+      };
+    };
+
+    # ── Sync health for Prometheus ───────────────────────────────────────────
+    # The builder failing is caught by DigitalGardenBuildFailed, but a sync that
+    # quietly stops delivering (expired token, deleted remote) leaves the
+    # service running and the site silently ageing, invisible to both the
+    # builder and the HTTP probe. This exports the age of the last completed
+    # sync cycle as a textfile metric, so DigitalGardenSyncStale can alert on
+    # its absence. Runs as root like every other exporter in this fleet; the
+    # metric is only scraped when cg.service.monitoring is enabled.
+    systemd.services.digital-garden-sync-health = lib.mkIf (cfg.source == "obsidian-sync") {
+      description = "Export Obsidian Sync health for Prometheus";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = lib.getExe syncHealth;
+      };
+    };
+
+    systemd.timers.digital-garden-sync-health = lib.mkIf (cfg.source == "obsidian-sync") {
+      description = "Timer for Obsidian Sync health export";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "2min";
+        OnUnitActiveSec = "15min";
+        Unit = "digital-garden-sync-health.service";
       };
     };
 

--- a/modules/services/digital-garden/lib/sync-health.nix
+++ b/modules/services/digital-garden/lib/sync-health.nix
@@ -1,0 +1,74 @@
+# Exports the "is Obsidian Sync still completing cycles?" positive signal as a
+# node_exporter textfile metric. See the header of digital-garden.nix and the
+# DigitalGardenSyncStale alert for why this exists.
+#
+# The obsidian-headless client tees its console output to
+# <stateDir>/obsidian/obsidian-headless/sync/<vault>/sync.log, one timestamped
+# line per event, and logs "Fully synced" only after a cycle that connected to
+# the server and reached steady state - about every 30s when healthy. The age
+# of the newest such line is therefore a positive signal that sync is working
+# (as opposed to a guess like "the vault mtime is old"), and exporting it lets
+# Prometheus alert on its absence.
+#
+# Fail-open: when there is no "Fully synced" line yet (sync not set up, or a
+# future obsidian-headless moved the message), nothing is emitted, so the alert
+# cannot fire on a guess. The reason is written to the journal instead.
+{
+  pkgs,
+  lib,
+  stateDir,
+  hostName,
+}:
+pkgs.writeShellApplication {
+  name = "digital-garden-sync-health";
+  runtimeInputs = [
+    pkgs.coreutils
+    pkgs.gnugrep
+    pkgs.gnused
+  ];
+  text = ''
+    # Overridable so the check in checks/ can point these at a fixture.
+    METRICS_DIR="''${DIGITAL_GARDEN_METRICS_DIR:-/var/lib/prometheus-node-exporter}"
+    SYNC_LOG_DIR="''${DIGITAL_GARDEN_SYNC_DIR:-${stateDir}/obsidian/obsidian-headless/sync}"
+    METRICS_FILE="$METRICS_DIR/digital_garden_sync.prom"
+    HOST="${hostName}"
+
+    mkdir -p "$METRICS_DIR"
+
+    latest=0
+    found=0
+    if [ -d "$SYNC_LOG_DIR" ]; then
+      for log in "$SYNC_LOG_DIR"/*/sync.log; do
+        [ -e "$log" ] || continue
+        # tac + quit-on-first-match finds the last "Fully synced" line without
+        # reading the whole (append-only, ever-growing) log. The line looks
+        # like "[2026-08-24T12:34:56.789Z] Fully synced".
+        ts=$(tac "$log" 2>/dev/null | sed -nE '/^\[[^]]+\] Fully synced$/{s/^\[([^]]+)\].*/\1/p;q}' || true)
+        if [ -n "$ts" ]; then
+          epoch=$(date -d "$ts" +%s 2>/dev/null || true)
+          if [ -n "$epoch" ]; then
+            found=1
+            if [ "$epoch" -gt "$latest" ]; then
+              latest=$epoch
+            fi
+          fi
+        fi
+      done
+    fi
+
+    if [ "$found" -eq 1 ]; then
+      cat > "$METRICS_FILE.tmp" <<EOF
+# HELP digital_garden_sync_last_ok_timestamp_seconds Unix timestamp of the last completed Obsidian Sync cycle
+# TYPE digital_garden_sync_last_ok_timestamp_seconds gauge
+digital_garden_sync_last_ok_timestamp_seconds{host="$HOST"} $latest
+EOF
+      mv "$METRICS_FILE.tmp" "$METRICS_FILE"
+    else
+      # Fail open: no data yet, or the log format moved under us. Emit nothing
+      # so the alert cannot fire on a guess; the journal carries the reason for
+      # whoever looks.
+      echo "digital-garden-sync-health: no 'Fully synced' timestamp found under $SYNC_LOG_DIR" >&2
+      rm -f "$METRICS_FILE"
+    fi
+  '';
+}

--- a/modules/services/digital-garden/publish-filter.py
+++ b/modules/services/digital-garden/publish-filter.py
@@ -107,6 +107,15 @@ from pathlib import Path
 
 import yaml
 
+# The libyaml-backed loader when it is available, the pure-Python one otherwise.
+# Both implement the SafeLoader schema, so this is a speed choice with no
+# semantic difference - the filter must not get faster at the cost of reading a
+# different YAML than before.
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:  # pragma: no cover
+    from yaml import SafeLoader
+
 FRONTMATTER = re.compile(r"\A---\n(.*?)\n---\n", re.S)
 # (?!\() rejects [[1]](url) — pasted Wikipedia prose is full of these.
 # The target may be empty, which is Obsidian's same-note link: [[#Heading]].
@@ -270,7 +279,7 @@ def split_frontmatter(text):
     if not m:
         return None
     try:
-        front = yaml.safe_load(m.group(1))
+        front = yaml.load(m.group(1), Loader=SafeLoader)
     except yaml.YAMLError:
         return None
     if not isinstance(front, dict):

--- a/modules/services/monitoring/alert-rules.yml
+++ b/modules/services/monitoring/alert-rules.yml
@@ -98,6 +98,19 @@ groups:
           summary: "Service unreachable"
           description: "{{ $labels.instance }} has been down for 5+ minutes"
 
+      # The blackbox probe keeps reading 200 while this is failing, because
+      # Caddy serves the last good build. A failed builder is otherwise
+      # invisible: the site silently ages. Distinct from the generic
+      # SystemdUnitFailed rule only so the message points at the right unit.
+      - alert: DigitalGardenBuildFailed
+        expr: node_systemd_unit_state{name="digital-garden-build.service", state="failed"} == 1
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Digital garden build failed on {{ $labels.instance }}"
+          description: "digital-garden-build.service is in failed state, so the site is serving the last good build. Check with: journalctl -u digital-garden-build"
+
   - name: infrastructure
     rules:
       # Auto-upgrade failures

--- a/modules/services/monitoring/alert-rules.yml
+++ b/modules/services/monitoring/alert-rules.yml
@@ -111,6 +111,21 @@ groups:
           summary: "Digital garden build failed on {{ $labels.instance }}"
           description: "digital-garden-build.service is in failed state, so the site is serving the last good build. Check with: journalctl -u digital-garden-build"
 
+      # A sync that quietly stops delivering leaves the service running and the
+      # site silently ageing: the builder keeps exiting 0 ("nothing to do") and
+      # the probe keeps reading 200. This is the positive signal for it -
+      # obsidian-headless logs "Fully synced" on every completed cycle (see
+      # digital-garden-sync-health), and its absence for 6 hours means sync is
+      # no longer completing, whatever the author has or has not written.
+      - alert: DigitalGardenSyncStale
+        expr: time() - digital_garden_sync_last_ok_timestamp_seconds > 21600
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Obsidian Sync has not completed a cycle on {{ $labels.host }}"
+          description: "digital-garden-sync has not logged a completed sync in over 6 hours; the garden is serving its last good build. Check: journalctl -u digital-garden-sync"
+
   - name: infrastructure
     rules:
       # Auto-upgrade failures


### PR DESCRIPTION
## Summary

Two things, plus a few small cleanups.

### Event-driven rebuilds

The garden used to poll the vault every minute (`minutely` timer) and publish whenever the stat-only gate noticed a change. It now rebuilds within ~5s of a change:

- A new `digital-garden-watch.service` watches the vault recursively with `inotifywait` (dotfiles excluded), debounces a sync burst for 5s, and writes a trigger file.
- A `digital-garden-build.path` unit turns that trigger into a build of the existing, unchanged `digital-garden-build.service`.
- The old timer stays, recast as a 15-minute fallback safety net (inotify overflow, changes landing mid-build).

Both new units are gated on `source = "obsidian-sync"` (in git mode the builder itself writes the vault and would self-trigger). Latency goes from ≤60s to ~5s + build.

### Sync-health monitoring (positive signal)

A sync that quietly stops delivering (expired token, deleted remote) previously left the site silently ageing — the builder keeps exiting 0 and the probe keeps reading 200. `obsidian-headless` logs `Fully synced` on every completed cycle, so:

- `digital-garden-sync-health` exports the age of the last completed cycle as a textfile metric.
- `DigitalGardenSyncStale` alerts when it exceeds 6 hours.

This is monitoring of existing logs — no change to the sync service or the package. The exporter fails open (emits nothing when the log format moves under us) and is covered by a `runCommand` check.

### Also

- `perf`: frontmatter is now parsed with libyaml's C loader (`CSafeLoader`, with a pure-Python fallback).
- Back up `dates.json` (publication dates exist nowhere else) to the existing restic repos.
- Alert `DigitalGardenBuildFailed` for a broken builder (the probe still reads 200 on the last good build).
- Removed a stray `__pycache__` artifact.

## Checks

- `.#checks.x86_64-linux.digital-garden` (VM test, incl. new watcher subtest) — pass
- `.#checks.x86_64-linux.digital-garden-sync-health` — pass
- `.#checks.x86_64-linux.alert-rules` (promtool) — pass
- `.#nixosConfigurations.homelab01.config.system.build.toplevel` — evaluates

## Notes for review

- The sync-health metric couples to `obsidian-headless`'s unversioned `"Fully synced"` string and `sync.log` path; the exporter check is there to catch that breaking at build time.
- Two commits touch `digital-garden.nix` and `alert-rules.yml` separately (event-driven vs sync-health / build-failure vs sync-stale) so the story is reviewable in pieces.