### PR TITLE
fix(monitoring): ntfy bridge port collision on homelab02; verification attribution

### DIFF
--- a/checks/upgrade-verify.nix
+++ b/checks/upgrade-verify.nix
@@ -70,6 +70,23 @@
           ExecStart = "${pkgs.coreutils}/bin/false";
         };
       };
+
+      # A second kind of broken: Restart= keeps re-offering a unit that keeps
+      # dying. With restarts slower than the start limit this never reaches
+      # the terminal "failed" state - it sits in "activating (auto-restart)",
+      # which is exactly why it needs its own subtest. RestartSec is long so
+      # the state is deterministic: verification always finds it mid-wait,
+      # never mid-crash and never start-limit-tripped into failed. Not
+      # Type=oneshot: systemd refuses to combine that with Restart=.
+      systemd.services.cg-verify-crashlooper = {
+        description = "Unit stuck in systemd's auto-restart state";
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${pkgs.coreutils}/bin/false";
+          Restart = "always";
+          RestartSec = "30s";
+        };
+      };
     };
 
   # A second machine, because the trigger under test is the one that fires
@@ -302,8 +319,36 @@
         assert metric("nixos_verify_result") == "0"
         assert metric("nixos_verify_rolled_back") == "0"
 
-    with subtest("a healthy staged generation is blessed"):
+    with subtest("a unit stuck restarting counts even though systemd calls it activating"):
+        # Regression guard for 2026-08-26: alertmanager-ntfy crash-looped all
+        # night in "activating (auto-restart)", invisible to list-units
+        # --failed, so verification judged the generation on the wrong
+        # evidence. The canary is cleared first so the crashlooper is the only
+        # thing wrong and the attribution in the journal is exact.
         machine.succeed("systemctl reset-failed cg-verify-canary.service")
+        # Unlike the oneshot canary above, a simple service's start job
+        # completes when the process is spawned; the failure and the restart
+        # are systemd's business afterwards.
+        machine.succeed("systemctl start cg-verify-crashlooper.service")
+        sub = machine.succeed(
+            "systemctl show cg-verify-crashlooper -p SubState --value"
+        ).strip()
+        assert sub == "auto-restart", (
+            "fixture is not exercising the auto-restart state: {}".format(sub)
+        )
+
+        journal = arm(staged=current, rolled_back_ago=60)
+
+        assert "cg-verify-crashlooper" in journal, journal
+        assert metric("nixos_verify_result") == "0"
+
+        machine.succeed("systemctl stop cg-verify-crashlooper.service")
+        # No reset-failed here: a unit stopped out of auto-restart goes
+        # inactive, never through failed, so there is nothing to reset.
+
+    with subtest("a healthy staged generation is blessed"):
+        # The crashlooper subtest above already cleared the canary, so
+        # everything is clean here by construction.
         machine.succeed("systemctl start nixos-upgrade-verify.service")
 
         assert metric("nixos_verify_result") == "1"
@@ -325,6 +370,36 @@
         machine.succeed("systemctl start nixos-upgrade-verify.service")
         journal = machine.succeed("journalctl -u nixos-upgrade-verify.service --no-pager")
         assert "already verified" in journal, journal
+
+    with subtest("a failed upgrade run does not itself condemn the generation"):
+        # Regression guard for 2026-08-26: the switch failed, nixos-upgrade
+        # entered the failed state before its ExecStopPost triggered
+        # verification, and verification counted the trigger unit as the new
+        # failure - a healthy generation reported as broken. Starting
+        # nixos-upgrade here reproduces exactly that: its flake ref is
+        # /dev/null, so the run fails, and ExecStopPost both records the staged
+        # generation (unchanged - the rebuild failed before it staged anything)
+        # and starts verification, which must now bless what is running.
+        machine.succeed("systemctl reset-failed cg-verify-canary.service")
+        machine.succeed("rm -f {}/verified-system".format(STATE))
+        # A real host always has a system profile for the ExecStopPost
+        # record-staged hook to read the staged generation off; a bare VM
+        # boots straight from the store without one, so seed it the way the
+        # rollback subtest does.
+        machine.succeed("nix-env -p /nix/var/nix/profiles/system --set {}".format(current))
+        machine.fail("systemctl start nixos-upgrade.service")
+        machine.succeed("systemctl is-failed nixos-upgrade.service")
+
+        # Verification is started by the upgrade's own ExecStopPost, as in
+        # production; give its settle window room to finish.
+        machine.sleep(20)
+
+        assert metric("nixos_verify_result") == "1"
+        assert metric("nixos_verify_manual_generation") == "0"
+        assert (
+            machine.succeed("cat {}/verified-system".format(STATE)).strip() == current
+        )
+        machine.succeed("systemctl reset-failed nixos-upgrade.service")
 
     with subtest("the schedule verifies a generation nothing announced"):
         # Nothing on this node ever starts verification: no upgrade runs, and

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -80,8 +80,12 @@ reports success while the new kernel waits for the next reboot.
 ## NixosVerifyFailed
 
 **Severity:** critical (buzzes) · **Fires when:** activation verification
-found critical units failing that were not failing before the upgrade - the
-new generation came up broken.
+found units failing that were not failing before the upgrade - the new
+generation came up broken. "Failing" includes units stuck in
+`activating (auto-restart)`, which never reach the terminal failed state; and
+it excludes the upgrade machinery itself (`nixos-upgrade`,
+`nixos-upgrade-verify`), whose failures are [NixosDeployFailed](#nixosdeployfailed)'s
+business, so a name in the journal is a genuine symptom.
 
 ### Do now
 

--- a/hosts/homelab02/default.nix
+++ b/hosts/homelab02/default.nix
@@ -163,7 +163,15 @@
         # Push lane. The ntfy server itself lives on homelab01; this host runs
         # only the local alertmanager-ntfy bridge, so either host can still
         # deliver on its own if the other is down.
-        ntfy.enable = true;
+        #
+        # Off 8000 because gluetun's control server is published there
+        # (qbittorrent.nix) - with the shared default the bridge lost the bind
+        # race on every start, and the 2026-08-26 upgrade that introduced it
+        # was marked failed by its own activation.
+        ntfy = {
+          enable = true;
+          port = 8015;
+        };
         email = {
           to = "cory@gyarmathy.co";
           from = "alerts@gyarmathy.co";

--- a/modules/nixos/upgrade-verify.nix
+++ b/modules/nixos/upgrade-verify.nix
@@ -70,6 +70,22 @@
 #     that keeps being re-offered flaps once a night rather than in a loop.
 #   - no rollback if the profile has no previous generation to return to.
 #
+# Two more things count, or do not count, as failure - both learned from the
+# night of 2026-08-26, when an upgrade introduced alertmanager-ntfy onto a
+# port gluetun already held and every guard misfired at once:
+#
+#   - A unit stuck in "activating (auto-restart)" counts as failing. One with
+#     Restart= configured whose restarts stay slower than its start limit
+#     never reaches the terminal "failed" state, so it is invisible to
+#     list-units --failed forever; that unit looped six thousand times while
+#     verification looked straight through it.
+#   - The machinery's own units do not count against the generation.
+#     nixos-upgrade enters the failed state before the ExecStopPost that
+#     triggers verification whenever the run fails for any reason, so counting
+#     it let a plumbing failure (the switch reporting the crash-looping bridge)
+#     be diagnosed as "the new generation came up broken" - the wrong unit
+#     named, and on a rollback-armed host a healthy generation reverted.
+#
 # `rollback.enable` is off by default. The failure mode of this module is
 # reverting a healthy server, and the honest way to find that out is to watch
 # it decide for a few weeks before letting it act.
@@ -226,14 +242,41 @@ let
     echo "systemd reports: ''${state:-unknown}"
 
     now="$(date +%s)"
-    ${failedUnits} | ${pkgs.gawk}/bin/awk '{print $1}' | sort -u > "${stateDir}/failed-units-now"
+
+    # Failed units, plus anything stuck restarting. A unit with Restart=
+    # configured that keeps losing the race against its own start limit sits
+    # in "activating (auto-restart)" indefinitely and never reaches "failed":
+    # alertmanager-ntfy crash-looped six thousand times overnight on
+    # 2026-08-26 while every check that read only list-units --failed saw a
+    # clean host. A service that is being restarted because it keeps dying is
+    # failing, whatever systemd's terminal-state vocabulary says.
+    {
+      ${failedUnits} | ${pkgs.gawk}/bin/awk '{print $1}'
+      # Columns of list-units are UNIT LOAD ACTIVE SUB: auto-restart is a
+      # substate, hence $4.
+      ${pkgs.systemd}/bin/systemctl list-units --state=activating --plain --no-legend --no-pager \
+        | ${pkgs.gawk}/bin/awk '$4 == "auto-restart" {print $1}'
+    } | sort -u > "${stateDir}/failed-units-now"
+
+    # Units owned by this machinery rather than by the generation being
+    # judged. nixos-upgrade enters the failed state *before* its ExecStopPost
+    # triggers verification whenever the run fails for any reason - including
+    # reasons that say nothing about the generation, like a switch returning
+    # non-zero for a unit that has since recovered. Counting it makes every
+    # plumbing failure read as "the new generation came up broken", which is
+    # both the wrong diagnosis at 04:00 and, on a host where rollback is ever
+    # armed, a healthy generation reverted. Its failures are NixosDeployFailed
+    # and NixosUpgradeFailed's business. nixos-upgrade-verify is excluded for
+    # the symmetric reason - it fails as a consequence of its own verdict -
+    # and excluding it masks nothing, since each run judges afresh.
+    machinery_re='^(nixos-upgrade|nixos-upgrade-verify)\.service$'
 
     # Only units that were not already broken before the upgrade started.
     if [ -r "${baselineFile}" ]; then
-      new_failures="$(comm -23 "${stateDir}/failed-units-now" "${baselineFile}" | tr '\n' ' ')"
+      new_failures="$({ comm -23 "${stateDir}/failed-units-now" "${baselineFile}" | grep -Ev -e "$machinery_re"; } | tr '\n' ' ')"
       baseline_age="$(( now - $(stat -c %Y "${baselineFile}") ))"
     else
-      new_failures="$(tr '\n' ' ' < "${stateDir}/failed-units-now")"
+      new_failures="$(grep -Ev -e "$machinery_re" "${stateDir}/failed-units-now" | tr '\n' ' ')"
       baseline_age=-1
     fi
 
@@ -547,6 +590,7 @@ in
       };
       path = [
         pkgs.coreutils # comm, sort, stat, timeout, tr
+        pkgs.gnugrep # machinery-unit exclusion from the new-failure set
         pkgs.gnused
       ];
     };

--- a/modules/services/monitoring/monitoring.nix
+++ b/modules/services/monitoring/monitoring.nix
@@ -223,10 +223,22 @@ in
       ntfy = {
         enable = lib.mkEnableOption "ntfy push routing for Alertmanager";
 
-        bridgeUrl = lib.mkOption {
-          type = lib.types.str;
-          default = "http://127.0.0.1:8000/hook";
-          description = "URL of the local alertmanager-ntfy webhook endpoint (/hook)";
+        # Loopback port the local bridge listens on, and the one port
+        # Alertmanager delivers to. Configurable because 8000 is already taken
+        # by convention wherever the media stack runs: gluetun's HTTP control
+        # server is published there (qbittorrent.nix), and gluetun coexists
+        # with this bridge precisely on storage hosts. When the bridge landed
+        # on homelab02 with the shared literal below it lost that race on
+        # every start, crash-looped all night, and the switch that activated
+        # it reported failed units. Anything loopback and free will do;
+        # there is nothing to match on either side.
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 8000;
+          description = ''
+            Loopback port for the local alertmanager-ntfy bridge. Move off
+            8000 on any host whose gluetun control server is published there.
+          '';
         };
 
         baseUrl = lib.mkOption {
@@ -708,7 +720,9 @@ in
                 name = "push";
                 webhook_configs = [
                   {
-                    url = cfg.alertmanager.ntfy.bridgeUrl;
+                    # Derived from the bridge's port so there is one literal,
+                    # not two that can drift apart.
+                    url = "http://127.0.0.1:${toString cfg.alertmanager.ntfy.port}/hook";
                     send_resolved = true;
                     http_config.basic_auth = {
                       username = "alertmanager";
@@ -772,7 +786,7 @@ in
         services.prometheus.alertmanager-ntfy = {
           enable = true;
           settings = {
-            http.addr = "127.0.0.1:8000";
+            http.addr = "127.0.0.1:${toString cfg.alertmanager.ntfy.port}";
             ntfy = {
               baseurl = cfg.alertmanager.ntfy.baseUrl;
               notification = {


### PR DESCRIPTION
## What happened

homelab02's 04:15 auto-upgrade on 2026-08-26 activated the revision that introduced the ntfy push lane (#62/#65). The new `alertmanager-ntfy` bridge binds `127.0.0.1:8000`; gluetun - which runs on this host - publishes its HTTP control server on `0.0.0.0:8000` (`modules/services/media-stack/qbittorrent.nix`). The bridge lost the bind race, `switch-to-configuration switch` reported failed units and exited 4, and `nixos-upgrade.service` failed. The bridge has crash-looped ever since (~6,100 restarts; push delivery continued via homelab01's bridge through the Alertmanager cluster).

Alerts received: `NixosVerifyFailed` (critical), `NixosDeployFailed`, `NixosUpgradeFailed`, `SystemdUnitFailed` x2.

## Why the safety net misfired

Verification was right that the generation was unhealthy, and wrong in two specifics:

1. **It named the wrong unit.** `nixos-upgrade.service` enters failed state *before* its ExecStopPost triggers verification, so it was counted as the "new failure" - any plumbing failure would read as "the generation came up broken". On a rollback-armed host this would revert a healthy generation.
2. **It missed the real culprit.** A unit with `Restart=` whose restarts outrun its start limit sits in `activating (auto-restart)` forever and never reaches `failed`, so `list-units --failed` cannot see it.

A latent third problem: tonight's baseline will contain the failed `nixos-upgrade.service`, so a repeat of yesterday would have made verification *bless* a broken generation.

## Changes

- `modules/services/monitoring/monitoring.nix` + `hosts/homelab02/default.nix`: replace the hardcoded bridge URL with a `port` option (default unchanged at 8000; homelab02 → 8015); the Alertmanager webhook URL is derived from it so one literal can't drift from the other.
- `modules/nixos/upgrade-verify.nix`: count units stuck in `auto-restart` as failing (through the same baseline filter as everything else); exclude the upgrade machinery's own units (`nixos-upgrade`, `nixos-upgrade-verify`) from new-failure attribution.
- `checks/upgrade-verify.nix`: two regression subtests - a crash-looping unit must be found even though systemd calls it activating, and a failed upgrade run must not condemn a healthy generation. Both fail against the old script.
- `docs/runbooks/deployment.md`: NixosVerifyFailed runbook reflects the changed semantics.

## Validation

- `nix flake check --print-build-logs`: all checks passed (all host builds, promtool/amtool static checks, all VM tests including 11/11 upgrade-verify subtests).

## Operational notes

- homelab02 stays degraded until this promotes and deploys (~04:15); `nixos_verify_result` returns to 1 by itself afterwards. Optional cleanup post-deploy: `systemctl reset-failed nixos-upgrade nixos-upgrade-verify`.
- Nothing remote was modified during investigation (read-only SSH only).