### PR TITLE
feat(garden): link treatment, a vendored serif, and the polish pass

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -492,6 +492,28 @@
             "the home page links KaTeX with no maths on it"
         machine.succeed("curl -sf -o /dev/null http://localhost:8086/katex/katex.min.css")
 
+    with subtest("the heading face is vendored, not requested from anyone"):
+        # The same shape as KaTeX above and asserted for the same reason: a
+        # webfont whose file is missing does not fail a build or a page, it
+        # silently leaves every reader on their own serif. Worse here than for
+        # KaTeX, because this machine HAS Noto Serif installed and a browser
+        # keeps a family's installed faces alongside the ones @font-face adds,
+        # so the page looks correct to whoever is looking at it.
+        page = served("/")
+        assert "/fonts/noto-serif-latin.woff2" in page, \
+            "the heading face is not preloaded from the page"
+        machine.succeed(
+            "curl -sf -o /dev/null http://localhost:8086/fonts/noto-serif-latin.woff2"
+        )
+        # And it is OURS. The whole toolchain is offline by construction; a
+        # stylesheet that names someone else's host undoes that in one line,
+        # and it would still render perfectly on a machine with a network.
+        href = re.search(r'href="([^"]*main\.[^"]*\.css)"', page)
+        assert href, "no fingerprinted stylesheet linked from the home page"
+        css = served(href.group(1))
+        assert "fonts.googleapis.com" not in css and "fonts.gstatic.com" not in css, \
+            "the stylesheet fetches a font from a CDN"
+
     with subtest("a dollar-sign pair in prose does not fail the build"):
         # The 2026-08-25 outage: two unrelated amounts of money in one
         # paragraph are an inline maths span to the $...$ passthrough

--- a/docs/plans/digital-garden-design.md
+++ b/docs/plans/digital-garden-design.md
@@ -8,7 +8,7 @@ Status: proposed 2026-08-27; decisions taken the same day, see _Decisions_ below
 | 2   | Kanagawa palette                    | medium | 1          | **done** 2026-08-27 |
 | 3   | An index of everything published    | small  | -          | not started |
 | 4   | Right-hand rail: contents, backlinks| medium | 1          | **done** 2026-08-27 |
-| 5   | Link and image treatment            | small  | 2          | not started |
+| 5   | Link and image treatment            | small  | 2          | **done** 2026-08-27 |
 | 6   | Typography                          | small  | 2          | **agreed, not scheduled** |
 | 7   | Wikilink hover previews             | medium | -          | optional    |
 | 8   | Footnotes as sidenotes              | large  | 4          | optional    |
@@ -177,9 +177,17 @@ For links: drop the tint and use an underline with `text-underline-offset: 0.15e
 
 For images: a paper-coloured mat behind them in dark mode — a few pixels of padding in a colour near the light theme's background — rather than a `filter: brightness()`, which would also dim the photographs, and there are photographs.
 
+### What shipped, and the two things worth recording
+
+**The chrome exclusion list was the whole of the work.** Dropping the tint is one declaration; deciding which links are prose and which are machinery is the rest. Footnote references are the case the problem statement named, and they turn out to be the case an underline is worst for as well: the line under a superscript numeral lands in the gap above the next line of text rather than under anything. So the reference and the backref both keep `text-decoration: none`, alongside the site title, the footer links and the heading anchors. The footer's hover underline is restored explicitly, because `a:hover` no longer sets a line for it to inherit.
+
+That list also had a redundant pair in it — `a.footnote-backref` and `[role="doc-backlink"]` are the same element, Hugo emits both — which was invisible while the rule only removed a background. It is one selector now.
+
+**The mat frames the glare rather than removing it,** and that is the trade the plan chose when it ruled out a filter. A white diagram on paper is still white; what changes is that it reads as a page rather than as a hole cut in a dark one. The fixture's SVG is white to its own edges, so what the mat shows is a cream ring — which is the honest picture of what this does to a real Lighting diagram. Photographs get the same ring, which reads as a mount.
+
 ### Cost and risk
 
-An hour. Reversible in one commit.
+An hour, and it took about that. Reversible in one commit.
 
 ## 6. Typography
 

--- a/docs/plans/digital-garden-design.md
+++ b/docs/plans/digital-garden-design.md
@@ -9,7 +9,7 @@ Status: proposed 2026-08-27; decisions taken the same day, see _Decisions_ below
 | 3   | An index of everything published    | small  | -          | not started |
 | 4   | Right-hand rail: contents, backlinks| medium | 1          | **done** 2026-08-27 |
 | 5   | Link and image treatment            | small  | 2          | **done** 2026-08-27 |
-| 6   | Typography                          | small  | 2          | **agreed, not scheduled** |
+| 6   | Typography                          | small  | 2          | **done** 2026-08-27 |
 | 7   | Wikilink hover previews             | medium | -          | optional    |
 | 8   | Footnotes as sidenotes              | large  | 4          | optional    |
 | 9   | Reading time in the dateline        | small  | -          | optional    |
@@ -201,9 +201,28 @@ Vendor a face from nixpkgs exactly as `lib/hugo.nix` already vendors KaTeX: copy
 
 Whether to use a serif was the real question, and it is decided: **a serif for headings, the system sans for body**. A serif body suits an essay site and is what most gardens reach for, but it breaks the what-you-see-is-what-you-get property with Obsidian that the current layout was built around. Headings alone give the page a voice and leave the reading experience matching the editor.
 
+### What it took to hit the weight budget
+
+nixpkgs does not ship a woff2. `noto-fonts` carries `NotoSerif.ttf`, a **1.9MB variable font**: every weight from 100 to 900, and very nearly every glyph Noto covers. Shipping that, or a naive woff2 of it, would have been forty times the budget.
+
+Two reductions, both at build time in `lib/hugo.nix`, both from packages already on `flake.lock`:
+
+1. `fonttools varLib.instancer` pins the weight axis at 600 — the weight the headings already used. This is the big one. `gvar`, the table describing how each glyph deforms across the axis, is two thirds of the file, and instancing removes it outright.
+2. `pyftsubset` cuts the glyphs to Google's own `latin` range plus the punctuation these notes use.
+
+`woff2_compress` does the rest. The result is **28,952 bytes**, inside the 20-40KB the plan asked for. A heading that ever needs a glyph outside the range falls back to the body stack for that heading, which is the degradation the site already had.
+
+### The finding: you cannot check this by looking at it
+
+A browser keeps the faces **installed** under a family name in that family, alongside the ones `@font-face` adds. This machine has Noto Serif in fontconfig, and so does every Android phone. So a `src` pointing at a URL that 404s still renders a serif heading here, taken from the system, and the screenshot is indistinguishable from the working one — verified, twice, at zero differing pixels.
+
+The check that does work is to rename the family to something nobody has and screenshot that: the heading is still a serif, so the woff2 was fetched, parsed and used. That is now a comment in the stylesheet, and the VM test asserts the file is served at all — which is the same class of silent failure as item 2's inline Chroma colours, and the same reason for testing it.
+
+The same fact settles a question the plan did not ask. Adding `local("Noto Serif")` to the `src` would let those readers skip the download, but the installed face at that name is Regular, and claiming it as the 600 weight would render headings light on exactly the machines that have it. One URL, one weight, the same face for everyone.
+
 ### Cost and risk
 
-Two hours. The risk is page weight — one weight of one face is 20-40KB, which is on the same order as everything else the page loads, and it is worth being deliberate about rather than adding four weights.
+Two hours, and it took about that. The risk was page weight, and the answer is above: 29KB, preloaded, on every page.
 
 ## 7. Wikilink hover previews (optional)
 

--- a/docs/plans/digital-garden-design.md
+++ b/docs/plans/digital-garden-design.md
@@ -1,6 +1,6 @@
 # Plan: theme and navigation for the digital garden
 
-Status: proposed 2026-08-27; decisions taken the same day, see _Decisions_ below. Items 1, 2 and 4 are the agreed first pass. Two ideas asked for — a Kanagawa palette and a right-hand navigation column — plus seven more that came out of looking at what the site actually serves today. Everything below is scoped against `modules/services/digital-garden/lib/hugo/`, which is the whole design: four layouts, six partials, three render hooks and a 488-line stylesheet. There is no theme underneath to fight, so every item here is an edit to files this repository owns.
+Status: proposed 2026-08-27; decisions taken the same day, see _Decisions_ below. Items 1, 2 and 4 were the agreed first pass; 5, 6 and 10 followed on the same day. Item 3 is the only one left that fixes something broken today. Two ideas asked for — a Kanagawa palette and a right-hand navigation column — plus seven more that came out of looking at what the site actually serves today. Everything below is scoped against `modules/services/digital-garden/lib/hugo/`, which is the whole design: four layouts, six partials, three render hooks and a 488-line stylesheet. There is no theme underneath to fight, so every item here is an edit to files this repository owns.
 
 | #   | Item                                | Size   | Depends on | Status      |
 | --- | ----------------------------------- | ------ | ---------- | ----------- |
@@ -13,7 +13,7 @@ Status: proposed 2026-08-27; decisions taken the same day, see _Decisions_ below
 | 7   | Wikilink hover previews             | medium | -          | optional    |
 | 8   | Footnotes as sidenotes              | large  | 4          | optional    |
 | 9   | Reading time in the dateline        | small  | -          | optional    |
-| 10  | Polish: print, selection, motion    | small  | 2          | optional    |
+| 10  | Polish: print, selection, motion    | small  | 2          | **done** 2026-08-27 |
 | -   | Graph view                          | -      | -          | **rejected**, see below |
 
 ## Decisions, 2026-08-27
@@ -236,9 +236,33 @@ Once the grid from item 4 exists, footnotes can be moved into the right margin b
 
 `publish-filter.py` already counts words for `LONG_NOTE_WORDS`. Surfacing an estimate next to the date is a few lines. Given that half the notes are under 500 words, this may say more about the garden than is flattering, which is either a reason not to do it or the honest thing about a slip box.
 
-## 10. Polish (optional)
+## 10. Polish
 
 A print stylesheet — these are essays, and people print essays; hide the masthead controls, unstick the rail, print link targets after external links. `prefers-reduced-motion` around the two transitions. A "follow system" third state on the theme toggle, which currently has no way back to the OS preference once a reader has chosen. Each is minutes; none is interesting; together they are the difference between finished and nearly finished.
+
+Selection was the fourth item in the title and it was taken in item 2, where the palette had the Kanagawa values to hand.
+
+### The print stylesheet was not a nicety
+
+Printing from the dark theme produced **a blank sheet**. Browsers do not print background colours by default, so the ground goes and the text stays: fujiWhite on white paper. The fix is to override both token blocks inside `@media print` — paper is white and the ink is black, whichever theme the reader was in — and it is the reason this item stopped being optional.
+
+Two smaller consequences of the same fact. `==highlight==` is a background and so does not print; it takes an underline instead, which is the same mark made with ink. And the dark theme's image mat from item 5 keys off `data-theme`, which is still `"dark"` for someone printing from it, so it has to be switched off by hand rather than by the palette.
+
+The rest went as described. External destinations print after the link, scoped to the article so the footer's chrome does not; `break-after: avoid` on headings and `break-inside: avoid` on the blocks that cannot be scrolled past; the rail needs no unsticking in practice, because print media is about 794px wide and the grid needs 1280, but it is unstuck explicitly since `sticky` in a paged medium is browser-dependent and none of the answers are a table of contents.
+
+### The toggle: three states, and no dead click
+
+A literal three-way cycle — system, light, dark — has a click in it that does nothing. Leaving "system" for the theme the system was already showing changes no pixel, and a control that appears not to work is worse than one that cannot reach a state.
+
+So the button flips the theme every time, and "follow the system" is where the flip lands when the result agrees with the system preference. Two clicks back to it from anywhere, and every click changes the page. `data-theme` stays what the page is painted in; a second attribute, `data-theme-source`, carries whether that was chosen, which is what the third glyph and the button's label read.
+
+The state that this buys, beyond a way back: a reader who has not chosen now follows the system **while the page is open**, not merely as it was at load.
+
+Verified by driving headless Chrome over the DevTools protocol — click the button four times at each system preference and read back the attribute, the stored value, which glyph is displayed and the computed background — because this is behaviour, and a screenshot cannot press a button. `Emulation.setEmulatedMedia` is what sets the system preference for that: `--blink-settings=preferredColorScheme` works for a plain screenshot but does not reach `matchMedia` once devtools is attached.
+
+### Cost and risk
+
+Two hours, most of it in the printing. No risk taken: every rule here is inside a media query or behind an attribute the page already sets.
 
 ## Rejected: a graph view
 
@@ -248,6 +272,10 @@ The canonical Quartz feature, and it should not be built here. Nineteen nodes wi
 
 Item 1 first, because everything after it is judged by looking. Then item 2, the largest visible change, which wants the fixture page to land against. Then item 4. Then 5 and 6 as taste passes over a palette that has settled.
 
-Item 3 is out of the first pass by choice, not by dependency; it can be taken at any point, including between the others, since it touches no file the rest of them touch. Items 7 through 10 are likewise independent of each other and of the rest.
+Items 5, 6 and 10 were taken together on 2026-08-27, in that order, which is the order the plan gives them: the link treatment and the face are both judged against the palette, and the polish is judged against both.
+
+Item 3 is out of the first pass by choice, not by dependency; it can be taken at any point, including between the others, since it touches no file the rest of them touch. Items 7 through 9 are likewise independent of each other and of the rest.
 
 Each item is its own PR, per the usual gate. Item 2 will not change the VM test's assertions — the test looks for a stylesheet, not for its contents — which is worth stating explicitly, because it means the gate is not evidence for any of this and the screenshots are.
+
+That held for items 2, 4 and 5 and stopped holding at item 6, which added two. A webfont is not a colour: the file either is served from this site or it is not, and if it is not, nothing fails — every reader silently gets their own serif. That is a fact about the output tree and it belongs in the check, alongside the assertion that the stylesheet names no font CDN. The rest of the judgement is still the screenshots'.

--- a/modules/services/digital-garden/lib/hugo.nix
+++ b/modules/services/digital-garden/lib/hugo.nix
@@ -30,6 +30,44 @@
 }:
 let
   theme = ./hugo;
+
+  # The heading face, vendored on exactly the terms KaTeX is: taken from a
+  # package that rides flake.lock, reduced here, and served as an ordinary
+  # static file. Nothing is fetched at build time and nothing is fetched by the
+  # reader's browser — which is the property this whole file exists to hold, and
+  # the reason a webfont is affordable at all. A CDN link would have been one
+  # line and would have made every reader's page load depend on Google.
+  #
+  # Noto Serif ships as a 1.9MB variable TTF: every weight from 100 to 900, and
+  # a glyph for very nearly every language Noto covers. Two reductions get that
+  # to ~29KB, which is the budget the plan set.
+  #
+  #   1. Instance the variable axes at the ONE weight the headings use. This is
+  #      the big one: `gvar`, the table describing how every glyph deforms
+  #      across the weight axis, is two thirds of the file and it goes entirely.
+  #   2. Subset the glyphs to Latin plus the punctuation these notes contain.
+  #      The range is Google Fonts' own `latin` subset, which is what a heading
+  #      in English with an em dash and a curly quote in it needs.
+  #
+  # If a note ever takes a heading outside this range, the browser falls back to
+  # the body stack for that heading rather than showing tofu — the same
+  # degradation the site had before the face existed.
+  headingFont =
+    pkgs.runCommand "noto-serif-latin-600.woff2"
+      {
+        nativeBuildInputs = [
+          pkgs.python3Packages.fonttools
+          pkgs.woff2
+        ];
+      }
+      ''
+        fonttools varLib.instancer -o instance.ttf \
+          ${pkgs.noto-fonts}/share/fonts/noto/NotoSerif.ttf wght=600
+        pyftsubset instance.ttf --output-file=subset.ttf --no-hinting \
+          --unicodes='U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+2074,U+20AC,U+2122,U+2190-2193,U+2212,U+2215,U+FEFF,U+FFFD'
+        woff2_compress subset.ttf
+        cp subset.woff2 $out
+      '';
 in
 {
   mkRenderer =
@@ -161,6 +199,13 @@ in
         mkdir -p "$work/static/katex"
         cp ${pkgs.katex}/lib/node_modules/katex/dist/katex.min.css "$work/static/katex/"
         cp -r ${pkgs.katex}/lib/node_modules/katex/dist/fonts "$work/static/katex/fonts"
+
+        # The heading face, subset above. One file, one weight, on every page:
+        # unlike KaTeX there is no test for "did this page use it", because
+        # every page has a title.
+        mkdir -p "$work/static/fonts"
+        cp ${headingFont} "$work/static/fonts/noto-serif-latin.woff2"
+
         # Store paths copy out read-only, and the exit trap's rm -rf cannot
         # remove a read-only directory's contents.
         chmod -R u+w "$work/static"

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -200,9 +200,23 @@ footer {
   outline-offset: 2px;
 }
 
+/* The glyph is the state, not the action: whichever of the three the page is
+ * currently in. The system glyph is hidden by default and the two theme
+ * glyphs are hidden when it is showing, so the rules stay in the order the
+ * script sets the attributes in. */
 :root[data-theme="dark"] .icon-sun,
-:root[data-theme="light"] .icon-moon {
+:root[data-theme="light"] .icon-moon,
+.icon-system {
   display: none;
+}
+
+:root[data-theme-source="system"] .icon-sun,
+:root[data-theme-source="system"] .icon-moon {
+  display: none;
+}
+
+:root[data-theme-source="system"] .icon-system {
+  display: block;
 }
 
 /* ── prose ──────────────────────────────────────────────────────────────── */
@@ -820,5 +834,123 @@ pagefind-modal {
 @media (max-width: 700px) {
   .page {
     padding-top: 1.5rem;
+  }
+}
+
+/* ── motion ─────────────────────────────────────────────────────────────── */
+
+/* This file has one transition in it, on the heading anchors, and it would be
+ * cheaper to name it than to write this. The blanket is deliberate anyway,
+ * because it is the only rule here that can reach Pagefind's stylesheet: the
+ * Component UI ships a shimmering skeleton while a search runs, that sheet is
+ * injected AFTER this one, and `!important` is what wins across that boundary
+ * regardless of order. A reader who has asked their system for less motion has
+ * asked the search dialog too.
+ *
+ * A very short duration rather than `none`, so that anything listening for
+ * transitionend still hears it. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}
+
+/* ── print ──────────────────────────────────────────────────────────────── */
+
+/* These are essays, and people print essays.
+ *
+ * The palette override is not a nicety. Browsers do not print background
+ * colours by default, so a page printed from the dark theme loses the ground
+ * and keeps the text: fujiWhite on white paper, which is a blank sheet with a
+ * toner bill. Both token blocks are overridden here, so the sheet is the same
+ * whichever theme the reader happened to be in.
+ *
+ * Paper is white rather than Lotus's cream for the same reason - the cream is
+ * a background colour that will not print, and designing against a ground that
+ * is not there produces contrast ratios that are not there either. */
+@media print {
+  :root,
+  :root[data-theme="dark"] {
+    --bg: #fff;
+    --surface: #fff;
+    --border: #999;
+    --code-bg: #fff;
+    --muted: #444;
+    --text: #000;
+    --strong: #000;
+    /* Black links. On paper the colour is not an affordance, and the
+     * destination is printed after the link instead. */
+    --accent: #000;
+    color-scheme: light;
+  }
+
+  /* A search button and a theme toggle on a sheet of paper are icons that do
+   * nothing; the heading anchors are a hover affordance for a hover that
+   * cannot happen; and the arrow back to a footnote's reference is a jump on a
+   * page that is already in the reader's hand. */
+  .icon-button,
+  .heading-anchor,
+  .footnote-backref {
+    display: none;
+  }
+
+  /* The mat exists because the page is dark. Here it is not, and the tokens
+   * above have already said so - but that rule keys off data-theme, which is
+   * still "dark" for a reader who printed from the dark theme, so it has to be
+   * turned off by hand rather than by the palette. */
+  :root[data-theme="dark"] img {
+    background: none;
+    padding: 0;
+  }
+
+  /* The rail is already in its narrow layout here - print media is about 794px
+   * wide, well under the 80rem the grid needs - so the contents list is hidden
+   * and the backlinks follow the essay, which is right on both counts: a list
+   * of same-page anchors is useless on paper, and the notes that cite this one
+   * are worth having. This unsticks it explicitly anyway, because `sticky` in a
+   * paged medium either repeats on every sheet or pins to the first depending
+   * on the browser, and neither is what the rule meant. */
+  .rail {
+    position: static;
+    max-height: none;
+    overflow: visible;
+  }
+
+  /* Where an external link went, since it cannot be followed. Scoped to the
+   * article: the footer's two links are chrome, and the masthead's is the page
+   * you are holding. */
+  article a[href^="http://"]::after,
+  article a[href^="https://"]::after {
+    content: " <" attr(href) ">";
+    font-size: 0.85em;
+    /* A URL is one unbreakable word and the measure is narrow. */
+    word-break: break-all;
+  }
+
+  /* ==highlight== is a background, so it does not print either; underlined
+   * instead, which is the same mark made with ink. */
+  mark {
+    text-decoration: underline;
+  }
+
+  /* Breaks that a page has no way to scroll past. A heading at the foot of a
+   * sheet is the worst of them, because the section it names is overleaf. */
+  h1,
+  h2,
+  h3,
+  h4 {
+    break-after: avoid;
+  }
+
+  pre,
+  blockquote,
+  table,
+  img,
+  .callout {
+    break-inside: avoid;
   }
 }

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -206,28 +206,45 @@ blockquote {
   font-size: 0.875rem;
 }
 
+/* An underline, not a tinted box. The box was a legible affordance and a bad
+ * one: at the link density of these notes — and especially at footnote density,
+ * where every reference took one too — a page of them reads as prose somebody
+ * else has been through with a highlighter.
+ *
+ * The line is set in --muted rather than in the link's own colour, so the
+ * affordance is present without being the loudest thing in the paragraph, and
+ * it takes the accent on hover. The offset clears the descenders; without it an
+ * underline at this size cuts through every g and y on the page. */
 a {
   color: var(--accent);
-  text-decoration: none;
-  /* Underlined on hover rather than always: at this link density a permanently
-   * underlined page is harder to read than an undecorated one. */
-  border-radius: 3px;
-  padding: 0 0.1em;
-  background: var(--surface);
+  text-decoration: underline;
+  text-decoration-color: var(--muted);
+  text-underline-offset: 0.15em;
 }
 
 a:hover {
-  text-decoration: underline;
+  text-decoration-color: var(--accent);
 }
 
-/* Chrome, not prose: a highlight behind these reads as a stray box. */
+/* Chrome, not prose. These are navigation and machinery — the site title, a
+ * heading's own anchor, the two ends of a footnote — and a rule under each one
+ * marks a page that is mostly links as a page that is mostly underlined. A
+ * superscript numeral is the worst of them: the line lands in the gap above the
+ * following line of text.
+ *
+ * The hover underline is restored below for the two that are ordinary
+ * destinations; the anchor and the footnote pair are already unmistakable at
+ * the moment you are pointing at them. */
 footer a,
 .masthead-title,
 .heading-anchor,
-a.footnote-backref,
-[role="doc-backlink"] {
-  background: none;
-  padding: 0;
+.footnote-ref,
+.footnote-backref {
+  text-decoration: none;
+}
+
+footer a:hover {
+  text-decoration: underline;
 }
 
 /* An external link says so, rather than being discovered by following it.
@@ -349,6 +366,21 @@ img {
   height: auto;
   border-radius: 5px;
   margin: 1rem 0;
+}
+
+/* Most diagrams in this vault are light-background scans and exports, and on
+ * sumiInk3 a white rectangle is a torch. A mat rather than a filter: dimming
+ * the image would dim the photographs too, and there are photographs. This
+ * puts the diagram on paper instead — the light theme's own ground, which is
+ * where the thing was drawn to be seen — and leaves what is inside the frame
+ * exactly as its author exported it.
+ *
+ * A photograph gets a few pixels of cream around it, which reads as a mount.
+ * That is the trade, and it is the right way round: a border on a photograph
+ * is a decision, a glare in the middle of a dark page is a fault. */
+:root[data-theme="dark"] img {
+  background: #f9f6e1; /* the light theme's --bg: lotusWhite3, lightened */
+  padding: 0.5rem;
 }
 
 hr {
@@ -667,14 +699,12 @@ h4:hover > .heading-anchor,
    * between a list of links and a sense of place. */
   .rail a {
     display: block;
-    padding: 0;
-    background: none;
     color: var(--muted);
+    text-decoration: none;
   }
 
   .rail a:hover {
     color: var(--text);
-    text-decoration: none;
   }
 
   .rail a.current {

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -26,10 +26,40 @@
  *   the longest note here has twenty-nine; a coloured heading every screen is
  *   more page than it is emphasis.
  *
- * Fonts are the system stack. Asking for a webfont and not shipping it is the
- * same as this with extra steps, and shipping one is a request this site has
- * no reason to make of a reader.
+ * Fonts are a serif for headings and the system stack for body text. The
+ * reasoning for each is at the @font-face below.
  */
+
+/* Noto Serif, subset to Latin at one weight by lib/hugo.nix and served from
+ * this site. The earlier version of this file used the system stack throughout
+ * and argued that asking for a webfont without shipping it is the worst of both
+ * — which is right, and is why this one IS shipped: vendored from nixpkgs at
+ * build time exactly as KaTeX is, no CDN, no DNS lookup to anyone else.
+ *
+ * Headings only. A serif body would suit an essay site and is what most gardens
+ * reach for, but these notes are written in Obsidian in the system sans, and a
+ * page that reads the same in the editor and in the browser is worth more here
+ * than a page that reads like a book. Headings alone give it a voice.
+ *
+ * One weight, 600, which is the weight the headings already had. A second would
+ * double the payload for a distinction the type scale is already making with
+ * size. `swap` because the fallback below is a real typeface and not a
+ * placeholder: showing a heading in it immediately beats showing nothing.
+ *
+ * A trap for whoever checks this by looking. A browser keeps the faces INSTALLED
+ * under a family name in the family alongside the ones @font-face adds, so on
+ * any machine with Noto Serif in fontconfig — this one, and every Android phone
+ * — a broken `src` still renders a serif heading, taken from the system. A
+ * screenshot here therefore cannot tell you whether this file was fetched at
+ * all. Rename the family to something nobody has and screenshot that: if the
+ * heading is still a serif, the woff2 loaded. */
+@font-face {
+  font-family: "Noto Serif";
+  src: url("/fonts/noto-serif-latin.woff2") format("woff2");
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
 
 :root {
   /* Lotus. The three grounds are lotusWhite3/2/0 lightened toward white; the
@@ -46,6 +76,11 @@
   --body-font:
     system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji";
+  /* The fallbacks are the serifs a reader is most likely to already have, in
+   * rough order of how close they sit to Noto Serif's proportions, so a heading
+   * shown before the file arrives is not a different shape from the one that
+   * replaces it. */
+  --heading-font: "Noto Serif", Georgia, "Times New Roman", Times, serif;
   --measure: 40rem;
   color-scheme: light;
 }
@@ -177,6 +212,7 @@ h2,
 h3,
 h4 {
   color: var(--strong);
+  font-family: var(--heading-font);
   font-weight: 600;
   line-height: 1.25;
   margin: 2rem 0 0.75rem;
@@ -610,8 +646,13 @@ h4:hover > .heading-anchor,
   border-top: 1px solid var(--border);
 }
 
+/* Back to the body stack. These two are <h2> for the outline and for the
+ * `aria-labelledby` on each nav, not because they are headings in the essay:
+ * they are 0.8rem uppercase labels, and a serif at that size and spacing is
+ * the one place the face looks like a mistake. */
 .rail h2 {
   margin: 0 0 0.75rem;
+  font-family: var(--body-font);
   font-size: 0.8rem;
   font-weight: 600;
   letter-spacing: 0.06em;

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/icon-theme.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/icon-theme.html
@@ -1,8 +1,17 @@
-{{/* Both glyphs ship; CSS shows whichever the current theme does not use. */}}
+{{/*
+  Three glyphs ship and CSS shows one. The sun and the moon are the theme the
+  reader chose; the third is the state where they have chosen nothing and the
+  page is following the operating system, which is where everyone starts and
+  which a two-glyph control has no way to say.
+*/}}
 <svg class="icon-sun" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
   <circle cx="12" cy="12" r="4.5" />
   <path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4" />
 </svg>
 <svg class="icon-moon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" aria-hidden="true">
   <path d="M20 14.5A8.5 8.5 0 0 1 9.5 4a8.5 8.5 0 1 0 10.5 10.5Z" />
+</svg>
+<svg class="icon-system" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <rect x="2.5" y="4" width="19" height="13" rx="2" />
+  <path d="M9 21h6M12 17v4" />
 </svg>

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -9,6 +9,24 @@
     {{ with partial "description.html" . }}<meta name="description" content="{{ . }}" />{{ end }}
     <link rel="canonical" href="{{ .Permalink }}" />
     {{ partial "social.html" . }}
+    {{/*
+      The heading face, before the stylesheet that asks for it. A font
+      referenced from CSS is not discovered until the stylesheet has been
+      fetched AND parsed AND matched to an element, which for the <h1> at the
+      top of every page here is one round trip too late; this starts it with
+      the stylesheet instead. `crossorigin` is not optional even though the
+      file is same-origin: fonts are fetched in CORS mode, and a preload
+      without it is a second, unused download.
+
+      Unconditional, unlike KaTeX below, because every page has a title.
+    */}}
+    <link
+      rel="preload"
+      href="{{ "fonts/noto-serif-latin.woff2" | relURL }}"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
     {{ with resources.Get "main.css" | fingerprint }}
       <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" />
     {{ end }}

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -48,6 +48,16 @@
       Applied before first paint, so a reader who chose dark does not get a
       white flash on every navigation. Inline for the same reason: an external
       file would be fetched after the document starts rendering.
+
+      TWO attributes, not one. data-theme is what the page is painted in and is
+      always "dark" or "light"; data-theme-source says whether that was chosen
+      or inherited from the operating system. Only the first is needed to draw
+      the page - the second exists because the control has to be able to show
+      "following your system" as a state, and because a reader following the
+      system should keep following it when the system changes under them.
+
+      Anything other than the two words is read as no choice at all, which is
+      also how a cleared localStorage reads.
     */}}
     <script>
       (function () {
@@ -55,10 +65,16 @@
         try {
           saved = localStorage.getItem("theme");
         } catch (e) {}
-        var dark = saved
-          ? saved === "dark"
-          : window.matchMedia("(prefers-color-scheme: dark)").matches;
-        document.documentElement.dataset.theme = dark ? "dark" : "light";
+        var chosen = saved === "dark" || saved === "light";
+        var root = document.documentElement;
+        root.dataset.themeSource = chosen ? "user" : "system";
+        root.dataset.theme = (
+          chosen
+            ? saved === "dark"
+            : window.matchMedia("(prefers-color-scheme: dark)").matches
+        )
+          ? "dark"
+          : "light";
       })();
     </script>
   </head>
@@ -74,7 +90,11 @@
         >
           {{ partial "icon-search.html" . }}
         </button>
-        <button class="icon-button" id="theme-toggle" aria-label="Toggle dark mode">
+        {{/* The label is rewritten by the script below, which is the only
+             thing that knows which of the three states the page is in. This
+             one is what a reader with no JavaScript gets, where the button
+             does nothing anyway. */}}
+        <button class="icon-button" id="theme-toggle" aria-label="Change theme">
           {{ partial "icon-theme.html" . }}
         </button>
       </header>
@@ -116,12 +136,53 @@
     <script>
       (function () {
         var root = document.documentElement;
-        document.getElementById("theme-toggle").addEventListener("click", function () {
-          var next = root.dataset.theme === "dark" ? "light" : "dark";
-          root.dataset.theme = next;
+        var button = document.getElementById("theme-toggle");
+        var media = window.matchMedia("(prefers-color-scheme: dark)");
+
+        // Three states, and still one button that always changes the page.
+        //
+        // A literal three-way cycle - system, light, dark - has a dead click
+        // in it: leaving "system" for the theme the system was already showing
+        // does nothing visible, and a control that appears not to work is worse
+        // than one that cannot reach a state. So the button flips the theme,
+        // every time, and the way back to "follow the system" is the flip that
+        // happens to land on what the system was asking for anyway. Two clicks
+        // from anywhere, and each one does something.
+        function apply(theme, source) {
+          root.dataset.theme = theme;
+          root.dataset.themeSource = source;
           try {
-            localStorage.setItem("theme", next);
+            if (source === "system") localStorage.removeItem("theme");
+            else localStorage.setItem("theme", theme);
           } catch (e) {}
+          label();
+        }
+
+        // The button's name is the action; the state goes in brackets after it,
+        // because "following your system" is not visible from the glyph alone
+        // if you cannot see the glyph.
+        function label() {
+          var state =
+            root.dataset.themeSource === "system"
+              ? "following your system"
+              : root.dataset.theme;
+          var name = "Change theme (currently " + state + ")";
+          button.setAttribute("aria-label", name);
+          button.title = name;
+        }
+        label();
+
+        button.addEventListener("click", function () {
+          var next = root.dataset.theme === "dark" ? "light" : "dark";
+          apply(next, next === (media.matches ? "dark" : "light") ? "system" : "user");
+        });
+
+        // The point of the third state: a reader who has not chosen follows the
+        // system, including when it changes while the page is open. Without
+        // this, "follow the system" means "follow it as it was at page load".
+        media.addEventListener("change", function (e) {
+          if (root.dataset.themeSource !== "system") return;
+          apply(e.matches ? "dark" : "light", "system");
         });
 
         // Everything below is deferred loading. Opening, closing, focus and


### PR DESCRIPTION
Items 5, 6 and 10 of `docs/plans/digital-garden-design.md`, in the order the plan gives them: the link treatment and the face are both judged against the palette from #72, and the polish is judged against both. One PR rather than three because all three edit the same stylesheet and would otherwise have to merge in a fixed order; the commits are separable.

## 5 — links and images

Every inline link carried a `--surface` tint box. At the link density of these notes, and especially at footnote density where every reference took one too, a page of them read as prose somebody else had been through with a highlighter. An underline instead, set in `--muted` so the affordance is present without being the loudest thing in the paragraph, taking the accent on hover, offset far enough to clear descenders.

Deciding which links are prose and which are machinery was the rest of the work. Footnote references are the case the underline is worst for — the line under a superscript numeral lands in the gap above the next line rather than under anything — so the reference and the backref stay undecorated along with the site title, the footer links and the heading anchors. The footer's hover underline is restored explicitly, since `a:hover` no longer sets a line for it to inherit. The exclusion list also had a redundant pair in it: `a.footnote-backref` and `[role="doc-backlink"]` are the same element, which was invisible while the rule only removed a background.

Diagrams in the vault are mostly light-background scans and exports, and on sumiInk3 a white rectangle is a torch. A mat rather than a filter — dimming the image would dim the photographs too, and there are photographs. The mat frames the glare rather than removing it, but it reads as a page instead of a hole cut in a dark one.

## 6 — typography

A serif for headings, the system sans for body. These notes are written in Obsidian in the system sans, and a page that reads the same in the editor and in the browser is worth more here than a page that reads like a book.

Noto Serif, vendored on exactly the terms KaTeX already is: from a package that rides `flake.lock`, reduced at build time, served as a static file. No CDN, nothing fetched during the build. nixpkgs ships no woff2, and `NotoSerif.ttf` is a 1.9MB variable font, so two reductions get it into the plan's 20–40KB budget — instance the weight axis at 600, which drops `gvar` and with it two thirds of the file, then subset the glyphs to Latin. `woff2_compress` leaves **28,952 bytes**, preloaded ahead of the stylesheet that asks for it.

**The finding, which cost most of the time.** A browser keeps a family's *installed* faces alongside the ones `@font-face` adds. This machine has Noto Serif, and so does every Android phone, so a `src` that 404s still renders a serif heading and the screenshot is identical — verified twice at zero differing pixels before working out why. Renaming the family to something nobody has is the check that works, and it is a comment in the stylesheet now.

That is the same silent-success shape as the inline Chroma colours in #72, so this is the first item in the plan to change the VM test: it asserts the font file is served, and that the stylesheet names no font CDN. A webfont is not a colour — the file either is served from this site or it is not, and if it is not, nothing fails and every reader quietly gets their own serif.

## 10 — polish

**Printing from the dark theme produced a blank sheet.** Browsers do not print background colours by default, so the ground goes and the text stays: fujiWhite on white paper. `@media print` overrides both token blocks — paper is white and the ink is black, whichever theme the reader was in. Two consequences of the same fact ride along: `==highlight==` is a background and so takes an underline on paper instead, and item 5's image mat keys off `data-theme`, which is still `"dark"` for someone printing from it. Then the rest of what a printed essay wants: masthead controls and heading anchors gone, external destinations printed after the link and scoped to the article so the footer's chrome is not, breaks avoided after headings and inside the blocks nobody can scroll past.

`prefers-reduced-motion` is a blanket rather than a rule naming the site's one transition, because `!important` in this file is the only thing that reaches Pagefind's own stylesheet — it is injected later, and it ships a shimmering skeleton while a search runs.

The theme toggle gains its third state, "following your system", which is where every reader starts and which the two-glyph control had no way to say or to return to. Not a three-way cycle: leaving "system" for the theme the system was already showing changes no pixel, and a control that appears not to work is worse than one that cannot reach a state. The button flips the theme every time, and "follow the system" is where the flip lands when the result agrees with the system preference — two clicks back from anywhere, every click doing something. A second attribute, `data-theme-source`, carries whether the theme was chosen. It also buys what the plan did not ask for: a reader who has not chosen follows the system *while the page is open*, not as it was at load.

## How this was checked

The gate is not evidence for most of this, which is what item 1 exists for.

- Rendered against `garden-preview --fixture` at both themes, at 1440px and at 420px, and read as screenshots.
- The toggle was driven over the Chrome DevTools protocol — four clicks at each system preference, reading back the attributes, the stored value, the visible glyph and the computed background — because this is behaviour and a screenshot cannot press a button. `Emulation.setEmulatedMedia` sets the system preference for that; `--blink-settings=preferredColorScheme` works for a plain screenshot but does not reach `matchMedia` once devtools is attached.
- The print stylesheet was checked by printing the fixture to PDF from the dark theme.
- `nix flake check` passes, including the two new assertions.
