### PR TITLE
fix(ci): wait for the crash-loop fixture's state instead of racing it

### DIFF
--- a/checks/upgrade-verify.nix
+++ b/checks/upgrade-verify.nix
@@ -307,14 +307,18 @@
         # thing wrong and the attribution in the journal is exact.
         machine.succeed("systemctl reset-failed cg-verify-canary.service")
         # Unlike the oneshot canary above, a simple service's start job
-        # completes when the process is spawned; the failure and the restart
-        # are systemd's business afterwards.
+        # completes when the process is SPAWNED - so `systemctl start` returns
+        # while the fixture is still "running", and systemd only moves it to
+        # auto-restart once it reaps the child and schedules the restart.
+        # Reading SubState once, straight after start, is therefore a race:
+        # it usually wins on an idle machine and lost in CI on 2026-08-27,
+        # reporting "running" and failing a test about the state after that.
+        # Waiting for the state asserts the same property without the race -
+        # the fixture must be in auto-restart before verification looks at it.
         machine.succeed("systemctl start cg-verify-crashlooper.service")
-        sub = machine.succeed(
+        machine.wait_until_succeeds(
             "systemctl show cg-verify-crashlooper -p SubState --value"
-        ).strip()
-        assert sub == "auto-restart", (
-            "fixture is not exercising the auto-restart state: {}".format(sub)
+            " | grep -qx auto-restart"
         )
 
         journal = arm(staged=current, rolled_back_ago=60)


### PR DESCRIPTION
## Problem

`upgrade-verify` failed the gate on #73, a PR that touches only the digital garden's templates and stylesheet:

```
!!! Test "a unit stuck restarting counts even though systemd calls it activating" failed with error:
    "fixture is not exercising the auto-restart state: running"
```

The subtest starts `cg-verify-crashlooper` and then reads its `SubState` **once**, expecting `auto-restart`. The comment directly above that read already names why that cannot be relied on:

> Unlike the oneshot canary above, a simple service's start job completes when the process is spawned; the failure and the restart are systemd's business afterwards.

So `systemctl start` returns while the unit is still `running`, and systemd only moves it to `auto-restart` once it has reaped the child and scheduled the restart. That window is sub-millisecond on an idle machine — which is why this has always passed locally — and it is not sub-millisecond on a loaded CI runner.

Nothing about the code under test is wrong. The precondition was being assumed rather than established.

## Change

Replace the single read and assert with `wait_until_succeeds` on the same condition. It asserts exactly the same property — the fixture must really be in `auto-restart` before verification looks at it — without depending on winning the race, and the comment now records the mechanism rather than gesturing at it.

The subtest's actual assertions, about what verification then reports and which unit it names, are untouched.

## Verification

- `nix build .#checks.x86_64-linux.upgrade-verify` — passes, 11 subtests, test script 79.0s (in line with the ~75s #69 brought it down to).
- From the run log: `waiting for success: … | grep -qx auto-restart, in 0.09 seconds`. That is both why the original read usually won and why waiting for it costs nothing.
- `nixfmt` clean.

## Note

This is the second thing found in this area since #69 tightened the test's timings. The pattern is the same one that PR applied deliberately elsewhere — poll for the state you need rather than assume the previous command left you in it — applied to the one spot it did not reach.