### PR TITLE
fix(monitoring): restore ntfy push delivery

### DIFF
--- a/checks/monitoring.nix
+++ b/checks/monitoring.nix
@@ -51,14 +51,23 @@
         # Plaintext stand-ins for the three credentials the alerting path
         # reads: the SMTP token (never exercised - the sandbox has no network,
         # so the archive lane's sends fail and are ignored by these asserts),
-        # the ntfy access token, and the shared webhook password.
+        # the ntfy access token, and the shared webhook password. All three
+        # are listed as private, so they land root-owned 0400 like sops-nix's
+        # production defaults instead of world-readable store paths - the
+        # webhook password is read by Alertmanager itself, and a missing
+        # owner declaration must fail here the way it failed on homelab01.
         (import ./stub-secrets.nix {
+          private = [
+            "monitoring/proton_smtp_token"
+            "monitoring/ntfy/alerts-token"
+            "monitoring/ntfy/webhook-password"
+          ];
           secrets."monitoring/proton_smtp_token" = "test-smtp-token";
           secrets."monitoring/ntfy/alerts-token" = "test-ntfy-token";
           secrets."monitoring/ntfy/webhook-password" = "test-webhook-password";
           templates."monitoring/ntfy/alertmanager-ntfy-auth" = ''
             http:
-              basic:
+              auth:
                 username: alertmanager
                 password: "test-webhook-password"
             ntfy:
@@ -274,6 +283,29 @@
         machine.wait_for_unit("ntfy-sh.service")
         machine.wait_until_succeeds("curl -sf http://localhost:9093/-/ready", timeout=60)
         machine.wait_until_succeeds("curl -sf http://localhost:2586/v1/health", timeout=60)
+
+        # The 2026-08-25 Grafana page died here: Alertmanager could not read
+        # its own webhook password because the secret was declared without an
+        # owner and landed root:root 0400. The private fixtures reproduce
+        # those production permissions, so this is the assertion that turns a
+        # silent delivery failure into a red test.
+        machine.succeed("runuser -u alertmanager -- test -r /run/stub-secrets/monitoring/ntfy/webhook-password")
+
+        # alertmanager-ntfy ignores unknown config keys, so a wrong key in the
+        # auth file (http.basic instead of http.auth) disables /hook auth with
+        # nothing but a startup warning to show for it.
+        bridge_log = machine.succeed("journalctl -u alertmanager-ntfy -b --no-pager")
+        assert "Basic auth is disabled" not in bridge_log, (
+            "the bridge started without incoming authentication; "
+            "the auth template's keys do not match what alertmanager-ntfy reads"
+        )
+
+        # And behaviourally, from the outside: no credentials, no entry.
+        unauth = machine.succeed(
+            "curl -s -o /dev/null -w '%{http_code}' -XPOST -H 'Content-Type: application/json' "
+            "-d '{\"alerts\":[]}' http://127.0.0.1:8000/hook || true"
+        ).strip()
+        assert unauth == "401", f"unauthenticated webhook post was not rejected: {unauth}"
 
         def post_alerts(alerts):
             body = json.dumps(

--- a/checks/stub-secrets.nix
+++ b/checks/stub-secrets.nix
@@ -29,24 +29,63 @@
 #       templates."caddy-cloudflare-env" = "CF_API_TOKEN=not-a-real-token\n";
 #     })
 #   ];
+#
+# Secrets named in `private` are installed differently: copied to
+# /run/stub-secrets/<name> with the owner, group and mode each secret
+# declares (sops-nix's defaults being root:root 0400), which is what
+# production gets. Use this for secrets a non-root service reads directly,
+# so the test fails the way production would if the module forgot to
+# declare an owner - store fixtures are world-readable and mask exactly
+# that bug class.
 {
   secrets ? { },
   templates ? { },
+  private ? [ ],
 }:
-{ lib, pkgs, ... }:
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
 let
   # The name is a sops key path, so it contains slashes; only the last segment
   # is usable as a store path name.
   fixture = name: content: toString (pkgs.writeText "stub-${baseNameOf name}" content);
+
+  privateInstall =
+    name:
+    let
+      s = config.sops.secrets.${name};
+      # This pinned sops-nix leaves owner/group null and installs as
+      # uid/gid 0 when unset; resolve them the way its installer would.
+      owner = if s.owner != null then s.owner else "root";
+      group = if s.group != null then s.group else config.users.users.${owner}.group or "root";
+    in
+    ''
+      mkdir -p "/run/stub-secrets/$(dirname "${name}")"
+      install -m ${s.mode} -o ${owner} -g ${group} "${fixture name secrets.${name}}" "/run/stub-secrets/${name}"
+    '';
 in
 {
   sops.secrets = lib.mapAttrs (name: content: {
-    path = lib.mkForce (fixture name content);
+    path =
+      if lib.elem name private then
+        lib.mkForce "/run/stub-secrets/${name}"
+      else
+        lib.mkForce (fixture name content);
   }) secrets;
 
   sops.templates = lib.mapAttrs (name: content: {
     path = lib.mkForce (fixture name content);
   }) templates;
+
+  # Installs the `private` fixtures under their declared ownership.
+  # Runs in activation, so the files exist before any service starts; /run
+  # is tmpfs, and activation runs on every boot for exactly this reason.
+  system.activationScripts.stubPrivateSecrets = lib.mkIf (private != [ ]) (
+    lib.stringAfter [ "etc" ] (lib.concatMapStringsSep "\n" privateInstall private)
+  );
 
   # Satisfies sops-nix's "no key source configured" assertion, which fires as
   # soon as any secret is declared. Nothing reads the path, because the unit

--- a/modules/services/monitoring/monitoring.nix
+++ b/modules/services/monitoring/monitoring.nix
@@ -732,17 +732,34 @@ in
       # Alertmanager's cluster deduplicates the result exactly as it does
       # for email.
       (lib.mkIf (cfg.alertmanager.enable && cfg.alertmanager.ntfy.enable) {
+        # Only ever consumed through the rendered template below, which
+        # sops-nix writes as root; nothing reads this file directly.
         sops.secrets.${cfg.alertmanager.ntfy.tokenSecret} = { };
-        sops.secrets.${cfg.alertmanager.ntfy.webhookPasswordSecret} = { };
+
+        # Alertmanager reads this one itself when delivering to the local
+        # bridge's /hook endpoint, so it must be readable by the service
+        # user. The root:root 0400 default made every push delivery fail
+        # with "permission denied" while the behaviour test stayed green -
+        # its fixtures are world-readable store paths, so ownership bugs
+        # cannot reproduce there. Same shape as proton_smtp_token above.
+        sops.secrets.${cfg.alertmanager.ntfy.webhookPasswordSecret} = {
+          owner = "alertmanager";
+          group = "alertmanager";
+        };
 
         # Merged over the plain-text settings at runtime so neither
         # credential ever lands in the store. The bridge reads these via
         # systemd LoadCredential, which PID1 opens before dropping
         # privileges, so the file's owner does not matter - 0400 root.
+        #
+        # The incoming-auth block must be `http.auth`, not `http.basic`:
+        # alertmanager-ntfy (as of 1.2.1) silently ignores unknown keys, so
+        # a `basic:` there disables /hook authentication entirely and the
+        # only symptom is a startup warning in the journal.
         sops.templates."monitoring/ntfy/alertmanager-ntfy-auth" = {
           content = ''
             http:
-              basic:
+              auth:
                 username: alertmanager
                 password: "${config.sops.placeholder.${cfg.alertmanager.ntfy.webhookPasswordSecret}}"
             ntfy:


### PR DESCRIPTION
## Why

The push lane has never delivered anything. During today's Grafana outage, `ServiceDown` (warning) fired correctly at ~16:38 AWST and Alertmanager matched it to the `push` route — then every webhook attempt failed:

```
receiver=push integration=webhook[0] err="unable to read basic auth password:
unable to read file /run/secrets/monitoring/ntfy/webhook-password: permission denied"
```

Retries exhausted each cycle until the alert resolved ~17:33. Email was unaffected. Two defects, both invisible to the existing checks:

1. **Secret ownership.** `monitoring/ntfy/webhook-password` was declared bare, so sops-nix installed it `root:root 0400`, but Alertmanager (uid `alertmanager`) reads it at send time. The behaviour test could not reproduce this: its stub fixtures live in the world-readable Nix store.
2. **Wrong config key.** The rendered bridge auth file used `http.basic`; alertmanager-ntfy 1.2.1 reads `http.auth` and silently ignores unknown keys — `/hook` ran with no authentication, its only symptom a startup warning in the journal (verified against upstream source and reproduced locally).

## What changed

- `modules/services/monitoring/monitoring.nix`: declare `owner`/`group = alertmanager` on the webhook password (same shape as `proton_smtp_token`); fix the template key to `http.auth`.
- `checks/stub-secrets.nix`: opt-in `private` list installs fixtures under each secret's *declared* ownership via activation script, mimicking production permissions. Existing callers unchanged.
- `checks/monitoring.nix`: use private stubs; stub template uses the correct key; three new assertions — Alertmanager can read the password as its service user (`runuser -u alertmanager -- test -r ...`), the bridge journal contains no "Basic auth is disabled", and an unauthenticated POST to `/hook` is rejected with 401.

The readability assertion fails against the old module and passes with this one, so the bug class is genuinely guarded now.

## Checks

- `nix build .#checks.x86_64-linux.monitoring` — pass (end-to-end: criticals urgent / warnings silent after group_wait / inhibition / info off-push, plus the new assertions)
- `nix build .#checks.x86_64-linux.{alert-rules,alertmanager-config}` — pass
- All eight checks evaluate

## Rollout notes

- After promotion, hosts pick this up at their nightly windows (04:00 / 04:15 AWST). homelab02 is still on 57c9fb8 (pre-push-lane); until it upgrades, HA dedup means an alert group dispatched from homelab02 would be email-only.
- Warnings stay muted 22:00–07:00 AWST by design; a deliberate end-to-end verification should use a critical or run outside quiet hours.