### PR TITLE
fix(garden): images as exported, and headings back in the sans

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -346,6 +346,12 @@
         css = served(href.group(1))
         for selector in [".masthead", ".page", "--pf-border"]:
             assert selector in css, f"{selector} missing from the stylesheet"
+        # And it asks nobody else for anything. The whole toolchain is offline
+        # by construction; an @import or a font CDN named here undoes that in
+        # one line, and it would still render perfectly on a machine with a
+        # network, so nothing else would notice.
+        assert "fonts.googleapis.com" not in css and "fonts.gstatic.com" not in css, \
+            "the stylesheet fetches a font from a CDN"
 
     with subtest("search costs a reading page nothing until it is asked for"):
         # The bundle is ~46KB gzipped that a reader who never searches never
@@ -491,28 +497,6 @@
         assert "katex.min.css" not in served("/"), \
             "the home page links KaTeX with no maths on it"
         machine.succeed("curl -sf -o /dev/null http://localhost:8086/katex/katex.min.css")
-
-    with subtest("the heading face is vendored, not requested from anyone"):
-        # The same shape as KaTeX above and asserted for the same reason: a
-        # webfont whose file is missing does not fail a build or a page, it
-        # silently leaves every reader on their own serif. Worse here than for
-        # KaTeX, because this machine HAS Noto Serif installed and a browser
-        # keeps a family's installed faces alongside the ones @font-face adds,
-        # so the page looks correct to whoever is looking at it.
-        page = served("/")
-        assert "/fonts/noto-serif-latin.woff2" in page, \
-            "the heading face is not preloaded from the page"
-        machine.succeed(
-            "curl -sf -o /dev/null http://localhost:8086/fonts/noto-serif-latin.woff2"
-        )
-        # And it is OURS. The whole toolchain is offline by construction; a
-        # stylesheet that names someone else's host undoes that in one line,
-        # and it would still render perfectly on a machine with a network.
-        href = re.search(r'href="([^"]*main\.[^"]*\.css)"', page)
-        assert href, "no fingerprinted stylesheet linked from the home page"
-        css = served(href.group(1))
-        assert "fonts.googleapis.com" not in css and "fonts.gstatic.com" not in css, \
-            "the stylesheet fetches a font from a CDN"
 
     with subtest("a dollar-sign pair in prose does not fail the build"):
         # The 2026-08-25 outage: two unrelated amounts of money in one

--- a/docs/plans/digital-garden-design.md
+++ b/docs/plans/digital-garden-design.md
@@ -8,8 +8,8 @@ Status: proposed 2026-08-27; decisions taken the same day, see _Decisions_ below
 | 2   | Kanagawa palette                    | medium | 1          | **done** 2026-08-27 |
 | 3   | An index of everything published    | small  | -          | not started |
 | 4   | Right-hand rail: contents, backlinks| medium | 1          | **done** 2026-08-27 |
-| 5   | Link and image treatment            | small  | 2          | **done** 2026-08-27 |
-| 6   | Typography                          | small  | 2          | **done** 2026-08-27 |
+| 5   | Link and image treatment            | small  | 2          | **done** 2026-08-27; the image mat reverted the same day |
+| 6   | Typography                          | small  | 2          | built and **reverted** 2026-08-27 |
 | 7   | Wikilink hover previews             | medium | -          | optional    |
 | 8   | Footnotes as sidenotes              | large  | 4          | optional    |
 | 9   | Reading time in the dateline        | small  | -          | optional    |
@@ -23,7 +23,7 @@ Taken against the rendered comparisons rather than the swatches, which is the po
 - **The light theme is Lotus, lightened.** `#f2ecbc` mixed 45% toward white, `#f9f6e1`, with the surface, border and code-well tokens lightened to match. Option 1 of the three below. Lotus as specified is out: rendered at full width it is a buttery yellow that the Lighting notes' white-background diagrams have to fight.
 - **Headings stay neutral.** `fujiWhite` in dark, `lotusInk2` in light. No `carpYellow`.
 - **The first pass is items 1, 2 and 4.** The fixture, the palette, the rail. Item 3 is not dropped — it is still the only item that fixes something broken today — but it is not in this pass.
-- **Typography goes serif for headings and stays on the system sans for body.** One vendored face, and the body text keeps matching the editor. Item 6 is agreed in direction; it is sequenced after item 2 rather than scheduled now, because a face chosen against the old palette would be chosen twice.
+- **Typography goes serif for headings and stays on the system sans for body.** One vendored face, and the body text keeps matching the editor. Item 6 is agreed in direction; it is sequenced after item 2 rather than scheduled now, because a face chosen against the old palette would be chosen twice. **Reversed the same day, on the rendered pages** — see item 6. The direction was agreed in the abstract and did not survive being looked at; the site is back on the system stack throughout.
 
 ## What the site actually contains, 2026-08-27
 
@@ -185,11 +185,23 @@ That list also had a redundant pair in it — `a.footnote-backref` and `[role="d
 
 **The mat frames the glare rather than removing it,** and that is the trade the plan chose when it ruled out a filter. A white diagram on paper is still white; what changes is that it reads as a page rather than as a hole cut in a dark one. The fixture's SVG is white to its own edges, so what the mat shows is a cream ring — which is the honest picture of what this does to a real Lighting diagram. Photographs get the same ring, which reads as a mount.
 
+### The mat is reverted, 2026-08-27
+
+**It was judged on the fixture's SVG and the fixture's SVG is not the vault.** Two things showed up against real images, and each of them is a case the paragraph above assumed away.
+
+On a photograph the ring does not read as a mount. It reads as a white rectangle drawn around the picture — the plan called it "a decision" and accepted it as the price of the diagrams, and looked at, it is not a decision, it is an artefact.
+
+The diagrams are worse, and they are the reverse of the problem the mat was built for. Not every diagram in the vault is a light-background scan: some were drawn **for** a dark background, and the mat puts cream behind a figure whose own strokes are pale, so it takes parts of the drawing from readable to invisible. A treatment that damages the case it was meant to help is not a trade, and there is nothing to tune here — the mat cannot know which kind of image it is behind.
+
+So images render as their author exported them, in both themes, which is where this started. The glare is real and it remains unsolved; the honest position is that it is the image's problem and belongs upstream in the vault — a diagram exported with a transparent or dark ground fixes it for every reader and every theme, and no stylesheet rule can. The link half of this item stands unchanged.
+
 ### Cost and risk
 
-An hour, and it took about that. Reversible in one commit.
+An hour, and it took about that. Reversible in one commit, which is what happened.
 
 ## 6. Typography
+
+**Built and reverted on 2026-08-27.** The sections below are the reasoning as it stood, kept because the build is worth reading and the finding in it is worth keeping; _Reverted_ near the end is what happened when it was looked at. The site is on the system stack, headings included.
 
 ### The problem
 
@@ -220,9 +232,19 @@ The check that does work is to rename the family to something nobody has and scr
 
 The same fact settles a question the plan did not ask. Adding `local("Noto Serif")` to the `src` would let those readers skip the download, but the installed face at that name is Regular, and claiming it as the 600 weight would render headings light on exactly the machines that have it. One URL, one weight, the same face for everyone.
 
+### Reverted, 2026-08-27: the headings look better in the sans
+
+The face was correct on every measure the plan set for it — vendored, 29KB, preloaded, no CDN, no DNS lookup to anyone else — and the page reads better without it. A serif heading over sans body text gives the page a voice the page did not need; the type scale was already doing the work, and one face throughout is quieter and closer to what the notes look like in Obsidian, which is the property this item's own reasoning kept coming back to.
+
+That is a taste call and it was made the way item 1 exists to have it made: by looking at the rendered pages, at both themes, rather than at the argument. The argument was good, which is why it was built at all.
+
+What came out: the `@font-face` and `--heading-font` from the stylesheet, the `varLib.instancer`/`pyftsubset`/`woff2_compress` derivation from `lib/hugo.nix`, the static copy, the preload from `baseof.html`, and the VM subtest that asserted the file was served. One assertion outlives the face and stays, moved into the "the site is styled" subtest: **the stylesheet names no font CDN**. That guard is about the offline property, not about this face, and it is the line that would be cheapest to undo by accident.
+
+What is kept in this document rather than in the code is the finding, because it will be true for whoever tries this next: **you cannot check a webfont by looking at it** on a machine that has the family installed. That section stands above.
+
 ### Cost and risk
 
-Two hours, and it took about that. The risk was page weight, and the answer is above: 29KB, preloaded, on every page.
+Two hours to build and ten minutes to remove. The risk taken was page weight and it was not the one that bit — the plan had no way to sequence "does this look right" before "does this work", because the answer to the first needs the second in front of it.
 
 ## 7. Wikilink hover previews (optional)
 
@@ -246,7 +268,7 @@ Selection was the fourth item in the title and it was taken in item 2, where the
 
 Printing from the dark theme produced **a blank sheet**. Browsers do not print background colours by default, so the ground goes and the text stays: fujiWhite on white paper. The fix is to override both token blocks inside `@media print` — paper is white and the ink is black, whichever theme the reader was in — and it is the reason this item stopped being optional.
 
-Two smaller consequences of the same fact. `==highlight==` is a background and so does not print; it takes an underline instead, which is the same mark made with ink. And the dark theme's image mat from item 5 keys off `data-theme`, which is still `"dark"` for someone printing from it, so it has to be switched off by hand rather than by the palette.
+One smaller consequence of the same fact: `==highlight==` is a background and so does not print; it takes an underline instead, which is the same mark made with ink. (A second rule rode along here — the dark theme's image mat from item 5, which keyed off `data-theme` and so was still on for someone printing from the dark theme — and it went when the mat did.)
 
 The rest went as described. External destinations print after the link, scoped to the article so the footer's chrome does not; `break-after: avoid` on headings and `break-inside: avoid` on the blocks that cannot be scrolled past; the rail needs no unsticking in practice, because print media is about 794px wide and the grid needs 1280, but it is unstuck explicitly since `sticky` in a paged medium is browser-dependent and none of the answers are a table of contents.
 
@@ -278,4 +300,4 @@ Item 3 is out of the first pass by choice, not by dependency; it can be taken at
 
 Each item is its own PR, per the usual gate. Item 2 will not change the VM test's assertions — the test looks for a stylesheet, not for its contents — which is worth stating explicitly, because it means the gate is not evidence for any of this and the screenshots are.
 
-That held for items 2, 4 and 5 and stopped holding at item 6, which added two. A webfont is not a colour: the file either is served from this site or it is not, and if it is not, nothing fails — every reader silently gets their own serif. That is a fact about the output tree and it belongs in the check, alongside the assertion that the stylesheet names no font CDN. The rest of the judgement is still the screenshots'.
+That held for items 2, 4 and 5, and stopped holding at item 6, which added two assertions: a webfont is not a colour — the file either is served from this site or it is not, and if it is not, nothing fails, every reader silently gets their own serif. When the face was reverted one of the two went with it and one stayed, which is the useful line between them. The file being served was a fact about a decision that got reversed; **the stylesheet naming no font CDN** is a fact about the property this whole toolchain exists to hold, and it holds whether or not there is ever a webfont again. The rest of the judgement is still the screenshots'.

--- a/modules/services/digital-garden/lib/hugo.nix
+++ b/modules/services/digital-garden/lib/hugo.nix
@@ -30,44 +30,6 @@
 }:
 let
   theme = ./hugo;
-
-  # The heading face, vendored on exactly the terms KaTeX is: taken from a
-  # package that rides flake.lock, reduced here, and served as an ordinary
-  # static file. Nothing is fetched at build time and nothing is fetched by the
-  # reader's browser — which is the property this whole file exists to hold, and
-  # the reason a webfont is affordable at all. A CDN link would have been one
-  # line and would have made every reader's page load depend on Google.
-  #
-  # Noto Serif ships as a 1.9MB variable TTF: every weight from 100 to 900, and
-  # a glyph for very nearly every language Noto covers. Two reductions get that
-  # to ~29KB, which is the budget the plan set.
-  #
-  #   1. Instance the variable axes at the ONE weight the headings use. This is
-  #      the big one: `gvar`, the table describing how every glyph deforms
-  #      across the weight axis, is two thirds of the file and it goes entirely.
-  #   2. Subset the glyphs to Latin plus the punctuation these notes contain.
-  #      The range is Google Fonts' own `latin` subset, which is what a heading
-  #      in English with an em dash and a curly quote in it needs.
-  #
-  # If a note ever takes a heading outside this range, the browser falls back to
-  # the body stack for that heading rather than showing tofu — the same
-  # degradation the site had before the face existed.
-  headingFont =
-    pkgs.runCommand "noto-serif-latin-600.woff2"
-      {
-        nativeBuildInputs = [
-          pkgs.python3Packages.fonttools
-          pkgs.woff2
-        ];
-      }
-      ''
-        fonttools varLib.instancer -o instance.ttf \
-          ${pkgs.noto-fonts}/share/fonts/noto/NotoSerif.ttf wght=600
-        pyftsubset instance.ttf --output-file=subset.ttf --no-hinting \
-          --unicodes='U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+2074,U+20AC,U+2122,U+2190-2193,U+2212,U+2215,U+FEFF,U+FFFD'
-        woff2_compress subset.ttf
-        cp subset.woff2 $out
-      '';
 in
 {
   mkRenderer =
@@ -199,12 +161,6 @@ in
         mkdir -p "$work/static/katex"
         cp ${pkgs.katex}/lib/node_modules/katex/dist/katex.min.css "$work/static/katex/"
         cp -r ${pkgs.katex}/lib/node_modules/katex/dist/fonts "$work/static/katex/fonts"
-
-        # The heading face, subset above. One file, one weight, on every page:
-        # unlike KaTeX there is no test for "did this page use it", because
-        # every page has a title.
-        mkdir -p "$work/static/fonts"
-        cp ${headingFont} "$work/static/fonts/noto-serif-latin.woff2"
 
         # Store paths copy out read-only, and the exit trap's rm -rf cannot
         # remove a read-only directory's contents.

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -26,40 +26,13 @@
  *   the longest note here has twenty-nine; a coloured heading every screen is
  *   more page than it is emphasis.
  *
- * Fonts are a serif for headings and the system stack for body text. The
- * reasoning for each is at the @font-face below.
+ * Fonts are the system stack, for headings as well as for body text. A
+ * vendored serif for headings was built and then removed: the machinery was
+ * sound - 29KB, subset at build time, no CDN - and the page still read better
+ * with one face throughout. A heading here is a size and a weight, not a
+ * change of voice. The rest of the argument stands as it did: shipping a
+ * webfont is a request this site has no reason to make of a reader.
  */
-
-/* Noto Serif, subset to Latin at one weight by lib/hugo.nix and served from
- * this site. The earlier version of this file used the system stack throughout
- * and argued that asking for a webfont without shipping it is the worst of both
- * — which is right, and is why this one IS shipped: vendored from nixpkgs at
- * build time exactly as KaTeX is, no CDN, no DNS lookup to anyone else.
- *
- * Headings only. A serif body would suit an essay site and is what most gardens
- * reach for, but these notes are written in Obsidian in the system sans, and a
- * page that reads the same in the editor and in the browser is worth more here
- * than a page that reads like a book. Headings alone give it a voice.
- *
- * One weight, 600, which is the weight the headings already had. A second would
- * double the payload for a distinction the type scale is already making with
- * size. `swap` because the fallback below is a real typeface and not a
- * placeholder: showing a heading in it immediately beats showing nothing.
- *
- * A trap for whoever checks this by looking. A browser keeps the faces INSTALLED
- * under a family name in the family alongside the ones @font-face adds, so on
- * any machine with Noto Serif in fontconfig — this one, and every Android phone
- * — a broken `src` still renders a serif heading, taken from the system. A
- * screenshot here therefore cannot tell you whether this file was fetched at
- * all. Rename the family to something nobody has and screenshot that: if the
- * heading is still a serif, the woff2 loaded. */
-@font-face {
-  font-family: "Noto Serif";
-  src: url("/fonts/noto-serif-latin.woff2") format("woff2");
-  font-weight: 600;
-  font-style: normal;
-  font-display: swap;
-}
 
 :root {
   /* Lotus. The three grounds are lotusWhite3/2/0 lightened toward white; the
@@ -76,11 +49,6 @@
   --body-font:
     system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji";
-  /* The fallbacks are the serifs a reader is most likely to already have, in
-   * rough order of how close they sit to Noto Serif's proportions, so a heading
-   * shown before the file arrives is not a different shape from the one that
-   * replaces it. */
-  --heading-font: "Noto Serif", Georgia, "Times New Roman", Times, serif;
   --measure: 40rem;
   color-scheme: light;
 }
@@ -226,7 +194,6 @@ h2,
 h3,
 h4 {
   color: var(--strong);
-  font-family: var(--heading-font);
   font-weight: 600;
   line-height: 1.25;
   margin: 2rem 0 0.75rem;
@@ -411,26 +378,19 @@ details[open] > summary.callout-title {
   margin-bottom: 0.25rem;
 }
 
+/* An image arrives as its author exported it, in both themes. A white-
+ * background diagram does glare on sumiInk3, and neither answer to that
+ * survived being looked at: a paper-coloured mat behind the image reads as a
+ * white rectangle drawn around a photograph, and puts a cream ground under the
+ * diagrams that were drawn FOR a dark page, which is the reverse of the
+ * problem; a filter dims the photographs. Nothing here can tell which kind of
+ * image it is behind. The fix for a glaring diagram is to export it with a
+ * transparent ground, which fixes it for every reader and every theme. */
 img {
   max-width: 100%;
   height: auto;
   border-radius: 5px;
   margin: 1rem 0;
-}
-
-/* Most diagrams in this vault are light-background scans and exports, and on
- * sumiInk3 a white rectangle is a torch. A mat rather than a filter: dimming
- * the image would dim the photographs too, and there are photographs. This
- * puts the diagram on paper instead — the light theme's own ground, which is
- * where the thing was drawn to be seen — and leaves what is inside the frame
- * exactly as its author exported it.
- *
- * A photograph gets a few pixels of cream around it, which reads as a mount.
- * That is the trade, and it is the right way round: a border on a photograph
- * is a decision, a glare in the middle of a dark page is a fault. */
-:root[data-theme="dark"] img {
-  background: #f9f6e1; /* the light theme's --bg: lotusWhite3, lightened */
-  padding: 0.5rem;
 }
 
 hr {
@@ -660,13 +620,8 @@ h4:hover > .heading-anchor,
   border-top: 1px solid var(--border);
 }
 
-/* Back to the body stack. These two are <h2> for the outline and for the
- * `aria-labelledby` on each nav, not because they are headings in the essay:
- * they are 0.8rem uppercase labels, and a serif at that size and spacing is
- * the one place the face looks like a mistake. */
 .rail h2 {
   margin: 0 0 0.75rem;
-  font-family: var(--body-font);
   font-size: 0.8rem;
   font-weight: 600;
   letter-spacing: 0.06em;
@@ -896,15 +851,6 @@ pagefind-modal {
   .heading-anchor,
   .footnote-backref {
     display: none;
-  }
-
-  /* The mat exists because the page is dark. Here it is not, and the tokens
-   * above have already said so - but that rule keys off data-theme, which is
-   * still "dark" for a reader who printed from the dark theme, so it has to be
-   * turned off by hand rather than by the palette. */
-  :root[data-theme="dark"] img {
-    background: none;
-    padding: 0;
   }
 
   /* The rail is already in its narrow layout here - print media is about 794px

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -9,24 +9,6 @@
     {{ with partial "description.html" . }}<meta name="description" content="{{ . }}" />{{ end }}
     <link rel="canonical" href="{{ .Permalink }}" />
     {{ partial "social.html" . }}
-    {{/*
-      The heading face, before the stylesheet that asks for it. A font
-      referenced from CSS is not discovered until the stylesheet has been
-      fetched AND parsed AND matched to an element, which for the <h1> at the
-      top of every page here is one round trip too late; this starts it with
-      the stylesheet instead. `crossorigin` is not optional even though the
-      file is same-origin: fonts are fetched in CORS mode, and a preload
-      without it is a second, unused download.
-
-      Unconditional, unlike KaTeX below, because every page has a title.
-    */}}
-    <link
-      rel="preload"
-      href="{{ "fonts/noto-serif-latin.woff2" | relURL }}"
-      as="font"
-      type="font/woff2"
-      crossorigin
-    />
     {{ with resources.Get "main.css" | fingerprint }}
       <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" />
     {{ end }}


### PR DESCRIPTION
Reverses two of the taste passes from 2026-08-27. Both were judged against the rendering fixture; both look wrong against the real vault and the real page.

## The image mat (item 5, image half)

`:root[data-theme="dark"] img` put a paper-coloured ground behind every image in the dark theme, and its `@media print` counterpart switched that off again for anyone printing from dark. Both go.

It was judged on the fixture's SVG, which is white to its own edges — and the fixture's SVG is not the vault:

- On a **photograph** the cream ring does not read as a mount. It reads as a white rectangle drawn around the picture.
- On **diagrams** it is worse, and it is the reverse of the problem the mat was built for. Not every diagram here is a light-background scan; some were drawn _for_ a dark background, and a cream ground behind pale strokes takes parts of the drawing from readable to invisible.

Nothing in a stylesheet can tell which kind of image it is behind, so there is nothing to tune. Images now render as their author exported them, in both themes.

The glare that motivated the mat is real and is left unsolved on purpose: it is the image's problem and belongs upstream in the vault, where exporting a diagram with a transparent ground fixes it for every reader and every theme at once.

The link half of item 5 — the underlines — is untouched.

## The serif headings (item 6)

The face was correct on every measure the plan set for it: vendored from nixpkgs, 28,952 bytes, preloaded, no CDN, nothing fetched at build time. The page still reads better without it. A serif heading over sans body gives the page a voice it did not need when the type scale was already making the distinction, and one face throughout is closer to what these notes look like in Obsidian.

Removed: the `@font-face` and `--heading-font`, the `font-family` on `h1`–`h4`, the `.rail h2` override that existed only to escape the serif, the `varLib.instancer` / `pyftsubset` / `woff2_compress` derivation and its static copy in `lib/hugo.nix`, and the preload in `baseof.html`. 29KB less on every page and nothing under `/fonts/`.

## The check

The subtest that asserted the woff2 was served goes with the file. **One assertion moves rather than dying with it: the stylesheet names no font CDN.** That guards the offline-by-construction property this toolchain exists to hold, not the face, and it is the cheapest line here to undo by accident — so it now lives in the "the site is styled" subtest, which already has the fingerprinted stylesheet in hand.

## Plan

`docs/plans/digital-garden-design.md` records the reversal for both, and keeps item 6's finding in full, because it stays true for whoever tries a webfont next: on a machine that has the family installed, you cannot check one by looking at it.

## Verification

- Fixture rendered at 1440px in both themes: headings sans, images unmatted.
- Fixture printed to PDF from the dark theme — still black on white, mat gone with no leftover override.
- `/fonts/noto-serif-latin.woff2` returns 404 and the page carries no preload.
- `nix build .#checks.x86_64-linux.digital-garden` passes.