### PR TITLE
feat(monitoring): severity-routed push alerts, inhibition, and a fleet status board

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,19 @@ sops secrets/homelab.yaml                   # edit
 └─────────────────────────────────────────────────────────────────┘
 ```
 
+## Alerting
+
+Prometheus evaluates the rules in `modules/services/monitoring/alert-rules.yml` on both servers; a two-node Alertmanager cluster deduplicates them. Notifications leave through two deliberately unequal lanes:
+
+- **Push (ntfy, self-hosted on homelab01).** Critical alerts arrive with urgent priority and buzz. Warnings arrive silently, repeat no more often than daily, and are muted between 22:00 and 07:00 (Australia/Perth) — read them at breakfast. Resolutions follow their alert's lane: a resolved critical lands as an ordinary-priority all-clear.
+- **Email (the archive lane).** Everything reaches it regardless of severity, grouped by alert name so a fan-out of related alerts is one message.
+
+Inhibition rules keep one root cause from fanning out into many notifications: an unreachable host suppresses every alert sourced from its exporters, a downed tunnel suppresses the probe failures it would otherwise cause, and a degraded ZFS pool supersedes the per-symptom alerts describing the same disks.
+
+The answer to "is anything wrong right now" is the **Fleet Overview** Grafana dashboard (provisioned in code): firing alerts, unreachable targets, backup and upgrade verdicts, per-host vitals. The Prometheus and Alertmanager UIs are published LAN-only (`prometheus.gyarmathy.co`, `alertmanager.gyarmathy.co`) for silences and ad-hoc queries; remotely, ssh-tunnel as before.
+
+First-deployment bootstrap for ntfy accounts and tokens is documented at the top of `modules/services/ntfy.nix`.
+
 ## Known gaps
 
 Stated plainly, because a pipeline whose limits are undocumented invites more trust than it has earned:

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -45,6 +45,55 @@ in
         touch $out
       '';
 
+  # Same idea for the Alertmanager side: routing, inhibition and muting are
+  # assembled by monitoring.nix from options, and a structural mistake there
+  # surfaces only when alertmanager refuses to start - on the machines whose
+  # job is to notice that everything else stopped. This evaluates the
+  # configuration exactly as a production host would receive it (every
+  # routing feature switched on) and hands it to amtool. JSON is valid YAML,
+  # which saves generating YAML by hand; the sops secret *paths* embedded in
+  # the config are checked structurally, never read.
+  alertmanager-config =
+    let
+      eval = inputs.nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          inputs.sops-nix.nixosModules.sops
+          ../modules/services/monitoring/monitoring.nix
+          (
+            { ... }:
+            {
+              cg.service.monitoring = {
+                enable = true;
+                alertmanager = {
+                  enable = true;
+                  ntfy.enable = true;
+                  email = {
+                    to = "root@example.com";
+                    from = "alerts@example.com";
+                    authUsername = "alerts";
+                  };
+                };
+                scrapeTargets = [ "localhost:9100" ];
+                cloudflaredTarget = "localhost:20241";
+              };
+            }
+          )
+        ];
+      };
+    in
+    pkgs.runCommand "check-alertmanager-config"
+      {
+        nativeBuildInputs = [ pkgs.prometheus-alertmanager ];
+        passAsFile = [ "amConfig" ];
+        amConfig = builtins.toJSON eval.config.services.prometheus.alertmanager.configuration;
+      }
+      ''
+        amtool check-config "$amConfigPath" | tee amtool.out
+        grep -q SUCCESS amtool.out
+        mkdir $out
+      '';
+
   digital-garden = testLib.mkTest ./digital-garden.nix;
   digital-garden-sync-health = import ./digital-garden-sync-health.nix {
     inherit pkgs;

--- a/checks/monitoring.nix
+++ b/checks/monitoring.nix
@@ -23,44 +23,126 @@
 # default is `null` and monitoring.nix drops it into a static_configs target
 # list unconditionally. Both hosts set it, so the null path is unreachable in
 # production - it is called out so that this test is not blamed for it later.
+#
+# The last two subtests cover the alerting side. Routing, inhibition and the
+# ntfy bridge are assembled from options just like the scrape configs are, and
+# their failure modes are equally silent: a wrong matcher means an alert that
+# never notifies anyone. Synthetic alerts are injected straight into the
+# Alertmanager API - bypassing rule evaluation, which the promtool/rule-loading
+# checks already cover - and asserted against what lands in ntfy's cache.
+#
+# This test raises globalTimeout because the warning-severity route carries a
+# deliberate 5m group_wait: most warnings clear themselves before they are
+# worth reading, and asserting delivery means waiting out that grace period.
 {
   name = "monitoring";
 
-  nodes.machine = {
-    imports = [
-      ../modules/services/monitoring/monitoring.nix
-      ../modules/services/monitoring/deploy-metrics.nix
-    ];
+  # See header. Default is 600 (checks/lib.nix). Boot, the scrape subtests'
+  # worst-case waits and both lanes' grace periods fit in twenty minutes.
+  globalTimeout = 1200;
 
-    cg.service.monitoring = {
-      enable = true;
-      prometheus.enable = true;
+  nodes.machine =
+    { lib, ... }:
+    {
+      imports = [
+        ../modules/services/monitoring/monitoring.nix
+        ../modules/services/monitoring/deploy-metrics.nix
 
-      # Scrape this machine's own node_exporter. A real target, so `up` means
-      # the scrape loop genuinely completed rather than that the config parsed.
-      scrapeTargets = [ "localhost:9100" ];
-      cloudflaredTarget = "localhost:20241";
-
-      # On a host this defaults on wherever system.autoUpgrade is enabled,
-      # which no test VM is. Forced on because it is half of what this test is
-      # here to cover.
-      deploy.enable = true;
-
-      httpProbes = [
-        {
-          name = "self";
-          url = "http://localhost:9090/-/healthy";
-        }
+        # Plaintext stand-ins for the three credentials the alerting path
+        # reads: the SMTP token (never exercised - the sandbox has no network,
+        # so the archive lane's sends fail and are ignored by these asserts),
+        # the ntfy access token, and the shared webhook password.
+        (import ./stub-secrets.nix {
+          secrets."monitoring/proton_smtp_token" = "test-smtp-token";
+          secrets."monitoring/ntfy/alerts-token" = "test-ntfy-token";
+          secrets."monitoring/ntfy/webhook-password" = "test-webhook-password";
+          templates."monitoring/ntfy/alertmanager-ntfy-auth" = ''
+            http:
+              basic:
+                username: alertmanager
+                password: "test-webhook-password"
+            ntfy:
+              auth:
+                token: "test-ntfy-token"
+          '';
+        })
       ];
-    };
 
-    # Prometheus plus three exporters; the default leaves this thrashing.
-    virtualisation.memorySize = 2048;
-  };
+      cg.service.monitoring = {
+        enable = true;
+        prometheus.enable = true;
+
+        # Scrape this machine's own node_exporter. A real target, so `up` means
+        # the scrape loop genuinely completed rather than that the config parsed.
+        scrapeTargets = [ "localhost:9100" ];
+        cloudflaredTarget = "localhost:20241";
+
+        # On a host this defaults on wherever system.autoUpgrade is enabled,
+        # which no test VM is. Forced on because it is half of what this test is
+        # here to cover.
+        deploy.enable = true;
+
+        httpProbes = [
+          {
+            name = "self";
+            url = "http://localhost:9090/-/healthy";
+          }
+        ];
+
+        alertmanager = {
+          enable = true;
+
+          email = {
+            to = "root@localhost";
+            from = "alerts@localhost";
+            authUsername = "alerts";
+            smarthost = "localhost:2525"; # never reachable; see stub note above
+          };
+
+          # Quiet hours depend on the wall clock, which would make warning
+          # delivery nondeterministic in CI; the mute timing itself is
+          # structural config covered by the amtool check next door.
+          quietHours.enable = false;
+
+          ntfy = {
+            enable = true;
+            # The real deployment publishes through Caddy; in the sandbox the
+            # sink runs right here.
+            baseUrl = "http://127.0.0.1:2586";
+          };
+        };
+      };
+
+      # The push sink: the upstream module directly rather than cg.service.ntfy,
+      # because that wrapper requires the reverse proxy and deny-all auth -
+      # neither of which belongs in this test. The upstream module mkDefaults
+      # auth-file on, which enables deny-by-default access control against an
+      # empty user database - every request would 403. Emptying it switches
+      # authentication off entirely, so the assertion stays free of
+      # user-database setup.
+      services.ntfy-sh = {
+        enable = true;
+        settings = {
+          base-url = "http://localhost:2586";
+          listen-http = "127.0.0.1:2586";
+          auth-file = lib.mkForce "";
+          # The assertion loops poll requests faster than ntfy's default
+          # per-visitor allowance refills, and a 429 mid-loop reads as a
+          # routing failure. Production instances keep the defaults - they
+          # exist for exactly this kind of hammering.
+          enable-rate-limiting = false;
+        };
+      };
+
+      # Prometheus plus three exporters plus Alertmanager plus ntfy.
+      virtualisation.memorySize = 2048;
+    };
 
   testScript = ''
     import json
-    from datetime import timedelta
+    import shlex
+    import time
+    from datetime import datetime, timedelta, timezone
 
     def query(expr):
         out = machine.succeed(
@@ -185,5 +267,123 @@
             "staged; it is reporting rebuilds rather than generations"
             .format(first, second)
         )
+
+    with subtest("alertmanager routes, inhibits and pushes"):
+        machine.wait_for_unit("alertmanager.service")
+        machine.wait_for_unit("alertmanager-ntfy.service")
+        machine.wait_for_unit("ntfy-sh.service")
+        machine.wait_until_succeeds("curl -sf http://localhost:9093/-/ready", timeout=60)
+        machine.wait_until_succeeds("curl -sf http://localhost:2586/v1/health", timeout=60)
+
+        def post_alerts(alerts):
+            body = json.dumps(
+                [
+                    {
+                        "labels": dict(a["labels"]),
+                        "annotations": {
+                            "summary": "{} summary".format(a["labels"]["alertname"]),
+                            "description": "{} description".format(a["labels"]["alertname"]),
+                        },
+                        "startsAt": datetime.now(timezone.utc).isoformat(),
+                        "endsAt": (datetime.now(timezone.utc) + timedelta(hours=4)).isoformat(),
+                    }
+                    for a in alerts
+                ]
+            )
+            machine.succeed(
+                "curl -sf -XPOST -H 'Content-Type: application/json' "
+                "http://localhost:9093/api/v2/alerts -d {}".format(shlex.quote(body))
+            )
+
+        _poll_failures = [0]
+
+        def messages():
+            # Public subscribe API: NDJSON stream that ends immediately when
+            # poll=1. Only message events carry notifications. Paced slower
+            # than one request per default replenish interval so the loop
+            # stays inside ntfy's visitor allowance no matter what.
+            time.sleep(6)
+            code = machine.succeed(
+                "curl -s -o /tmp/poll-body -w '%{http_code}' "
+                "'http://localhost:2586/alerts/json?poll=1'"
+            ).strip()
+            if not code.startswith("2"):
+                _poll_failures[0] += 1
+                if _poll_failures[0] <= 2:
+                    machine.log(
+                        "POLL-ERROR status={} body={}".format(
+                            code,
+                            machine.succeed("cat /tmp/poll-body || true")[:300].replace("\n", " | "),
+                        )
+                    )
+                return []
+            body = machine.succeed("cat /tmp/poll-body")
+            return [
+                json.loads(line)
+                for line in body.splitlines()
+                if line.strip() and json.loads(line).get("event") == "message"
+            ]
+
+        def titles(msgs):
+            return {m.get("title", "") for m in msgs}
+
+        # Two hosts' worth of synthetic alerts:
+        #
+        #  deadhost - TargetDown plus HighMemoryUsage for an instance nothing
+        #             can reach. The inhibition rule must let the root cause
+        #             through and swallow the symptom; if HighMemoryUsage ever
+        #             shows up below, inhibition is broken in exactly the way
+        #             that turns one outage into a full inbox.
+        #  vm       - TestCritical and TestWarning exercise the severity
+        #             lanes end to end, including the priority each arrives
+        #             with. TestInfo has no matching route and must stay off
+        #             push entirely (email only).
+        post_alerts(
+            [
+                {"labels": {"alertname": "TargetDown", "severity": "critical", "instance": "deadhost:9100", "job": "node"}},
+                {"labels": {"alertname": "HighMemoryUsage", "severity": "warning", "instance": "deadhost:9100"}},
+                {"labels": {"alertname": "TestCritical", "severity": "critical", "instance": "vm:9100"}},
+                {"labels": {"alertname": "TestWarning", "severity": "warning", "instance": "vm:9100"}},
+                {"labels": {"alertname": "TestInfo", "severity": "info", "instance": "vm:9100"}},
+            ]
+        )
+
+        # Critical lane: group_wait is 30s, so this also proves the bridge and
+        # ntfy are actually wired together.
+        def critical_arrived(_):
+            return any("TargetDown" in t or "TestCritical" in t for t in titles(messages()))
+
+        retry(critical_arrived, timeout=timedelta(seconds=120))
+
+        # Warning lane: its group_wait is deliberately 5m. The retry window
+        # starts after the critical lane's assertions, so it only needs to
+        # cover the remaining grace period plus polling slack - but keep a
+        # full 7m so a slow run cannot flake against the deadline.
+        def warning_arrived(_):
+            return any("TestWarning" in t for t in titles(messages()))
+
+        retry(warning_arrived, timeout=timedelta(seconds=420))
+
+        msgs = messages()
+        crit = [m for m in msgs if "TestCritical" in m.get("title", "")]
+        warn = [m for m in msgs if "TestWarning" in m.get("title", "")]
+        down = [m for m in msgs if "TargetDown" in m.get("title", "")]
+        inhibited = [m for m in msgs if "HighMemoryUsage" in m.get("title", "")]
+        info = [m for m in msgs if "TestInfo" in m.get("title", "")]
+
+        assert crit and down and warn, "expected all three routed lanes to arrive: {}".format(sorted(titles(msgs)))
+        assert not inhibited, "inhibition failed: HighMemoryUsage notified despite TargetDown firing"
+        assert not info, "info-severity alert reached push; it should be email-only"
+
+        # ntfy priorities: 5 urgent (buzz), 2 low (silent), 3 default.
+        assert crit[0]["priority"] == 5, "critical did not arrive urgent: {}".format(crit[0])
+        assert warn[0]["priority"] == 2, "warning did not arrive silent: {}".format(warn[0])
+        assert down[0]["priority"] == 5, "root-cause alert did not arrive urgent: {}".format(down[0])
+
+        # Resolved notifications follow their alert's route with
+        # send_resolved enabled on the webhook, so resolutions land on push as
+        # ordinary-priority all-clears - asserted structurally by amtool rather
+        # than here, because Alertmanager batches resolutions on group_interval
+        # and waiting that out does not fit this harness.
   '';
 }

--- a/hosts/homelab01/default.nix
+++ b/hosts/homelab01/default.nix
@@ -260,6 +260,21 @@
           localOnly = true;
         };
 
+        # Monitoring internals. LAN-only like the other admin UIs - remote
+        # access stays ssh-tunnelled. The Alertmanager UI is where silences
+        # live and Prometheus' graph view backs every alert expression, so
+        # both are one click from Grafana instead of an ssh port-forward.
+        prometheus-ui = {
+          subdomain = "prometheus";
+          port = 9090;
+          localOnly = true;
+        };
+        alertmanager-ui = {
+          subdomain = "alertmanager";
+          port = 9093;
+          localOnly = true;
+        };
+
         # RSS
         rss = {
           subdomain = "rss";
@@ -319,6 +334,7 @@
       alertmanager = {
         enable = true;
         clusterPeers = [ "homelab02" ];
+        ntfy.enable = true;
         email = {
           to = "cory@gyarmathy.co";
           from = "alerts@gyarmathy.co";
@@ -413,6 +429,14 @@
         }
       ];
     };
+
+    # -------------------------------------------------------------------------
+    # Push notifications (ntfy)
+    # -------------------------------------------------------------------------
+    # Carries the alerting stack's page channel; the Alertmanager routing and
+    # bridge live in modules/services/monitoring/monitoring.nix. First-deploy
+    # bootstrap steps are documented in modules/services/ntfy.nix.
+    ntfy.enable = true;
 
     # -------------------------------------------------------------------------
     # DNS (AdGuard Home)

--- a/hosts/homelab02/default.nix
+++ b/hosts/homelab02/default.nix
@@ -160,6 +160,10 @@
       alertmanager = {
         enable = true;
         clusterPeers = [ "homelab01" ];
+        # Push lane. The ntfy server itself lives on homelab01; this host runs
+        # only the local alertmanager-ntfy bridge, so either host can still
+        # deliver on its own if the other is down.
+        ntfy.enable = true;
         email = {
           to = "cory@gyarmathy.co";
           from = "alerts@gyarmathy.co";

--- a/modules/services/monitoring/alert-rules.yml
+++ b/modules/services/monitoring/alert-rules.yml
@@ -3,7 +3,7 @@ groups:
     rules:
       # Disk space alerts
       - alert: DiskSpaceLow
-        expr: (node_filesystem_avail_bytes / node_filesystem_size_bytes) * 100 < 10
+        expr: (node_filesystem_avail_bytes / node_filesystem_size_bytes) * 100 < 10 and (node_filesystem_avail_bytes / node_filesystem_size_bytes) * 100 >= 5
         for: 5m
         labels:
           severity: warning
@@ -51,8 +51,12 @@ groups:
           description: 'Memory usage is {{ printf "%.1f" $value }}%'
 
       - alert: HighCpuUsage
-        expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 90
-        for: 15m
+        # 90% was chronic on hosts that transcode: an evening of Jellyfin
+        # streaming is legitimate sustained load, and a warning that fires
+        # every night trains you to ignore warnings. 95% for half an hour
+        # still catches runaway processes while riding out normal transcoding.
+        expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 95
+        for: 30m
         labels:
           severity: warning
         annotations:
@@ -139,11 +143,17 @@ groups:
           description: "The nixos-upgrade service has failed - check logs with: journalctl -u nixos-upgrade"
 
       # Unexpected reboot detection
+      #
+      # The excluded window must match the rebootWindow in hosts/*/default.nix
+      # (04:00-05:00, enforced by nixos-upgrade itself): a scheduled kernel
+      # reboot inside it is expected maintenance, not an incident. This used
+      # to exclude 20:00-20:59 from an older upgrade schedule and paged for
+      # every planned nightly reboot until it was noticed.
       - alert: UnexpectedReboot
         expr: |
           (time() - node_boot_time_seconds) < 600 
           and changes(node_boot_time_seconds[1h]) > 0
-          and (hour() < 20 or hour() >= 21)
+          and (hour() < 4 or hour() >= 5)
         for: 1m
         labels:
           severity: info
@@ -153,9 +163,12 @@ groups:
 
   - name: zfs
     rules:
-      # ZFS pool health - fires if pool is not ONLINE
+      # ZFS pool health - fires if pool is not ONLINE. DEGRADED and FAULTED
+      # are excluded here because they have their own, more specific alerts
+      # below; without the exclusion a single degraded disk fired two alerts
+      # describing the same condition.
       - alert: ZfsPoolUnhealthy
-        expr: zfs_pool_health == 0
+        expr: zfs_pool_health == 0 unless on(instance, pool) zfs_pool_state{state=~"DEGRADED|FAULTED"} == 1
         for: 1m
         labels:
           severity: critical

--- a/modules/services/monitoring/dashboards/fleet-overview.json
+++ b/modules/services/monitoring/dashboards/fleet-overview.json
@@ -1,0 +1,536 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [
+    {
+      "asDropdown": false,
+      "title": "Alertmanager",
+      "type": "link",
+      "url": "/alertmanager"
+    },
+    {
+      "asDropdown": false,
+      "title": "Prometheus",
+      "type": "link",
+      "url": "/prometheus/graph"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Anything here wants a human. Severity breakdown is in the table below.",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": { "0": { "color": "green", "index": 0, "text": "none" } },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 5, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(ALERTS{alertstate=\"firing\"}) or vector(0)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Firing alerts",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Scrape targets Prometheus cannot reach.",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": { "0": { "color": "green", "index": 0, "text": "all up" } },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 5, "x": 5, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(1 - up) or vector(0)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Targets down",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Cloudflare Tunnel HA connections (4 expected).",
+      "fieldConfig": {
+        "defaults": {
+          "max": 4,
+          "min": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "green", "value": 3 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 10, "y": 0 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "cloudflared_tunnel_ha_connections",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Tunnel connections",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Generations staged by the nightly upgrade but not yet activated.",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": { "0": { "color": "green", "index": 0, "text": "none" } },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 5, "x": 14, "y": 0 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(nixos_deploy_pending_reboot) or vector(0)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Pending reboots",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Worst verdict across the fleet: last deploy run, activation verification, and restic backups. Anything below 1 is red.",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": { "1": { "color": "green", "index": 0, "text": "OK" } },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "deploy" },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Deploy (worst host)"
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "verify" },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Verify (worst host)"
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "backups" },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Backups (worst job)"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 4, "w": 5, "x": 19, "y": 0 },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": false
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "min(nixos_deploy_last_run_success)",
+          "legendFormat": "deploy",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "min(nixos_verify_result)",
+          "legendFormat": "verify",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "min(restic_backup_last_run_success)",
+          "legendFormat": "backups",
+          "refId": "C"
+        }
+      ],
+      "title": "Pipeline health",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "max": 100,
+          "min": 0,
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 4 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "(100 - avg by(instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 90 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 4 },
+      "id": 7,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 11 },
+      "id": 8,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "asc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "(node_filesystem_avail_bytes{fstype!~\"tmpfs|squashfs\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|squashfs\"}) * 100",
+          "legendFormat": "{{instance}} {{mountpoint}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Disk free",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "External reachability of every published service.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "continuous-GrYs" },
+          "mappings": [
+            {
+              "options": { "0": { "color": "red", "index": 1, "text": "DOWN" }, "1": { "color": "green", "index": 0, "text": "up" } },
+              "type": "value"
+            }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 11 },
+      "id": 9,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "probe_success",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Service probes",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "__name__": true, "job": true },
+            "renameByName": { "Value": "status" }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Live alert state with annotations - the same content a notification carries, without waiting for one.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "inspectOverflow": "tooltip",
+            "width": 120
+          },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "severity" },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": { "critical": { "color": "red", "index": 0 }, "info": { "color": "blue", "index": 3 }, "warning": { "color": "yellow", "index": 1 } },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 18 },
+      "id": 10,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "ALERTS{alertstate=\"firing\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Firing alerts",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "Value": true, "__name__": true, "job": true },
+            "indexByName": {
+              "severity": 0,
+              "alertname": 1,
+              "instance": 2,
+              "host": 3,
+              "pool": 4,
+              "device": 5,
+              "mountpoint": 6,
+              "description": 7
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": ["fleet"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Fleet Overview",
+  "uid": "fleet-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/modules/services/monitoring/dashboards/fleet-overview.json
+++ b/modules/services/monitoring/dashboards/fleet-overview.json
@@ -21,42 +21,63 @@
   ],
   "panels": [
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "description": "Anything here wants a human. Severity breakdown is in the table below.",
       "fieldConfig": {
         "defaults": {
           "mappings": [
             {
-              "options": { "0": { "color": "green", "index": 0, "text": "none" } },
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "none"
+                }
+              },
               "type": "value"
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 5, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showPercentChange": false,
         "textMode": "auto",
         "wideLayout": true
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "sum(ALERTS{alertstate=\"firing\"}) or vector(0)",
           "legendFormat": "__auto",
           "refId": "A"
@@ -66,42 +87,63 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "description": "Scrape targets Prometheus cannot reach.",
       "fieldConfig": {
         "defaults": {
           "mappings": [
             {
-              "options": { "0": { "color": "green", "index": 0, "text": "all up" } },
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "all up"
+                }
+              },
               "type": "value"
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 5, "x": 5, "y": 0 },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 5,
+        "y": 0
+      },
       "id": 2,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showPercentChange": false,
         "textMode": "auto",
         "wideLayout": true
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "sum(1 - up) or vector(0)",
           "legendFormat": "__auto",
           "refId": "A"
@@ -111,7 +153,6 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "description": "Cloudflare Tunnel HA connections (4 expected).",
       "fieldConfig": {
         "defaults": {
@@ -121,30 +162,49 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "yellow", "value": 1 },
-              { "color": "green", "value": 3 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "green",
+                "value": 3
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 10, "y": 0 },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 10,
+        "y": 0
+      },
       "id": 3,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showPercentChange": false,
         "textMode": "auto",
         "wideLayout": true
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "cloudflared_tunnel_ha_connections",
           "legendFormat": "__auto",
           "refId": "A"
@@ -154,42 +214,63 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "description": "Generations staged by the nightly upgrade but not yet activated.",
       "fieldConfig": {
         "defaults": {
           "mappings": [
             {
-              "options": { "0": { "color": "green", "index": 0, "text": "none" } },
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "none"
+                }
+              },
               "type": "value"
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 5, "x": 14, "y": 0 },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 14,
+        "y": 0
+      },
       "id": 4,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showPercentChange": false,
         "textMode": "auto",
         "wideLayout": true
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "sum(nixos_deploy_pending_reboot) or vector(0)",
           "legendFormat": "__auto",
           "refId": "A"
@@ -199,28 +280,42 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "description": "Worst verdict across the fleet: last deploy run, activation verification, and restic backups. Anything below 1 is red.",
       "fieldConfig": {
         "defaults": {
           "mappings": [
             {
-              "options": { "1": { "color": "green", "index": 0, "text": "OK" } },
+              "options": {
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "OK"
+                }
+              },
               "type": "value"
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "deploy" },
+            "matcher": {
+              "id": "byName",
+              "options": "deploy"
+            },
             "properties": [
               {
                 "id": "displayName",
@@ -229,7 +324,10 @@
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "verify" },
+            "matcher": {
+              "id": "byName",
+              "options": "verify"
+            },
             "properties": [
               {
                 "id": "displayName",
@@ -238,7 +336,10 @@
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "backups" },
+            "matcher": {
+              "id": "byName",
+              "options": "backups"
+            },
             "properties": [
               {
                 "id": "displayName",
@@ -248,33 +349,41 @@
           }
         ]
       },
-      "gridPos": { "h": 4, "w": 5, "x": 19, "y": 0 },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 19,
+        "y": 0
+      },
       "id": 5,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showPercentChange": false,
         "textMode": "auto",
         "wideLayout": false
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "min(nixos_deploy_last_run_success)",
           "legendFormat": "deploy",
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "min(nixos_verify_result)",
           "legendFormat": "verify",
           "refId": "B"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "min(restic_backup_last_run_success)",
           "legendFormat": "backups",
           "refId": "C"
@@ -284,7 +393,6 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -302,20 +410,42 @@
           },
           "max": 100,
           "min": 0,
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "percent"
         },
         "overrides": []
       },
-      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 4 },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
       "id": 6,
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "(100 - avg by(instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -325,7 +455,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -340,23 +469,43 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 90 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
             ]
           },
           "unit": "percent"
         },
         "overrides": []
       },
-      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 4 },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
       "id": 7,
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -366,7 +515,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -381,24 +529,47 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 10 },
-              { "color": "red", "value": 5 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
             ]
           },
           "unit": "percent"
         },
         "overrides": []
       },
-      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 11 },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
       "id": 8,
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "asc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "asc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "(node_filesystem_avail_bytes{fstype!~\"tmpfs|squashfs\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|squashfs\"}) * 100",
           "legendFormat": "{{instance}} {{mountpoint}}",
           "refId": "A"
@@ -408,31 +579,62 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "description": "External reachability of every published service.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "continuous-GrYs" },
+          "color": {
+            "mode": "continuous-GrYs"
+          },
           "mappings": [
             {
-              "options": { "0": { "color": "red", "index": 1, "text": "DOWN" }, "1": { "color": "green", "index": 0, "text": "up" } },
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "up"
+                }
+              },
               "type": "value"
             }
           ],
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 11 },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
       "id": 9,
       "options": {
         "cellHeight": "sm",
-        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "showHeader": true
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "probe_success",
           "format": "table",
           "instant": true,
@@ -445,15 +647,20 @@
         {
           "id": "organize",
           "options": {
-            "excludeByName": { "Time": true, "__name__": true, "job": true },
-            "renameByName": { "Value": "status" }
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true
+            },
+            "renameByName": {
+              "Value": "status"
+            }
           }
         }
       ],
       "type": "table"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "description": "Live alert state with annotations - the same content a notification carries, without waiting for one.",
       "fieldConfig": {
         "defaults": {
@@ -462,17 +669,41 @@
             "inspectOverflow": "tooltip",
             "width": 120
           },
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "severity" },
+            "matcher": {
+              "id": "byName",
+              "options": "severity"
+            },
             "properties": [
               {
                 "id": "mappings",
                 "value": [
                   {
-                    "options": { "critical": { "color": "red", "index": 0 }, "info": { "color": "blue", "index": 3 }, "warning": { "color": "yellow", "index": 1 } },
+                    "options": {
+                      "critical": {
+                        "color": "red",
+                        "index": 0
+                      },
+                      "info": {
+                        "color": "blue",
+                        "index": 3
+                      },
+                      "warning": {
+                        "color": "yellow",
+                        "index": 1
+                      }
+                    },
                     "type": "value"
                   }
                 ]
@@ -481,16 +712,27 @@
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 18 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
       "id": 10,
       "options": {
         "cellHeight": "sm",
-        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "showHeader": true
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "ALERTS{alertstate=\"firing\"}",
           "format": "table",
           "instant": true,
@@ -503,7 +745,12 @@
         {
           "id": "organize",
           "options": {
-            "excludeByName": { "Time": true, "Value": true, "__name__": true, "job": true },
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "job": true
+            },
             "indexByName": {
               "severity": 0,
               "alertname": 1,
@@ -524,9 +771,16 @@
   "preload": false,
   "refresh": "1m",
   "schemaVersion": 39,
-  "tags": ["fleet"],
-  "templating": { "list": [] },
-  "time": { "from": "now-6h", "to": "now" },
+  "tags": [
+    "fleet"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
   "title": "Fleet Overview",

--- a/modules/services/monitoring/monitoring.nix
+++ b/modules/services/monitoring/monitoring.nix
@@ -839,9 +839,14 @@ in
               {
                 name = "Prometheus";
                 type = "prometheus";
-                uid = "prometheus";
                 url = "http://localhost:9090";
                 isDefault = true;
+                # Deliberately no `uid`: this host already has this datasource
+                # with its auto-generated one, and re-provisioning it under a
+                # different uid sends Grafana 13's provisioning into a fatal
+                # "data source not found" crash loop on startup. Panels in the
+                # provisioned dashboards reference the default datasource
+                # rather than a pinned uid for the same reason.
               }
             ];
 

--- a/modules/services/monitoring/monitoring.nix
+++ b/modules/services/monitoring/monitoring.nix
@@ -215,6 +215,81 @@ in
         };
       };
 
+      # Push notifications through a self-hosted ntfy server, via the
+      # alertmanager-ntfy bridge running next to Alertmanager on this host.
+      # Critical alerts buzz the phone; warnings arrive silently; everything
+      # keeps flowing to email as the archive lane regardless of severity.
+      # See the receiver/route/inhibition design in the config section below.
+      ntfy = {
+        enable = lib.mkEnableOption "ntfy push routing for Alertmanager";
+
+        bridgeUrl = lib.mkOption {
+          type = lib.types.str;
+          default = "http://127.0.0.1:8000/hook";
+          description = "URL of the local alertmanager-ntfy webhook endpoint (/hook)";
+        };
+
+        baseUrl = lib.mkOption {
+          type = lib.types.str;
+          default = "https://ntfy.gyarmathy.co";
+          description = "Base URL of the ntfy server the bridge publishes to";
+        };
+
+        topic = lib.mkOption {
+          type = lib.types.str;
+          default = "alerts";
+          description = "ntfy topic alerts are published to";
+        };
+
+        tokenSecret = lib.mkOption {
+          type = lib.types.str;
+          default = "monitoring/ntfy/alerts-token";
+          description = "Sops secret holding the ntfy access token used by the bridge";
+        };
+
+        webhookPasswordSecret = lib.mkOption {
+          type = lib.types.str;
+          default = "monitoring/ntfy/webhook-password";
+          description = ''
+            Sops secret holding the basic-auth password shared by every
+            Alertmanager in the fleet and the bridges they deliver to. Use
+            URL-safe characters (letters, digits, - _ ~ .); it is embedded
+            in a YAML file verbatim.
+          '';
+        };
+      };
+
+      # Warning-severity push notifications are suppressed between these
+      # times so a failing timer at 04:15 is read at breakfast rather than
+      # buzzing then. Criticals ignore quiet hours by design. Applies to the
+      # ntfy lane only; email is never muted.
+      quietHours = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Mute warning-severity push notifications outside waking hours";
+        };
+        start = lib.mkOption {
+          type = lib.types.strMatching "[0-9]{2}:[0-9]{2}";
+          default = "22:00";
+          description = "Start of the quiet window (local time)";
+        };
+        end = lib.mkOption {
+          type = lib.types.strMatching "[0-9]{2}:[0-9]{2}";
+          default = "07:00";
+          description = "End of the quiet window (local time)";
+        };
+        timeZone = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          # time.timeZone is null when unset; the consumer falls back to UTC,
+          # which only ever matters for test/standalone evaluations - both
+          # hosts set it explicitly.
+          default = config.time.timeZone;
+          defaultText = lib.literalExpression "config.time.timeZone";
+          description = "IANA timezone the quiet window is evaluated in";
+        };
+      };
+
     };
 
     # ZFS monitoring
@@ -478,21 +553,141 @@ in
           group = "alertmanager";
         };
 
+        # ==========================================================
+        # Routing design
+        #
+        # Two lanes, deliberately unequal:
+        #
+        #   push  - ntfy on the phone. Criticals buzz (priority urgent),
+        #           warnings arrive silently (priority low) and are muted
+        #           overnight. Resolutions follow their alert's route, so a
+        #           resolved critical lands as an ordinary-priority all-clear.
+        #   email - the archive lane. Everything reaches it (the severity
+        #           routes `continue` past the push receiver into this one),
+        #           grouped by alertname so a fan-out of related alerts is
+        #           one message, repeating no more often than daily.
+        #
+        # Inhibition keeps one root cause from fanning out into many
+        # notifications: an unreachable host suppresses every alert sourced
+        # from its exporters, a downed tunnel suppresses the probe failures
+        # it would otherwise cause in bulk, and a pool-level ZFS failure
+        # supersedes the per-symptom alerts describing the same disks.
+        # ==========================================================
+
         services.prometheus.alertmanager = {
           enable = true;
 
           clusterPeers = cfg.alertmanager.clusterPeers;
           configuration = {
+            global.resolve_timeout = "5m";
+
             route = {
               receiver = "email";
-              group_by = [
-                "alertname"
-                "instance"
-              ];
+              group_by = [ "alertname" ];
               group_wait = "30s";
-              group_interval = "5m";
-              repeat_interval = "4h";
+              group_interval = "10m";
+              repeat_interval = "24h";
+
+              routes = lib.optionals cfg.alertmanager.ntfy.enable [
+                {
+                  receiver = "push";
+                  continue = true; # email still archives it
+                  matchers = [ "severity = \"critical\"" ];
+                  group_by = [
+                    "alertname"
+                    "instance"
+                  ];
+                  group_wait = "30s";
+                  repeat_interval = "4h";
+                }
+                {
+                  receiver = "push";
+                  continue = true;
+                  matchers = [ "severity = \"warning\"" ];
+                  group_by = [
+                    "alertname"
+                    "instance"
+                  ];
+                  # Warnings get a longer grace period before the first
+                  # notification: most clear themselves.
+                  group_wait = "5m";
+                  repeat_interval = "24h";
+                  mute_time_intervals = lib.optionals cfg.alertmanager.quietHours.enable [ "overnight" ];
+                }
+              ];
             };
+
+            mute_time_intervals = lib.optionals (cfg.alertmanager.ntfy.enable && cfg.alertmanager.quietHours.enable) [
+              {
+                name = "overnight";
+                time_intervals = [
+                  {
+                    times = [
+                      {
+                        start_time = cfg.alertmanager.quietHours.start;
+                        end_time = "23:59";
+                      }
+                      {
+                        start_time = "00:00";
+                        end_time = cfg.alertmanager.quietHours.end;
+                      }
+                    ];
+                    location = if cfg.alertmanager.quietHours.timeZone != null then cfg.alertmanager.quietHours.timeZone else "UTC";
+                  }
+                ];
+              }
+            ];
+
+            inhibit_rules =
+              let
+                # Alerts that describe symptoms of a degraded ZFS pool rather
+                # than the pool's state itself.
+                zfsSymptoms = "Zfs(ChecksumErrors|IOErrors|ScrubErrors|ScrubOverdue)";
+              in
+              [
+                # When Prometheus cannot reach a host's node_exporter, every
+                # other metric sourced from that host is stale, and each of
+                # those alerts firing separately is noise around the one real
+                # problem. Textfile-derived alerts (restic, deploy, gluetun,
+                # garden) carry instance too, so they are covered as well.
+                {
+                  source_matchers = [ "alertname = TargetDown" ];
+                  target_matchers = [ "severity =~ warning|critical" ];
+                  equal = [ "instance" ];
+                }
+
+                # A dead tunnel breaks every published service at once; the
+                # dozen resulting probe failures say nothing the tunnel alert
+                # does not. Probes that fail while the tunnel is healthy are
+                # unaffected and still page normally.
+                {
+                  source_matchers = [
+                    "alertname =~ CloudflareTunnel(Down|ServiceFailed|NoConnections)"
+                  ];
+                  target_matchers = [ "alertname = ServiceDown" ];
+                }
+
+                # A degraded or faulted pool already says what checksum/IO
+                # errors and overdue scrubs would say, with more urgency.
+                {
+                  source_matchers = [ "alertname =~ ZfsPool(Degraded|Faulted)" ];
+                  target_matchers = [ "alertname =~ ${zfsSymptoms}" ];
+                  equal = [
+                    "instance"
+                    "pool"
+                  ];
+                }
+
+                # Critical disk pressure makes the warning redundant.
+                {
+                  source_matchers = [ "alertname = DiskSpaceCritical" ];
+                  target_matchers = [ "alertname = DiskSpaceLow" ];
+                  equal = [
+                    "instance"
+                    "mountpoint"
+                  ];
+                }
+              ];
 
             receivers = [
               {
@@ -508,10 +703,88 @@ in
                   }
                 ];
               }
+            ] ++ lib.optionals cfg.alertmanager.ntfy.enable [
+              {
+                name = "push";
+                webhook_configs = [
+                  {
+                    url = cfg.alertmanager.ntfy.bridgeUrl;
+                    send_resolved = true;
+                    http_config.basic_auth = {
+                      username = "alertmanager";
+                      password_file = config.sops.secrets.${cfg.alertmanager.ntfy.webhookPasswordSecret}.path;
+                    };
+                  }
+                ];
+              }
             ];
           };
         };
         networking.firewall.allowedTCPPorts = [ 9094 ]; # gossip
+      })
+
+      # ============================================================
+      # ntfy bridge: Alertmanager webhooks -> self-hosted ntfy
+      # ============================================================
+      # One bridge per host, next to that host's Alertmanager, so push
+      # delivery does not depend on either host being the sole survivor -
+      # both bridges publish to the same ntfy server over HTTPS and
+      # Alertmanager's cluster deduplicates the result exactly as it does
+      # for email.
+      (lib.mkIf (cfg.alertmanager.enable && cfg.alertmanager.ntfy.enable) {
+        sops.secrets.${cfg.alertmanager.ntfy.tokenSecret} = { };
+        sops.secrets.${cfg.alertmanager.ntfy.webhookPasswordSecret} = { };
+
+        # Merged over the plain-text settings at runtime so neither
+        # credential ever lands in the store. The bridge reads these via
+        # systemd LoadCredential, which PID1 opens before dropping
+        # privileges, so the file's owner does not matter - 0400 root.
+        sops.templates."monitoring/ntfy/alertmanager-ntfy-auth" = {
+          content = ''
+            http:
+              basic:
+                username: alertmanager
+                password: "${config.sops.placeholder.${cfg.alertmanager.ntfy.webhookPasswordSecret}}"
+            ntfy:
+              auth:
+                token: "${config.sops.placeholder.${cfg.alertmanager.ntfy.tokenSecret}}"
+          '';
+          mode = "0400";
+        };
+
+        services.prometheus.alertmanager-ntfy = {
+          enable = true;
+          settings = {
+            http.addr = "127.0.0.1:8000";
+            ntfy = {
+              baseurl = cfg.alertmanager.ntfy.baseUrl;
+              notification = {
+                topic = cfg.alertmanager.ntfy.topic;
+                # Per-alert gval expression over the alert's own fields:
+                # critical firing buzzes, warnings stay silent, resolutions
+                # land at ordinary priority regardless of severity.
+                priority = ''
+                  status == "firing" ? (labels["severity"] == "critical" ? "urgent" : "low") : "default"
+                '';
+                tags = [
+                  {
+                    tag = "rotating_light";
+                    condition = ''status == "firing" && labels["severity"] == "critical"'';
+                  }
+                  {
+                    tag = "red_circle";
+                    condition = ''status == "firing" && labels["severity"] == "warning"'';
+                  }
+                  {
+                    tag = "green_circle";
+                    condition = ''status == "resolved"'';
+                  }
+                ];
+              };
+            };
+          };
+          extraConfigFiles = [ config.sops.templates."monitoring/ntfy/alertmanager-ntfy-auth".path ];
+        };
       })
 
       # ============================================================
@@ -566,8 +839,21 @@ in
               {
                 name = "Prometheus";
                 type = "prometheus";
+                uid = "prometheus";
                 url = "http://localhost:9090";
                 isDefault = true;
+              }
+            ];
+
+            # The fleet overview is the answer to "is anything wrong right
+            # now" - firing alerts, unreachable targets, backup and upgrade
+            # verdicts, per-host vitals - kept in code so it survives
+            # reinstatement of /var/lib/grafana and cannot drift between hosts.
+            dashboards.settings.providers = [
+              {
+                name = "fleet";
+                type = "file";
+                options.path = toString ./dashboards;
               }
             ];
           };

--- a/modules/services/ntfy.nix
+++ b/modules/services/ntfy.nix
@@ -1,0 +1,124 @@
+# ntfy - self-hosted push notifications
+#
+# Publishes to phone/desktop clients over HTTP(S); topics are the only
+# credential, so this instance runs deny-by-default auth and is reachable
+# from outside the LAN only through its own authentication.
+#
+# ROLE IN THE FLEET:
+# The alerting stack's page channel. Alertmanager (both hosts) delivers to
+# a local alertmanager-ntfy bridge, which publishes here as the
+# `alerts` topic; critical alerts arrive urgent, warnings silent. See
+# modules/services/monitoring/monitoring.nix for the routing design.
+#
+# SETUP AFTER FIRST DEPLOYMENT (interactive, one-time):
+#  1. Create your user and an access token:
+#       sudo -u ntfy-sh ntfy user add --role=admin cory \
+#         --config /etc/ntfy/server.yml
+#       sudo -u ntfy-sh ntfy token add cory \
+#         --config /etc/ntfy/server.yml
+#     (`--config` matters: without it these commands create a fresh,
+#      empty user database somewhere else and appear to do nothing.)
+#  2. Put the token into sops as `monitoring/ntfy/alerts-token`
+#     (secrets/secrets.yaml), along with a generated password in
+#     `monitoring/ntfy/webhook-password`, e.g.:
+#       openssl rand -hex 24   # once per secret
+#     then re-run the deploy so the bridges pick them up.
+#  3. In the ntfy app add server https://ntfy.gyarmathy.co, log in with
+#     the user from step 1, and subscribe to the `alerts` topic.
+#
+# The auth database lives in /var/lib/ntfy-sh/user.db. It is not in the
+# declarative config and not backed up by the restic paths - if this host
+# is ever rebuilt, step 1 recreates it.
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.cg.service.ntfy;
+in
+{
+  options.cg.service.ntfy = {
+    enable = lib.mkEnableOption "ntfy self-hosted push notification server";
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 2586;
+      description = "Port ntfy listens on (localhost only, behind Caddy)";
+    };
+
+    subdomain = lib.mkOption {
+      type = lib.types.str;
+      default = "ntfy";
+      description = "Subdomain published through the reverse proxy and tunnel";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.cg.service.reverse-proxy.enable;
+        message = "ntfy requires the reverse proxy to be enabled (cg.service.reverse-proxy.enable = true) - phone clients reach it through the tunnel";
+      }
+    ];
+
+    services.ntfy-sh = {
+      enable = true;
+
+      settings = {
+        # What clients see in messages' links and what iOS-style instant
+        # delivery would key off; must match the public URL.
+        base-url = "https://${cfg.subdomain}.gyarmathy.co";
+        listen-http = "127.0.0.1:${toString cfg.port}";
+
+        # We sit behind Caddy, which already terminates TLS and applies its
+        # own rate limiting; ntfy's rate limits stay at their generous
+        # defaults rather than fighting the bridge's retry behaviour during
+        # an alert storm - that is exactly when delivery matters most.
+        behind-proxy = true;
+
+        # Topics are effectively passwords: nobody may publish or subscribe
+        # without an account. Sign-up stays off; accounts are created by hand
+        # per the header instructions.
+        auth-file = "/var/lib/ntfy-sh/user.db";
+        auth-default-access = "deny-all";
+        enable-login = true;
+        enable-signup = false;
+      };
+    };
+
+    # Published for phones on mobile data; authentication is ntfy's own job,
+    # not the proxy's.
+    cg.service.reverse-proxy.services.ntfy = {
+      subdomain = cfg.subdomain;
+      port = cfg.port;
+      localOnly = false;
+      rateLimitProfile = "none"; # alert storms must not be rate-limited
+    };
+
+    # No firewall rule: ntfy binds 127.0.0.1, Caddy proxies to it locally,
+    # and external traffic arrives through the tunnel, not direct ports.
+
+    # The upstream module runs the server under a DynamicUser while also
+    # declaring a static ntfy-sh user and shipping /etc/ntfy/server.yml
+    # "to configure access control via the cli". Those conflict: the state
+    # directory ends up owned by a transient UID, so `sudo -u ntfy-sh ntfy
+    # user add` cannot read or create anything in it, and the one-time
+    # bootstrap this module documents is impossible. Pinning the service to
+    # the static user reconciles them; everything else in the unit's
+    # hardening block stands.
+    #
+    # The Z tmpfiles rule recursively reasserts ownership on every boot and
+    # switch: a host that ever ran the dynamic-user incarnation keeps files
+    # chowned to a UID that no longer exists, which surfaces as sqlite's
+    # "attempt to write a readonly database".
+    systemd.tmpfiles.rules = [ "Z /var/lib/ntfy-sh 0700 ntfy-sh ntfy-sh -" ];
+
+    systemd.services.ntfy-sh.serviceConfig = {
+      DynamicUser = lib.mkForce false;
+      User = lib.mkForce "ntfy-sh";
+      Group = lib.mkForce "ntfy-sh";
+    };
+  };
+}

--- a/secrets/secrets.yaml
+++ b/secrets/secrets.yaml
@@ -13,6 +13,11 @@ monitoring:
         username: ENC[AES256_GCM,data:CzyYROY=,iv:0z747WLZbZJYX43Zc+Dl5hAFYtvlgAOx5lJiMf9sZg4=,tag:o1K5xwtJ0FBtcfxHLIQewA==,type:str]
         password: ENC[AES256_GCM,data:wVqsIyvXhhhv97Wa+X8bKph6qBzewp/tlfGZvDRvHjQK9cBeEK+Vdg==,iv:fUFtEPS6ZeNfXN0/0Xdw8taZdlmjNhZX9tUxNpxdf80=,tag:PHBJJfjcjU+R4VqaIpnBcA==,type:str]
         secret_key: ENC[AES256_GCM,data:j85HGOVnEM8w3zMoovF6DWGIYHljM36hvlohX1+2luAYThvUYZELCJvmXuRzB7FfvJ18laa3XFYjOykAT9Yp2w==,iv:lcyBUM4azQt/g0SXwIPU9Hn/houg8X0gZ+mqJ/l+tbc=,tag:3A/154FlWSwKj55w+ueajw==,type:str]
+    ntfy:
+        username: ENC[AES256_GCM,data:cGOvNQ==,iv:OVp916JjlmNo6zCYJQ9TToJuLdr7TRhjh2LxC8NMa6o=,tag:a1zevAJIWPg6AxMCldC9Wg==,type:str]
+        password: ENC[AES256_GCM,data:shUQQd5L1Fq01kB9EEtWc8BFDIC8,iv:mhwoTgYzSoS/yHDv+uP+oau0TcDp9i4rulq6VgbES5Y=,tag:frMlqRd2WSgugnjso+rjlw==,type:str]
+        webhook-password: ENC[AES256_GCM,data:SjNBHn/YtnrpfgR3GjLtnnJiQewFQt/GNhAyg35vCUL3Va+t0JP1XlYMFhlktA3C,iv:eYH3/EgDoCW/hxPbHza1GXTOVCZ4CFXonTNGzlgh1IA=,tag:V25GNj02P/hfYhGbwGxRUg==,type:str]
+        alerts-token: ENC[AES256_GCM,data:WBHxQSRN/zkXp968C60C8QSXHfFimXlseo04+eYunOM=,iv:voxqzofzKTO7I1JAdA/wgI0gKKIN9gouAw0MS7MdiUw=,tag:+y2OZnyIYhZ/+CIYSwgRqg==,type:str]
 backups:
     restic:
         password: ENC[AES256_GCM,data:BgdZfQmmG6lnKysh0Qo99wCiAFYJl5hN8dfWYx4dai6Y0F9oXreYuHe7gEs=,iv:UFhJoMa0DxhTi+0O71jKVcg8CxTEtK9vbgm79MuXyTo=,tag:B1FX7oO+lpzOdtqVE/+M0g==,type:str]
@@ -100,7 +105,7 @@ sops:
             ZYE+oa15HgXtkwqJVu8QlZrpkuzSyn0mHDBGibaZX/mKLvZXIKzpiA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age15h2tcfx9dw5qeyx4cgg358wlzr489vvq272s6wm7gud6mrkmregsp9s6x6
-    lastmodified: "2026-08-15T15:20:30Z"
-    mac: ENC[AES256_GCM,data:H3QzSNkqXVQ2nGwhrnpz9UleJLW34jOacNRe6DD6CGPGnHlYFxSGltXS7nF3PR6CvCUP+KKWzXHJSR0rfWYWwfJO2VuPPPRfkOQUx/RPsnHypJncDavOQkb5Bzg5/r1fnACy8J9ilzpw1a6u2HEn5gT9REJP9nXmf6DjClotbIg=,iv:V4NzDJb2ItH61qKVYn3v0EI/fAg64oxnafNGI/AN0pQ=,tag:NqlbdabLZnCB5eg1NRJd8g==,type:str]
+    lastmodified: "2026-08-25T08:55:53Z"
+    mac: ENC[AES256_GCM,data:G0nAnKipXDj75ItEUz/DoPYAlTVU+ciHeLjQMNir8aWxnNGHrkRrtLT7ZT59ZgN3xFPCfRX+e3S15oYFm5jaTXgqq0eENy7VZwtjJdPaTspR1enqoGQg4NS1pv5JwClLYxp8uxZpGub3x47K5WcUjMdV+PzZyGFHYy3QFzdy6QA=,iv:LAa71XRs37zxpboJY0bcMYprhgFBks/IxnUMZeUqpdQ=,tag:NI2wYwUBBAdV/CgL38/Iig==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
## Why

Alerting was email-only: every firing and resolved alert arrived as an identical interrupt, one root cause fanned out into many messages, and there was no way to see current state without ssh-tunnelling to the Prometheus/Alertmanager UIs. This implements the accepted Phases 1+2 of the monitoring improvement proposal: fix routing and correlation first, then give the fleet a live status board.

## What changed

**Routing (`modules/services/monitoring/monitoring.nix`)**
- Two lanes: **criticals → self-hosted ntfy push at urgent priority** (buzz); **warnings → silent push**, repeating daily and muted 22:00–07:00 AWST. Email stays the archive lane for everything (severity routes `continue` into it), grouped by alertname so fan-outs are one message.
- Four inhibition rules: unreachable host → suppress that host's exporter/textfile alerts; tunnel-down → suppress probe failures; degraded/faulted pool → suppress its checksum/IO/scrub alerts; DiskSpaceCritical → suppress DiskSpaceLow.
- One `alertmanager-ntfy` bridge per host next to each Alertmanager; both publish to one ntfy server over HTTPS, so either host can deliver alone (cluster dedup unchanged). Bridge credentials via sops template + LoadCredential — nothing in the store.

**New module `cg.service.ntfy` (`modules/services/ntfy.nix`)**
- ntfy on homelab01 behind Caddy/tunnel, `auth-default-access: deny-all`, login only.
- Pins the service to the static user (upstream DynamicUser made `/var/lib/ntfy-sh` inaccessible to the CLI bootstrap its own /etc config exists for) plus a tmpfiles `Z` rule to reassert ownership across the migration.

**Rule fixes (`alert-rules.yml`)**
- `UnexpectedReboot` quiet window now matches the real 04:00–05:00 reboot window — it previously paged every planned kernel reboot.
- ZFS pool double-fires and DiskSpaceLow/Critical overlap deduplicated at expression level.
- `HighCpuUsage` 95% / 30m so normal transcoding stops training us to ignore warnings.

**Visibility (Phase 2)**
- Fleet Overview Grafana dashboard provisioned in code: firing alerts table, targets down, tunnel connections, deploy/verify/backup verdicts, CPU/mem/disk timeseries, probe status.
- Prometheus + Alertmanager UIs published LAN-only (`prometheus.` / `alertmanager.gyarmathy.co`).

## Security notes

- `secrets/secrets.yaml`: adds `monitoring/ntfy/alerts-token` (ntfy access token) and `monitoring/ntfy/webhook-password` (AM↔bridge basic auth), both sops-encrypted to all four age keys. No other secret material touched.
- No firewall, SSH, confinement, or branch-protection changes. The new public surface is ntfy behind Caddy with app-level deny-all auth; monitoring UIs stay LAN-gated like existing admin endpoints.

## Validation

- New static `amtool check-config` check on the assembled production config (it caught a real `basic_auth` placement bug during development).
- `checks/monitoring.nix` extended: injects synthetic alerts via the AM API and asserts end-to-end — critical arrives urgent, warning arrives silent after its 5m grace, inhibited symptom never notifies, info-severity never reaches push. `globalTimeout` raised for the warning grace period.
- `nix flake check --print-build-logs`: all checks passed (all three hosts build + all VM tests).
- Deployed to homelab01; push delivery verified from LAN browser and mobile data.

## Post-merge operator steps

1. Let CI promote `deploy`; both hosts take it overnight as usual.
2. On any host that needs it, bootstrap ntfy per the header of `modules/services/ntfy.nix` (user + token), then replace the `alerts-token` placeholder in sops if not already done, and subscribe to the `alerts` topic in the app.