### PR TITLE
feat(monitoring): attach failed units' journal tails to their alerts

### DIFF
--- a/checks/alert-rules.test.yml
+++ b/checks/alert-rules.test.yml
@@ -1,0 +1,97 @@
+# promtool unit tests for the journal-tail enrichment in alert-rules.yml.
+#
+# checks/default.nix substitutes @RULES@ with the store path of the rule
+# file, because promtool resolves rule_files relative to its working
+# directory and this check runs from an empty build directory.
+#
+# What static `promtool check rules` cannot see and these fixtures pin down:
+#
+#   - the two-branch join behind systemd_unit_failed_with_journal_tail must
+#     return BOTH halves - a failed unit with a captured tail carrying the
+#     tail label, and a failed unit without one still selected. Losing the
+#     fallback branch would silently stop unit-failure alerting for exactly
+#     the units whose journals are quiet.
+#   - no duplicates: the enriched copy of a unit must not appear alongside
+#     its unenriched self.
+#   - the annotation templates render the tail into the notification, and
+#     degrade to the journalctl pointer when there is no tail.
+rule_files:
+  - @RULES@
+
+evaluation_interval: 1m
+
+tests:
+  # The generic SystemdUnitFailed alert against both branches at once.
+  - interval: 1m
+    input_series:
+      - series: 'node_systemd_unit_state{job="node",instance="homelab01:9100",name="broken.service",state="failed"}'
+        values: "1+0x20"
+      # Captured tail for the first host's unit only.
+      - series: 'systemd_unit_journal_tail_info{job="node",instance="homelab01:9100",name="broken.service",tail="2026-08-26T04:00:01 started\n2026-08-26T04:00:02 exited, code=exited/1"}'
+        values: "1+0x20"
+      - series: 'node_systemd_unit_state{job="node",instance="homelab02:9100",name="silent.service",state="failed"}'
+        values: "1+0x20"
+
+    promql_expr_test:
+      # Exactly one sample per failed unit - the enriched one for
+      # broken.service, the bare fallback for silent.service.
+      - expr: systemd_unit_failed_with_journal_tail == 1
+        eval_time: 5m
+        exp_samples:
+          - labels: 'systemd_unit_failed_with_journal_tail{job="node",instance="homelab01:9100",name="broken.service",state="failed",tail="2026-08-26T04:00:01 started\n2026-08-26T04:00:02 exited, code=exited/1"}'
+            value: 1
+          - labels: 'systemd_unit_failed_with_journal_tail{job="node",instance="homelab02:9100",name="silent.service",state="failed"}'
+            value: 1
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: SystemdUnitFailed
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: node
+              instance: homelab01:9100
+              name: broken.service
+              state: failed
+              tail: "2026-08-26T04:00:01 started\n2026-08-26T04:00:02 exited, code=exited/1"
+            exp_annotations:
+              runbook_url: "https://github.com/corygyarmathy/dotfiles/blob/master/docs/runbooks/node#systemdunitfailed"
+              summary: "Systemd unit failed on homelab01:9100"
+              description: "Unit broken.service has been in failed state for 5+ minutes.\n\nRecent journal output:\n2026-08-26T04:00:01 started\n2026-08-26T04:00:02 exited, code=exited/1"
+          - exp_labels:
+              severity: warning
+              job: node
+              instance: homelab02:9100
+              name: silent.service
+              state: failed
+            exp_annotations:
+              runbook_url: "https://github.com/corygyarmathy/dotfiles/blob/master/docs/runbooks/node#systemdunitfailed"
+              summary: "Systemd unit failed on homelab02:9100"
+              description: "Unit silent.service has been in failed state for 5+ minutes. No journal output was captured - check journalctl -u silent.service."
+
+  # A name-filtered consumer of the same recording rule: NixosUpgradeFailed
+  # must select only nixos-upgrade.service out of the enriched set.
+  - interval: 1m
+    input_series:
+      - series: 'node_systemd_unit_state{job="node",instance="homelab02:9100",name="nixos-upgrade.service",state="failed"}'
+        values: "1+0x20"
+      - series: 'systemd_unit_journal_tail_info{job="node",instance="homelab02:9100",name="nixos-upgrade.service",tail="error: hash mismatch in fixed-output derivation"}'
+        values: "1+0x20"
+      - series: 'node_systemd_unit_state{job="node",instance="homelab02:9100",name="something-else.service",state="failed"}'
+        values: "1+0x20"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NixosUpgradeFailed
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: node
+              instance: homelab02:9100
+              name: nixos-upgrade.service
+              state: failed
+              tail: "error: hash mismatch in fixed-output derivation"
+            exp_annotations:
+              runbook_url: "https://github.com/corygyarmathy/dotfiles/blob/master/docs/runbooks/deployment#nixosupgradefailed"
+              summary: "NixOS upgrade failed on homelab02:9100"
+              description: "The nixos-upgrade service has failed.\n\nRecent upgrade output:\nerror: hash mismatch in fixed-output derivation"

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -45,6 +45,32 @@ in
         touch $out
       '';
 
+  # Unit tests for the rules' logic against synthetic series - the two-branch
+  # join behind the journal-tail enrichment and the templates that render it.
+  # Static validity cannot catch a join that silently drops its fallback
+  # branch, which would turn every enrichment gap into a missed page, and
+  # waiting out SystemdUnitFailed's 5m hold-down in a VM just to read one
+  # annotation would be the slow way to learn the same thing.
+  #
+  # The @RULES@ placeholder becomes the rule file's store path, realised as a
+  # writeText input rather than passAsFile: promtool resolves rule_files
+  # relative to its working directory, which here is an empty build
+  # directory, so the test file needs the absolute path baked in either way.
+  alert-rules-unit =
+    let
+      testYml = pkgs.writeText "alert-rules.test.yml"
+        (builtins.replaceStrings
+          [ "@RULES@" ]
+          [ "${../modules/services/monitoring/alert-rules.yml}" ]
+          (builtins.readFile ./alert-rules.test.yml));
+    in
+    pkgs.runCommand "check-alert-rules-unit"
+      { nativeBuildInputs = [ pkgs.prometheus.cli ]; }
+      ''
+        promtool test rules ${testYml}
+        touch $out
+      '';
+
   # Same idea for the Alertmanager side: routing, inhibition and muting are
   # assembled by monitoring.nix from options, and a structural mistake there
   # surfaces only when alertmanager refuses to start - on the machines whose

--- a/checks/monitoring.nix
+++ b/checks/monitoring.nix
@@ -42,11 +42,12 @@
   globalTimeout = 1200;
 
   nodes.machine =
-    { lib, ... }:
+    { lib, pkgs, ... }:
     {
       imports = [
         ../modules/services/monitoring/monitoring.nix
         ../modules/services/monitoring/deploy-metrics.nix
+        ../modules/services/monitoring/journal-tail.nix
 
         # Plaintext stand-ins for the three credentials the alerting path
         # reads: the SMTP token (never exercised - the sandbox has no network,
@@ -119,6 +120,22 @@
             # sink runs right here.
             baseUrl = "http://127.0.0.1:2586";
           };
+        };
+      };
+
+      # A unit that fails loudly, leaving a distinctive line in its journal
+      # and itself in failed state, so the journal-tail exporter (on by
+      # default wherever monitoring is enabled) has something to capture.
+      # Reset once asserted: a permanently failed unit would otherwise mature
+      # into SystemdUnitFailed and wander into the push-lane assertions below.
+      systemd.services.journal-tail-canary = {
+        description = "Deliberately failing unit used to exercise journal tail capture";
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = pkgs.writeShellScript "journal-tail-canary" ''
+            echo "JOURNAL-TAIL-CANARY: the canary failed, as designed"
+            exit 1
+          '';
         };
       };
 
@@ -227,6 +244,36 @@
             return bool(query("nixos_deploy_revision_info"))
 
         retry(revision_exported, timeout=timedelta(seconds=180))
+
+    with subtest("a failed unit's journal tail reaches the textfile collector"):
+        # The canary exits 1 after printing its marker; `start` therefore
+        # reports failure and must not fail the test itself.
+        machine.succeed("systemctl start journal-tail-canary.service || true")
+
+        # Deterministic capture: run the exporter now rather than waiting for
+        # the timer. First the file it writes...
+        machine.succeed("systemctl start journal-tail-exporter.service")
+        machine.succeed(
+            "grep -q JOURNAL-TAIL-CANARY /var/lib/prometheus-node-exporter/journal_tail.prom"
+        )
+
+        # ...then that node_exporter serves it - the wiring step
+        # journal-tail.nix has to override a mkDefault to get.
+        machine.wait_until_succeeds(
+            "curl -sf -o /tmp/node-metrics http://localhost:9100/metrics "
+            "&& grep -q systemd_unit_journal_tail_info /tmp/node-metrics",
+            timeout=60,
+        )
+
+        # Prometheus-side presence is not asserted here: the file-to-scraper
+        # chain is generic and already proven by the deployment metrics
+        # subtest above, while firing SystemdUnitFailed end-to-end would mean
+        # waiting out its 5m hold-down for one annotation string. The join
+        # and templates are pinned exactly by the alert-rules-unit check.
+        #
+        # Clear the failed state so the canary can never leak into the
+        # push-lane assertions below as a real SystemdUnitFailed.
+        machine.succeed("systemctl reset-failed journal-tail-canary.service")
 
     with subtest("the staged timestamp tracks the generation, not the last rebuild"):
         # Read off the file rather than out of Prometheus: this is about what

--- a/docs/runbooks/node.md
+++ b/docs/runbooks/node.md
@@ -39,7 +39,13 @@ state for 5+ minutes. The unit name is in the notification.
 
 ### Do now
 
-- `ssh <host> systemctl status <unit>` then `journalctl -u <unit> -n 100`.
+- The notification carries the unit's last few journal lines when the
+  journal-tail exporter managed to capture them - obvious failures (a
+  traceback, a non-zero exit line) often need nothing more than reading the
+  alert.
+- For full history: `ssh <host> journalctl -u <unit> -n 100` (and
+  `systemctl status <unit>` for restart counts). Capture is best-effort: if
+  the alert says no output was captured, the unit logged nothing this boot.
 - Oneshot units (backups, exporters, garden builds) failing is normal noise;
   long-running services failing is the real signal. The unit name tells you
   which kind.

--- a/modules/services/monitoring/alert-rules.yml
+++ b/modules/services/monitoring/alert-rules.yml
@@ -33,16 +33,46 @@ groups:
           summary: "SMART health check failed"
           description: "Disk {{ $labels.device }} on {{ $labels.instance }} is reporting unhealthy"
 
+      # Failed units enriched with the journal tail captured by
+      # journal-tail-exporter (textfile metric systemd_unit_journal_tail_info,
+      # see journal-tail.nix).
+      #
+      # Two branches, so enrichment can never gate alerting: units WITH a
+      # captured tail get it attached (the arithmetic join is the only vector
+      # operation that copies labels across), units WITHOUT one - exporter has
+      # not run yet, or the unit logged nothing this boot - fall through the
+      # `unless` untouched. and/unless bind tighter than or, so this parses as
+      # (failed unless tail) or (failed joined with tail): disjoint halves of
+      # the failed set, never duplicates.
+      #
+      # The comparisons carry their own parentheses because * binds tighter
+      # than == in PromQL; unparenthesised, the match clause attaches to the
+      # scalar side and the parser rejects it outright - which is how this was
+      # caught, by the unit test below rather than on a host.
+      - record: systemd_unit_failed_with_journal_tail
+        expr: |
+          (
+            node_systemd_unit_state{state="failed"} == 1
+          )
+          unless on (instance, name) systemd_unit_journal_tail_info
+          or
+          (
+            (
+              node_systemd_unit_state{state="failed"} == 1
+            )
+            * on (instance, name) group_left (tail) systemd_unit_journal_tail_info
+          )
+
       # Systemd unit failures (catches NFS mount failures too)
       - alert: SystemdUnitFailed
-        expr: node_systemd_unit_state{state="failed"} == 1
+        expr: systemd_unit_failed_with_journal_tail == 1
         for: 5m
         labels:
           severity: warning
         annotations:
           runbook_url: "https://github.com/corygyarmathy/dotfiles/blob/master/docs/runbooks/node#systemdunitfailed"
           summary: "Systemd unit failed on {{ $labels.instance }}"
-          description: "Unit {{ $labels.name }} has been in failed state for 5+ minutes"
+          description: "Unit {{ $labels.name }} has been in failed state for 5+ minutes.{{ if $labels.tail }}\n\nRecent journal output:\n{{ $labels.tail }}{{ else }} No journal output was captured - check journalctl -u {{ $labels.name }}.{{ end }}"
 
       # High memory usage
       - alert: HighMemoryUsage
@@ -117,14 +147,14 @@ groups:
       # invisible: the site silently ages. Distinct from the generic
       # SystemdUnitFailed rule only so the message points at the right unit.
       - alert: DigitalGardenBuildFailed
-        expr: node_systemd_unit_state{name="digital-garden-build.service", state="failed"} == 1
+        expr: systemd_unit_failed_with_journal_tail{name="digital-garden-build.service"} == 1
         for: 15m
         labels:
           severity: warning
         annotations:
           runbook_url: "https://github.com/corygyarmathy/dotfiles/blob/master/docs/runbooks/digital-garden#digitalgardenbuildfailed"
           summary: "Digital garden build failed on {{ $labels.instance }}"
-          description: "digital-garden-build.service is in failed state, so the site is serving the last good build. Check with: journalctl -u digital-garden-build"
+          description: "digital-garden-build.service is in failed state, so the site is serving the last good build.{{ if $labels.tail }}\n\nRecent build output:\n{{ $labels.tail }}{{ else }} Check: journalctl -u digital-garden-build{{ end }}"
 
       # A sync that quietly stops delivering leaves the service running and the
       # site silently ageing: the builder keeps exiting 0 ("nothing to do") and
@@ -146,14 +176,14 @@ groups:
     rules:
       # Auto-upgrade failures
       - alert: NixosUpgradeFailed
-        expr: node_systemd_unit_state{name="nixos-upgrade.service", state="failed"} == 1
+        expr: systemd_unit_failed_with_journal_tail{name="nixos-upgrade.service"} == 1
         for: 5m
         labels:
           severity: warning
         annotations:
           runbook_url: "https://github.com/corygyarmathy/dotfiles/blob/master/docs/runbooks/deployment#nixosupgradefailed"
           summary: "NixOS upgrade failed on {{ $labels.instance }}"
-          description: "The nixos-upgrade service has failed - check logs with: journalctl -u nixos-upgrade"
+          description: "The nixos-upgrade service has failed{{ if $labels.tail }}.\n\nRecent upgrade output:\n{{ $labels.tail }}{{ else }} - check logs with: journalctl -u nixos-upgrade.{{ end }}"
 
       # Unexpected reboot detection
       #
@@ -305,14 +335,14 @@ groups:
 
       # Systemd service failure
       - alert: CloudflareTunnelServiceFailed
-        expr: node_systemd_unit_state{name="cloudflared-tunnel.service", state="failed"} == 1
+        expr: systemd_unit_failed_with_journal_tail{name="cloudflared-tunnel.service"} == 1
         for: 1m
         labels:
           severity: critical
         annotations:
           runbook_url: "https://github.com/corygyarmathy/dotfiles/blob/master/docs/runbooks/tunnel-and-probes#cloudflaretunnelservicefailed"
           summary: "cloudflared-tunnel.service has failed"
-          description: "The systemd service is in failed state - check logs with: journalctl -u cloudflared-tunnel"
+          description: "The systemd service is in failed state{{ if $labels.tail }}.\n\nRecent tunnel output:\n{{ $labels.tail }}{{ else }} - check logs with: journalctl -u cloudflared-tunnel.{{ end }}"
 
       # Service restarting frequently (crash loop)
       - alert: CloudflareTunnelCrashLoop

--- a/modules/services/monitoring/journal-tail.nix
+++ b/modules/services/monitoring/journal-tail.nix
@@ -1,0 +1,133 @@
+# modules/services/monitoring/journal-tail.nix
+#
+# Puts the last few journal lines of a failed unit INTO the alert that
+# reports it, without standing up a log pipeline (Loki + Alloy remain
+# deliberately deferred).
+#
+# The chain is the established textfile pattern: a oneshot service writes
+# journal_tail.prom next to the other exporters' files, node_exporter serves
+# it, Prometheus scrapes it, and a recording rule in alert-rules.yml joins
+# the captured tail onto node_systemd_unit_state so alert annotations can
+# render it directly. Everything downstream of the metric - push lane, email
+# lane, dashboard - flows unchanged.
+#
+# Deliberately best-effort. A unit whose journal has nothing for the current
+# boot produces no series, and the recording rule's fallback branch selects
+# the bare failed-unit condition instead; the alert then says so rather than
+# pretending output existed. Enrichment gaps must degrade to the old alert,
+# never suppress it.
+#
+# Sizing: 8 lines capped at 150 bytes each keeps a tail near 1.2 KB, so two
+# or three simultaneously-failed units still fit inside ntfy's 4 KB message
+# limit on the push lane. The email lane carries the full text regardless;
+# anything longer than the push message allows is what `journalctl` is for.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.cg.service.monitoring.journalTail;
+
+  metricsDir = "/var/lib/prometheus-node-exporter";
+  metricsFile = "${metricsDir}/journal_tail.prom";
+
+  # Prometheus text exposition escapes, applied line-wise before joining the
+  # lines with literal backslash-n sequences. Everything outside printable
+  # ASCII (control characters, ANSI colour codes, invalid UTF-8 from a
+  # misbehaving unit) is stripped first: one malformed label value makes
+  # node_exporter reject the WHOLE file for that scrape, which would take the
+  # zfs/gluetun/deploy metrics down with it. Truncation happens after that
+  # filtering, under LC_ALL=C so cut counts bytes and can never split a
+  # multibyte character.
+  journalTailScript = pkgs.writeShellScript "journal-tail-exporter" ''
+    set -euo pipefail
+
+    OUT_DIR="${metricsDir}"
+    TMP_FILE="${metricsFile}.tmp"
+    mkdir -p "$OUT_DIR"
+
+    {
+      echo "# HELP systemd_unit_journal_tail_info Recent journal output of a systemd unit, captured while it is in failed state"
+      echo "# TYPE systemd_unit_journal_tail_info gauge"
+
+      # Column 1 of list-units output is the unit name; --plain keeps table
+      # headers out of --no-legend output on the systemctl versions that
+      # would otherwise emit them.
+      units="$(systemctl list-units --state=failed --plain --no-legend 2>/dev/null | ${pkgs.gawk}/bin/awk '{print $1}' || true)"
+      for unit in $units; do
+        # Current boot only: failed state does not survive a reboot, so older
+        # entries cannot be what fired the alert. Timestamps stay in
+        # (short-iso) because crash-loop cadence is triage information.
+        tail="$(journalctl -u "$unit" -b -n ${toString cfg.lines} -o short-iso --no-pager 2>/dev/null \
+          | tr -d '\r' \
+          | tr -cd '\11\12\40-\176' \
+          | LC_ALL=C cut -c1-150 \
+          | ${pkgs.gawk}/bin/awk '{gsub(/\\/,"\\\\"); gsub(/"/,"\\\""); printf "%s%s", sep, $0; sep="\\n"}' \
+          || true)"
+        [ -n "$tail" ] || continue
+        printf 'systemd_unit_journal_tail_info{name="%s",tail="%s"} 1\n' "$unit" "$tail"
+      done
+    } > "$TMP_FILE"
+
+    # Atomic swap, same reason as deploy-metrics: the collector reads this
+    # directory continuously and a half-written file is a parse error rather
+    # than a missing metric.
+    mv "$TMP_FILE" "${metricsFile}"
+  '';
+in
+{
+  options.cg.service.monitoring.journalTail = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Capture the last journal lines of failed systemd units as a textfile
+        metric, so unit-failure alerts carry the relevant output instead of
+        only pointing at journalctl.
+      '';
+    };
+
+    lines = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 8;
+      description = "How many journal lines to capture per failed unit.";
+    };
+  };
+
+  config = lib.mkIf (config.cg.service.monitoring.enable && cfg.enable) {
+    # Overrides the mkDefault in monitoring.nix, which otherwise leaves the
+    # textfile collector off on any host without ZFS or the VPN - homelab01.
+    cg.service.monitoring.textfileCollector.enable = true;
+
+    systemd.tmpfiles.rules = [
+      "d ${metricsDir} 0755 root root -"
+    ];
+
+    systemd.services.journal-tail-exporter = {
+      description = "Capture failed units' journal tails for Prometheus";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = journalTailScript;
+      };
+    };
+
+    # One-minute cadence matches the scrape interval: the tail is never more
+    # than a couple of minutes older than the alert it enriches, well inside
+    # SystemdUnitFailed's 5m hold-down. A run with no failed units rewrites
+    # the file header-only, which is what clears stale tails promptly -
+    # skipping the write would leave a recovered unit's output attached to
+    # nothing until Prometheus staleness got around to it.
+    systemd.timers.journal-tail-exporter = {
+      description = "Timer for journal tail capture";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "1min";
+        OnUnitActiveSec = "1min";
+        Unit = "journal-tail-exporter.service";
+      };
+    };
+  };
+}


### PR DESCRIPTION
## What and why

The monitoring workflow discussion landed on deferring Loki + Alloy but wanting the obvious case covered: a service fails, and the relevant logs should be *in* the alert, not one ssh away. This is the cheap half of that wish, built entirely on the existing textfile-collector pattern.

A 1-minute oneshot (`journal-tail-exporter`) captures the last 8 journal lines of every currently-failed unit into `journal_tail.prom` (sanitized to printable ASCII, byte-capped per line, atomic swap - one malformed label value must never take down the zfs/gluetun/deploy textfile metrics). A recording rule joins tails onto `node_systemd_unit_state`, and four alerts render them:

- `SystemdUnitFailed` (generic)
- `DigitalGardenBuildFailed`
- `NixosUpgradeFailed`
- `CloudflareTunnelServiceFailed`

**Enrichment can never gate alerting.** The join is two disjoint branches: failed units with a captured tail get it attached; failed units without one (exporter not yet run, unit logged nothing this boot) fall through an `unless` untouched and degrade to the old "check journalctl" wording.

Tails flow through both existing lanes unchanged: push (ntfy) and email. Default-on wherever `cg.service.monitoring` is enabled (homelab01/02); xps15 unaffected.

## Sizing note

8 lines x 150 bytes keeps a tail near 1.2 KB, so 2-3 simultaneously-failed units still fit ntfy's 4 KB push message. Beyond that, email carries full text and `journalctl` covers history (tails are current-boot only).

## Checks

- **New:** `alert-rules-unit` - promtool unit tests over synthetic series pinning both join branches (with-tail / no-tail / no duplicates) and exact rendered annotations. First run caught a real bug pre-deploy: `*` binds tighter than `==` in PromQL, so the unparenthesized join was rejected outright.
- **Extended:** `monitoring` VM test gains a failing-canary subtest proving capture reaches node_exporter's `/metrics`. Its first run caught a second real bug: `awk` does not exist in a systemd service's default PATH.
- Green: `alert-rules`, `alertmanager-config`, `monitoring`, `grafana` checks; all three host toplevels evaluate; journal-tail units confirmed on homelab01/02.
- Skipped: full `nix flake check` (every VM test importing the changed modules ran individually).

## Docs

- `docs/runbooks/node.md`: SystemdUnitFailed now leads with "read the alert", ssh/journalctl demoted to deep-dive.