### PR TITLE
fix(digital-garden): survive dollar-sign prose and surface render failures

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -33,7 +33,7 @@
   nodes.machine =
     { pkgs, ... }:
     let
-      # Two published essays and a landing page; one note deliberately not
+      # Three published essays and a landing page; one note deliberately not
       # published, and one that fails to parse at all - because
       # publish-filter.py's stated rules are that publish defaults to false AND
       # that an unparseable note is skipped rather than published, and only the
@@ -109,6 +109,26 @@
         MARKER-BOUNDARIES-BODY
 
         ## A Heading, With Punctuation -- and More
+        NOTE
+
+        # Prose about money, which is the shape that took publishing down on
+        # 2026-08-25: two unrelated dollar amounts in one paragraph read as an
+        # inline maths span as far as the $...$ passthrough delimiters are
+        # concerned, and KaTeX strict mode treated the en-dash inside it -
+        # "Unrecognized Unicode character" - as a build-breaking error. It is
+        # in the initial fixture rather than added later so that the very first
+        # build has to survive it.
+        cat > $out/essays/on-money.md <<'NOTE'
+        ---
+        publish: true
+        thesis: Prose about money is not maths.
+        ---
+
+        # On Money
+
+        MARKER-MONEY-BODY
+
+        Roughly $80k on fixtures that last 5–7 years is a better position than ~$400k on fixtures that last 10+ years, because the second option locks you into decade-old technology you can no longer afford to replace.
         NOTE
 
         # A real landing page, because it is the one note whose handling is
@@ -219,7 +239,7 @@
         # the URL, and a file staged under any other name would mean the
         # generator was deciding the address after all.
         staged = sorted(machine.succeed("ls /var/lib/digital-garden/content").split())
-        assert staged == ["index.md", "on-boundaries.md", "on-gates.md"], staged
+        assert staged == ["index.md", "on-boundaries.md", "on-gates.md", "on-money.md"], staged
 
     with subtest("no unpublished content reaches the served site"):
         # Deliberately the whole tree rather than the rendered page. A leak
@@ -303,6 +323,7 @@
         for slug, marker in [
             ("on-gates", "MARKER-PUBLISHED-BODY"),
             ("on-boundaries", "MARKER-BOUNDARIES-BODY"),
+            ("on-money", "MARKER-MONEY-BODY"),
         ]:
             assert marker in served(f"/{slug}"), f"{slug} was not rendered"
 
@@ -470,6 +491,22 @@
         assert "katex.min.css" not in served("/"), \
             "the home page links KaTeX with no maths on it"
         machine.succeed("curl -sf -o /dev/null http://localhost:8086/katex/katex.min.css")
+
+    with subtest("a dollar-sign pair in prose does not fail the build"):
+        # The 2026-08-25 outage: two unrelated amounts of money in one
+        # paragraph are an inline maths span to the $...$ passthrough
+        # delimiters, and KaTeX strict mode escalated the en-dash inside it to
+        # a build error - so an ordinary sentence about cost took publishing
+        # down. strict=warn keeps genuine parse errors fatal while letting this
+        # render best-effort, which is what Obsidian shows for it too.
+        #
+        # Asserted on the note being served rather than merely the build
+        # exiting zero, because a build that skipped its pages also exits zero.
+        page = served("/on-money")
+        assert "MARKER-MONEY-BODY" in page
+        assert 'class="katex"' in page, \
+            "the accidental maths span was not rendered as maths"
+        assert "decade-old technology" in page
 
     with subtest("pages carry a social card built from the note's own claim"):
         page = served("/on-gates")

--- a/modules/services/digital-garden/lib/hugo.nix
+++ b/modules/services/digital-garden/lib/hugo.nix
@@ -164,13 +164,16 @@ in
           mv "$work/content/index.md" "$work/content/_index.md"
         fi
 
-        hugo --quiet --source "$work" --destination "$outdir"
+        # Not --quiet: this runs inside a oneshot service whose journal is the
+        # only place a failure surfaces. A quiet hugo turned "KaTeX could not
+        # render this expression" into two silent seconds and exit 1.
+        hugo --source "$work" --destination "$outdir"
 
         # Search index, built from the rendered HTML rather than from the
         # markdown, so what is searchable is exactly what is readable. Runs
         # here rather than as a separate step because a site whose index does
         # not match its pages is worse than one with no search at all.
-        pagefind --site "$outdir" --quiet
+        pagefind --site "$outdir"
       '';
     };
 }

--- a/modules/services/digital-garden/lib/hugo/layouts/_markup/render-passthrough.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_markup/render-passthrough.html
@@ -8,8 +8,17 @@
   An expression KaTeX cannot parse fails the build rather than printing an
   error into the page: the last good build keeps serving until the note is
   fixed, which is the failure posture of the rest of this toolchain.
+
+  strict=warn narrows that to genuine parse errors. The default (error) also
+  fails the build on lint-level complaints, and the one that bit was prose
+  about money: "costs $80k ... than ~$400k" is an inline maths span as far as
+  the passthrough delimiters are concerned, and the en-dash inside it is an
+  "unrecognized Unicode character" that took publishing down for a sentence
+  no one ever meant as maths. Obsidian renders such a span best-effort too,
+  so warn keeps the note reading the same in both places; a malformed
+  expression still returns .Err and still fails the build.
 */}}
-{{- $opts := dict "output" "htmlAndMathml" "displayMode" (eq .Type "block") }}
+{{- $opts := dict "output" "htmlAndMathml" "displayMode" (eq .Type "block") "strict" "warn" }}
 {{- with try (transform.ToMath .Inner $opts) }}
   {{- with .Err }}
     {{- errorf "KaTeX could not render this expression: %s: see %s" . $.Position }}


### PR DESCRIPTION
## What happened

`digital-garden-build.service` started failing on `homelab01` at 12:01 today, after a vault sync landed an edit to *Riverview Lighting Upgrade Writeup* containing:

> Roughly \$80k on fixtures that last 5–7 years is a better position than ~\$400k …

The `$...$` passthrough delimiters make that paragraph an inline maths span, and KaTeX strict mode escalated the en-dash inside it ("Unrecognized Unicode character") into a build-breaking error. The journal showed nothing but silent exit 1 because both `hugo` and `pagefind` run with `--quiet`.

The 04:15 build after the Quartz→Hugo migration had succeeded; the site kept serving that last good build throughout (the designed failure posture), so readers saw nothing.

## Changes

- `_markup/render-passthrough.html`: pass `"strict" "warn"` to `transform.ToMath`. Lint-level complaints render best-effort with a warning — which is what Obsidian shows for the same text — while genuine LaTeX parse errors still return `.Err` and still fail the build. Both postures verified against the real renderer.
- `lib/hugo.nix`: drop `--quiet` from the hugo and pagefind invocations so render/index failures reach the unit's journal instead of two silent seconds and exit 1.
- `checks/digital-garden.nix`: new published fixture note carrying exactly this dollar-pair shape, in the *initial* fixture so the first build has to survive it; wired into the exact-match staged-list and page-count assertions, plus a subtest asserting the note is served and rendered rather than merely "the build exited zero".

## Verification

- Renderer built from this branch: money-prose fixture builds with a visible `WARN`; malformed `$\frac{1}{$` still fails with the KaTeX error.
- `nix build .#checks.x86_64-linux.digital-garden` passes (40s VM run, all subtests green).

## Deployment note

Once promoted to `deploy` and pulled by the fleet, the renderer's store path change forces a rebuild via `buildInputsId`, so homelab01 recovers on its next build trigger with no manual action. No note edits required — though escaping one `$` as `\$` in that sentence will make it read as plain text instead of garbled best-effort maths.