### PR TITLE
build(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -185,11 +185,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787487906,
-        "narHash": "sha256-zIdM+8teujHm5hc5MIPDnV7k2UeOOT/pFyFtWjOCwsY=",
+        "lastModified": 1787540599,
+        "narHash": "sha256-MHwk52ty3NsLhq9a1IbIfBJZlCUJIdiUYFo52JLK9hY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cfba7ad5886b342b8dd63ba74354b3853ea4cfc9",
+        "rev": "03f4cd46bc1dd4f3a96da778d2ce9f7ce39dd450",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1787441254,
-        "narHash": "sha256-/7oA/UPfrk0ubngvJjDleROuiNdA7y4d+5qNcDeQuCA=",
+        "lastModified": 1787505430,
+        "narHash": "sha256-Q0EAhFsvsJP9vAm+2q6zEwTWK+fm6Xbe4kOr1UKW6yc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ae9396d21aa0dcfe9419f6bdc3bf415eba30a8b7",
+        "rev": "941ede61f9ab033fbf284f859af3b7f92562b85f",
         "type": "github"
       },
       "original": {
@@ -245,11 +245,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1787360063,
-        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `flake.lock` update.

The per-host deltas below are recorded in the commit body so they
land in `git log` on merge (ADR 0001).

Each host was built at the current lock and at the updated one, and
the closures compared. All three builds passing is a precondition of
this PR existing at all — but the `nixos ci` gate still has to pass
before it can merge, and merging is what promotes `deploy`.

### homelab01

autobrr: 1.83.0 → 1.84.0, 1022.6 KiB
nixos-manual: 17.8 KiB
nixos-system-homelab01: 26.11.20260822.2c423e0 → 26.11.20260823.56c02bc
source: 169.4 KiB
tmux: 3.7b → 3.7c
unit-fail2ban.socket: (no version) added

### homelab02

initrd-linux: -25.2 KiB
nixos-manual: 17.8 KiB
nixos-system-homelab02: 26.11.20260822.2c423e0 → 26.11.20260823.56c02bc
source: 169.4 KiB
tmux: 3.7b → 3.7c
unit-fail2ban.socket: (no version) added
zfs-kernel: 2.4.3-6.18.45 → 2.4.4-6.18.45
zfs-user: 2.4.3 → 2.4.4

### xps15

discord: 1.0.153, 1.0.153-fhsenv → 1.0.154, 1.0.154-fhsenv
discord-unwrapped: 1.0.153 → 1.0.154, 2.9 MiB
ldc: 22.5 KiB
nixos-manual: 17.8 KiB
nixos-system-xps15: 26.11.20260822.2c423e0 → 26.11.20260823.56c02bc
obs-studio: 32.1.2 → 32.2.1, 233.7 KiB
onedrive: -81.2 KiB
opencode: 1.18.18 → 1.18.21, 204.0 KiB
source: 169.4 KiB
unit-fail2ban.socket: (no version) added