### PR TITLE
feat(garden): a contents list and backlinks in the right margin

### DIFF
--- a/docs/plans/digital-garden-design.md
+++ b/docs/plans/digital-garden-design.md
@@ -7,7 +7,7 @@ Status: proposed 2026-08-27; decisions taken the same day, see _Decisions_ below
 | 1   | Rendering fixture + screenshot loop | small  | -          | **done** 2026-08-27 |
 | 2   | Kanagawa palette                    | medium | 1          | **done** 2026-08-27 |
 | 3   | An index of everything published    | small  | -          | not started |
-| 4   | Right-hand rail: contents, backlinks| medium | 1          | **first pass** |
+| 4   | Right-hand rail: contents, backlinks| medium | 1          | **done** 2026-08-27 |
 | 5   | Link and image treatment            | small  | 2          | not started |
 | 6   | Typography                          | small  | 2          | **agreed, not scheduled** |
 | 7   | Wikilink hover previews             | medium | -          | optional    |
@@ -151,9 +151,19 @@ An optional twenty lines of `IntersectionObserver` highlights the section curren
 
 The finicky part is alignment: the masthead and footer must line up with the prose column and not with the full page width, or the rule under the masthead extends past the text it belongs to. The prototype got this subtly wrong and it was visible immediately.
 
+### What it cost that the plan did not price in
+
+**Hugo wraps the heading tree in a synthetic root.** `.Fragments.Headings` returns one entry — `Level` 0, empty `Title` — whenever a page's headings do not start at H1, which here is *always*, because `publish-filter.py` lifts a note's leading H1 out of the body to become the title. So the count is one on every page, the threshold of three is never met, and the contents list silently renders nowhere. Nothing errors. It was found by a page with twelve visible sections reporting one, and it is now a comment in `rail.html` rather than a fact to rediscover.
+
+**A nil frontmatter key is not a zero-length one.** `len .Params.backlinks` errors on a note with no backlinks — `reflect: call of reflect.Value.Type on zero Value` — which is a build failure and not a missing rail. The truthiness of the value is the right test.
+
+### What it actually ships, on the real vault
+
+Six of nineteen pages get a rail: the five Lighting notes and Work-Life Balance. Three of those get a contents list. The other thirteen render no `<aside>` at all, which is what the plan asked for and what the numbers predicted.
+
 ### Cost and risk
 
-Half a day, most of it in the alignment and the narrow-width fallback. The risk is the one in the findings section: on thirteen of nineteen pages this ships nothing. The mitigation is the render-when-non-empty rule, and the reason to build it anyway is that the pages where it does appear — the Lighting set — are the ones people are actually sent to.
+Half a day, most of it in the two findings above rather than in the alignment. The risk is the one in the findings section: on thirteen of nineteen pages this ships nothing. The mitigation is the render-when-non-empty rule, and the reason to build it anyway is that the pages where it does appear — the Lighting set — are the ones people are actually sent to.
 
 ## 5. Link and image treatment
 

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -96,15 +96,23 @@ body {
 }
 
 /* One column, capped. "No sidebars" is not the same as "prose should span a 27
- * inch monitor" — line length is a legibility function. */
+ * inch monitor" — line length is a legibility function.
+ *
+ * The cap moved off .page and onto the three things inside it, so that .page
+ * can be full width for the grid below while the masthead, the prose and the
+ * footer stay exactly where they have always been. All three are capped at the
+ * measure and centred in the same padded box, so they agree with each other by
+ * construction rather than by three numbers that have to be kept equal. */
 .page {
   width: 100%;
-  /* The cap is on the TEXT, so the gutter has to be added to it rather than
-   * taken out of it - box-sizing: border-box would otherwise make the measure
-   * 3rem narrower than it says. */
-  max-width: calc(var(--measure) + 3rem);
-  margin: 0 auto;
   padding: 4rem 1.5rem 3rem;
+}
+
+.masthead,
+.layout,
+footer {
+  max-width: var(--measure);
+  margin-inline: auto;
 }
 
 /* ── masthead ───────────────────────────────────────────────────────────── */
@@ -553,18 +561,24 @@ h4:hover > .heading-anchor,
   }
 }
 
-/* ── backlinks ──────────────────────────────────────────────────────────── */
+/* ── the rail ───────────────────────────────────────────────────────────── */
 
-/* Set apart from the essay rather than continuing it: these are other notes'
- * words, and a reader who has reached the end of one piece should be able to
- * see where the piece ends. */
-.backlinks {
+/* Where you are in this note, and what else points at it. One piece of markup
+ * with two layouts: beneath the article by default, and in the right margin
+ * once there is a margin to put it in. See layouts/_partials/rail.html.
+ *
+ * The default is the narrow one, so the layout the site served before the rail
+ * existed is the one that needs no media query to produce. Set apart from the
+ * essay rather than continuing it: these are other notes' words and a list of
+ * this one's parts, and a reader who has reached the end of a piece should be
+ * able to see where the piece ends. */
+.rail {
   margin-top: 3rem;
   padding-top: 1.25rem;
   border-top: 1px solid var(--border);
 }
 
-.backlinks h2 {
+.rail h2 {
   margin: 0 0 0.75rem;
   font-size: 0.8rem;
   font-weight: 600;
@@ -573,19 +587,103 @@ h4:hover > .heading-anchor,
   color: var(--muted);
 }
 
-.backlinks ul {
+.rail ul {
   margin: 0;
   padding-left: 1.25rem;
 }
 
-.backlinks li {
+.rail li {
   margin-bottom: 0.35rem;
+}
+
+/* A contents list of the page you are already on is navigation, not reading,
+ * and duplicating the page's own headings beneath it is the one thing the
+ * narrow layout should NOT do. Backlinks are different: they are the only
+ * place those notes appear. */
+.rail-nav {
+  display: none;
 }
 
 /* Same treatment the index gives an annotated link: the claim is secondary to
  * the title it belongs to. */
 .backlink-thesis {
   color: var(--muted);
+}
+
+/* Wide enough for a rail that is a full 15rem AND leaves the prose centred:
+ * the two outer tracks are equal, so the article sits exactly where it does at
+ * every narrower width and the rail fills space that was empty. Below this the
+ * whole block above applies unchanged and nothing has moved. */
+@media (min-width: 80rem) {
+  .layout {
+    max-width: none;
+    display: grid;
+    /* minmax(0, …) on the centre track rather than a bare value: a wide table
+     * or a long code line inside the article would otherwise widen the track
+     * past the measure and push the rail off the page. */
+    grid-template-columns: 1fr minmax(0, var(--measure)) 1fr;
+    column-gap: 3rem;
+    align-items: start;
+  }
+
+  .layout > article {
+    grid-column: 2;
+  }
+
+  .rail {
+    grid-column: 3;
+    /* Aligned to the top of the prose, not stretched down the page: `start`
+     * on the grid keeps it the height of its own content, which is what
+     * sticky needs. */
+    width: min(15rem, 100%);
+    position: sticky;
+    top: 2rem;
+    /* A rail longer than the window scrolls inside itself. A nested scrollbar
+     * is a compromise rather than a design, and `##`-only exists so that it is
+     * rarely reached. */
+    max-height: calc(100dvh - 4rem);
+    overflow-y: auto;
+    margin-top: 0;
+    padding-top: 0;
+    border-top: none;
+    font-size: 0.875rem;
+    line-height: 1.45;
+  }
+
+  .rail-nav {
+    display: block;
+    margin-bottom: 2rem;
+  }
+
+  /* No bullets and no indent out here: the rail is a column of its own and the
+   * markers were doing work that the margin now does. */
+  .rail ul {
+    padding-left: 0;
+    list-style: none;
+  }
+
+  /* Rail links are navigation, not prose. The accent is spent on the section
+   * you are in rather than on all of them at once, which is the difference
+   * between a list of links and a sense of place. */
+  .rail a {
+    display: block;
+    padding: 0;
+    background: none;
+    color: var(--muted);
+  }
+
+  .rail a:hover {
+    color: var(--text);
+    text-decoration: none;
+  }
+
+  .rail a.current {
+    color: var(--accent);
+  }
+
+  .rail .backlink-thesis {
+    display: none;
+  }
 }
 
 /* ── footer ─────────────────────────────────────────────────────────────── */

--- a/modules/services/digital-garden/lib/hugo/layouts/404.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/404.html
@@ -1,6 +1,8 @@
 {{ define "main" }}
-  <article>
-    <h1>Not found</h1>
-    <p>There is no page at this address. Try the <a href="{{ "/" | relURL }}">index</a>.</p>
-  </article>
+  <div class="layout">
+    <article>
+      <h1>Not found</h1>
+      <p>There is no page at this address. Try the <a href="{{ "/" | relURL }}">index</a>.</p>
+    </article>
+  </div>
 {{ end }}

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/rail.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/rail.html
@@ -1,0 +1,64 @@
+{{/*
+  The right-hand rail: where a reader is in this note, and what else points at
+  it. Both belong beside the prose rather than beneath it — a reader who wants
+  to know what cites a note wants it while reading, not four screens below
+  where they stopped.
+
+  Rendered as a sibling of <article> in the same grid, and NOT inside it, for
+  the same reason backlinks.html always sat outside: these are other notes'
+  words and a list of this one's own headings, and indexing either would make a
+  search for a phrase return the page that listed it rather than the page that
+  said it.
+
+  The whole element is skipped when it would be empty, which today is most
+  pages: of nineteen published notes, ten have no `##` at all and five carry a
+  backlink. An empty box in the margin is worse than an empty margin.
+
+  There is exactly one copy of this markup. Below the breakpoint the grid
+  collapses and this falls back into the flow beneath the article, which is the
+  layout the site served before the rail existed - so the narrow case is CSS,
+  not a second partial that has to be kept in step.
+*/}}
+{{ $page := . }}
+{{/*
+  Top-level sections only - `##`, never `###`. The longest note in the vault
+  has twenty-nine headings and thirteen sections: the sections fit a viewport
+  and the headings do not, and a rail that scrolls inside itself is a
+  compromise rather than a design. Three is the threshold, because a contents
+  list of one or two entries restates the page rather than offering a way
+  around it.
+
+  The descent below is not decoration. Hugo wraps the heading tree in a
+  SYNTHETIC root - Level 0, empty Title - whenever a page's headings do not
+  start at H1, which here is always: publish-filter.py lifts a note's leading
+  H1 out of the body to become the title, so every note's markdown begins at
+  `##`. Without it .Fragments.Headings is a slice of one on every page, the
+  count is never three, and the contents list silently never renders anywhere -
+  which is exactly what it did until a page with twelve visible sections
+  reported one.
+*/}}
+{{ $sections := .Fragments.Headings }}
+{{ if and $sections (eq (index $sections 0).Level 0) }}
+  {{ $sections = (index $sections 0).Headings }}
+{{ end }}
+{{ $showToc := ge (len $sections) 3 }}
+{{/* Truthiness rather than a length: a note with no backlinks has no
+     `backlinks` key at all, and `len` on the missing value is an error and not
+     a zero. */}}
+{{ $showBacklinks := .Params.backlinks }}
+
+{{ if or $showToc $showBacklinks }}
+  <aside class="rail">
+    {{ if $showToc }}
+      <nav class="rail-nav" aria-labelledby="rail-toc-title">
+        <h2 id="rail-toc-title">On this page</h2>
+        <ul>
+          {{ range $sections }}
+            <li><a href="#{{ .ID }}">{{ .Title }}</a></li>
+          {{ end }}
+        </ul>
+      </nav>
+    {{ end }}
+    {{ with $page }}{{ partial "backlinks.html" . }}{{ end }}
+  </aside>
+{{ end }}

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -154,5 +154,66 @@
         });
       })();
     </script>
+
+    {{/*
+      Marks the section the reader is in. The contents list works without this
+      - it is a list of links either way - so everything here is guarded and
+      anything missing simply leaves it as one.
+
+      The observation band is the top fifth of the viewport, which is where a
+      reader's eye is when they have just arrived at a section, rather than the
+      whole window: with a full-height root every heading on a short page is
+      "visible" at once and the highlight never moves. When nothing is in the
+      band - mid-section, which is most of the time - the current section is
+      the last heading that has passed above the viewport.
+    */}}
+    <script>
+      (function () {
+        var nav = document.querySelector(".rail-nav");
+        if (!nav || !window.IntersectionObserver) return;
+
+        var links = {};
+        var headings = [];
+        nav.querySelectorAll("a[href^='#']").forEach(function (a) {
+          var id = decodeURIComponent(a.hash.slice(1));
+          var heading = document.getElementById(id);
+          if (!heading) return;
+          links[id] = a;
+          headings.push(heading);
+        });
+        if (!headings.length) return;
+
+        var current = null;
+        function mark(id) {
+          var next = id ? links[id] : null;
+          if (next === current) return;
+          if (current) current.classList.remove("current");
+          if (next) next.classList.add("current");
+          current = next;
+        }
+
+        var inBand = {};
+        var observer = new IntersectionObserver(
+          function (entries) {
+            entries.forEach(function (e) {
+              inBand[e.target.id] = e.isIntersecting;
+            });
+            for (var i = 0; i < headings.length; i++) {
+              if (inBand[headings[i].id]) return mark(headings[i].id);
+            }
+            for (var j = headings.length - 1; j >= 0; j--) {
+              if (headings[j].getBoundingClientRect().top < 0) {
+                return mark(headings[j].id);
+              }
+            }
+            mark(null);
+          },
+          { rootMargin: "0px 0px -80% 0px" }
+        );
+        headings.forEach(function (h) {
+          observer.observe(h);
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/modules/services/digital-garden/lib/hugo/layouts/home.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/home.html
@@ -4,8 +4,12 @@
     publish-filter.py has already annotated each bare link with the target's
     thesis, so what is authored is what should be shown.
   */}}
-  <article data-pagefind-body>
-    <h1>{{ .Title }}</h1>
-    {{ .Content }}
-  </article>
+  {{/* .layout carries the measure cap; it is a grid only where there is a
+       rail to put in it, and the landing page has none. */}}
+  <div class="layout">
+    <article data-pagefind-body>
+      <h1>{{ .Title }}</h1>
+      {{ .Content }}
+    </article>
+  </div>
 {{ end }}

--- a/modules/services/digital-garden/lib/hugo/layouts/page.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/page.html
@@ -1,8 +1,15 @@
 {{ define "main" }}
-  <article data-pagefind-body>
-    <h1>{{ .Title }}</h1>
-    {{ partial "dateline.html" . }}
-    {{ .Content }}
-  </article>
-  {{ partial "backlinks.html" . }}
+  {{/*
+    article and rail are siblings in one grid, so that the rail can occupy the
+    empty right margin at wide widths and fall back beneath the article at
+    narrow ones without a second copy of the markup. See _partials/rail.html.
+  */}}
+  <div class="layout">
+    <article data-pagefind-body>
+      <h1>{{ .Title }}</h1>
+      {{ partial "dateline.html" . }}
+      {{ .Content }}
+    </article>
+    {{ partial "rail.html" . }}
+  </div>
 {{ end }}


### PR DESCRIPTION
Item 4 of `docs/plans/digital-garden-design.md`, and the last of the agreed first pass.

## Problem

The prose column is capped at 40rem and centred, so a 1440px window has 400px of empty space on each side. The two things a reader wants *while* reading a long note — where they are in it, and what else points at it — were nowhere and at the very bottom of the page respectively.

## Change

One piece of markup, two layouts.

A three-track grid (`1fr minmax(0, var(--measure)) 1fr`) puts the article in the centre track at **exactly** the position it occupies today, at every width, and the rail in the right track — space that is empty now. The rail is sticky, so it follows you down.

Below 80rem the grid collapses, the contents list is hidden, and the rail falls back into the flow after the article — which is the bottom-of-page backlinks block the site already served. The narrow case is CSS, not a second partial that has to be kept in step.

The measure cap moved off `.page` and onto the masthead, the layout and the footer, so `.page` can be full width for the grid while all three agree with each other by construction rather than by three numbers that have to be kept equal. (Getting this wrong puts the rule under the masthead a few pixels wide of the text it belongs to — invisible in a diff, obvious in a screenshot.)

The contents list is **section-level only**, and renders only where there are at least three sections. Of nineteen published notes, ten have no `##` at all and five carry a single backlink; on the thirteen pages where the rail would be empty it renders no element at all, because an empty box in the margin is worse than an empty margin.

About twenty lines of `IntersectionObserver` mark the section on screen — the difference between a list of links and a sense of place, and the only JavaScript this needs. The observation band is the top fifth of the viewport rather than the whole window: with a full-height root every heading on a short page is "visible" at once and the highlight never moves.

## Two things that cost more than the layout did

**Hugo wraps the heading tree in a synthetic root.** `.Fragments.Headings` returns one entry — `Level` 0, empty `Title` — whenever a page's headings do not start at H1, which here is *always*, because `publish-filter.py` lifts a note's leading H1 out of the body to become the title. So the count is one on every page, the threshold of three is never met, and the contents list silently renders nowhere. Nothing errors, nothing warns. Found by a page with twelve visible sections reporting one. It is now a comment in `rail.html` rather than a fact to rediscover.

**A nil frontmatter key is not a zero-length one.** `len .Params.backlinks` on a note with no backlinks is `reflect: call of reflect.Value.Type on zero Value` — a build failure, not a missing rail. The truthiness of the value is the right test.

## What it ships on the real vault

| | pages |
| --- | --- |
| rail rendered | **6** of 19 — the five Lighting notes and Work-Life Balance |
| contents list | **3** |
| no `<aside>` at all | **13** |

Which is what the plan asked for and what the counts predicted.

## Verification

- Fixture at 1440px: rail present, prose centred at exactly 400–1040px, masthead rule aligned to the same 400–1040px. At 1100px: single column, no contents list, and the page bottom is the separator-plus-`LINKED FROM` block the site served before this PR. Screenshotted in both themes.
- Scroll-spy driven end to end: loading `/a-long-note/#sticky-positioning` and dumping the DOM shows `class="current"` on that link. No console errors on load. Near the document bottom the highlight correctly stays on the section containing the top of the viewport, since the last sections cannot be scrolled to the top.
- Conditional rendering asserted per page across the whole real vault (table above) and on the fixture, including a note with neither sections nor backlinks, which renders no rail.
- `nix build .#checks.x86_64-linux.digital-garden` — passes (40.7s). Templates are production.
- `nix run .#garden-preview -- --once` — real vault, 19 notes, 23 attachments.

## Next

Item 5 — the inline-link tint boxes and the glare from light-background diagrams on the dark page — and item 3, the index of everything published, which is still the only item that fixes something broken today.