### PR TITLE
fix(upgrade): keep the apply unit alive through its own switch

### DIFF
--- a/modules/nixos/auto-upgrade.nix
+++ b/modules/nixos/auto-upgrade.nix
@@ -157,6 +157,14 @@ in
     systemd.services.nixos-upgrade-apply = {
       description = "Apply the built NixOS configuration";
 
+      # This unit's ExecStart *is* the switch. If a promoted change touches
+      # this unit (e.g. a nixpkgs bump rewrites every ExecStart path), the
+      # switch stops it and SIGTERMs itself, aborting activation partway
+      # through and leaving stopped units down. Upstream marks its own
+      # nixos-upgrade service the same way.
+      restartIfChanged = false;
+      unitConfig.X-StopOnRemoval = false;
+
       serviceConfig = {
         Type = "oneshot";
         TimeoutStartSec = "1h";


### PR DESCRIPTION
## Problem

A manual apply on `xps15` aborted mid-switch:

```
stopping the following units: fail2ban.service, nixos-upgrade-apply.service, polkit.service, tlp.service
nixos-upgrade-apply.service: Main process exited, code=killed, status=15/TERM
```

`nixos-upgrade-apply` runs `switch-to-configuration switch` as its own main
process. Flake update #59 (nixpkgs bump) rewrote ExecStart paths across many
units, so the switch wanted to stop and restart `fail2ban`, `polkit`, `tlp` -
and the upgrade-apply unit itself. Stopping that unit SIGTERMs the process
performing the switch, so activation died partway through.

On hosts already hit by this, the system profile points at the new generation
but stopped units (`fail2ban`, `polkit`, `tlp`) stay down until a completed
switch or reboot; rebooting finishes activation cleanly.

## Fix

Mark `nixos-upgrade-apply` with `restartIfChanged = false` and
`unitConfig.X-StopOnRemoval = false` - the same treatment upstream gives its
own `nixos-upgrade` service. Switches no longer stop or restart it, whatever
the promoted diff contains. Because switch-to-configuration consults the *new*
configuration's flags, this change deploys safely through the very mechanism it
fixes.

## Validation

- `nix build .#nixosConfigurations.xps15.config.system.build.toplevel` succeeds.
- Built unit file contains `X-RestartIfChanged=false` and `X-StopOnRemoval=false`.
- VM tests do not cover this unit; behaviour verified against upstream's
  documented handling of `X-RestartIfChanged`.