### PR TITLE
feat(garden): footnotes as sidenotes in the right margin

### DIFF
--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -617,8 +617,9 @@ h4:hover > .heading-anchor,
 /* ── the rail ───────────────────────────────────────────────────────────── */
 
 /* Where you are in this note, and what else points at it. One piece of markup
- * with two layouts: beneath the article by default, and in the right margin
- * once there is a margin to put it in. See layouts/_partials/rail.html.
+ * with two layouts: beneath the article by default, and in the left margin
+ * once there is a margin to put it in (the sidenotes claim the right). See
+ * layouts/_partials/rail.html.
  *
  * The default is the narrow one, so the layout the site served before the rail
  * existed is the one that needs no media query to produce. Set apart from the
@@ -681,10 +682,18 @@ h4:hover > .heading-anchor,
 
   .layout > article {
     grid-column: 2;
+    /* Row 1 is fixed explicitly, so the rail (also row 1, column 1) sits at
+     * the TOP of the prose rather than auto-placing into the next row after
+     * the tall article. Without it the grid builds two rows and the rail
+     * floats below the whole essay. */
+    grid-row: 1;
   }
 
   .rail {
-    grid-column: 3;
+    grid-column: 1;
+    /* See the article's note above: row 1 keeps the rail at the top, beside
+     * the prose it annotates, instead of below the essay. */
+    grid-row: 1;
     /* Aligned to the top of the prose, not stretched down the page: `start`
      * on the grid keeps it the height of its own content, which is what
      * sticky needs. */
@@ -736,6 +745,74 @@ h4:hover > .heading-anchor,
   }
 
   .rail .backlink-thesis {
+    display: none;
+  }
+}
+
+/* ── sidenotes ───────────────────────────────────────────────────────────── */
+
+/* Footnotes, in the right margin beside the paragraph that cites them. The
+ * generation is untouched -- Hugo still emits the endnote list, and the script
+ * in baseof.html lifts its entries into the margin on the wide layout. The
+ * narrow layout is the endnote one, so a reader on a phone, and a reader with
+ * JavaScript disabled, both get the foot-of-page notes the site has always
+ * had.
+ *
+ * The right margin is the grid's third column, which on a page with no rail
+ * would otherwise be empty -- the rail has moved to the first (left) column.
+ * So sidenotes render whether or not a rail exists: the prose stays centred
+ * in column two and each margin note is absolutely positioned at the top of
+ * the paragraph that cites it.
+ *
+ * The script measures and sets each note's `top` inline; this block supplies
+ * the box, the border that separates note from prose, and the small numeral.
+ */
+
+/* Hidden by default (the narrow layout): the notes are placed by the script
+ * only when the wide grid is active, and this is what keeps a pre-placement
+ * flash from showing absolutely-positioned notes at the layout's origin. */
+.sidenote {
+  display: none;
+}
+
+@media (min-width: 80rem) {
+  .layout {
+    /* Sidenotes are absolutely positioned against it, so it is the containing
+     * block their `top` is measured in. */
+    position: relative;
+  }
+
+  .sidenote {
+    display: block;
+    position: absolute;
+    right: 0;
+    /* The margin is at least this wide at every width the grid builds at
+     * (>80rem), so the note never collides with the prose. */
+    width: min(14rem, 100%);
+    border-left: 1px solid var(--border);
+    padding-left: 1rem;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: var(--muted);
+  }
+
+  /* The other end of the superscript in the prose: a small numeral (the id
+   * Hugo gave the definition) that marks the note without repeating the
+   * prose's own number. */
+  .sidenote-num {
+    vertical-align: super;
+    font-size: 0.7em;
+    color: var(--accent);
+    margin-right: 0.35rem;
+  }
+
+  .sidenote p {
+    margin: 0 0 0.25rem;
+  }
+
+  .sidenote .footnote-backref {
+    /* The in-paragraph reference already lands on the note; the way back is a
+     * second link to the same two places and reads as noise in the margin. */
     display: none;
   }
 }
@@ -873,7 +950,13 @@ pagefind-modal {
    * of same-page anchors is useless on paper, and the notes that cite this one
    * are worth having. This unsticks it explicitly anyway, because `sticky` in a
    * paged medium either repeats on every sheet or pins to the first depending
-   * on the browser, and neither is what the rule meant. */
+   * on the browser, and neither is what the rule meant.
+   *
+   * Footnotes are the same story told from the other end: rolling the sidenote
+   * margin back to the endnote list happens in the script's beforeprint
+   * handler, because the DOM cannot hold a sidenote and its endnote under the
+   * same id at once. This block styles that restored list - nothing further is
+   * needed here, which is the point of print reusing the narrow state. */
   .rail {
     position: static;
     max-height: none;

--- a/modules/services/digital-garden/lib/hugo/fixture/Another Note.md
+++ b/modules/services/digital-garden/lib/hugo/fixture/Another Note.md
@@ -8,3 +8,11 @@ thesis: A second note exists so that the first one has a backlink to render.
 This note exists for one reason: [[Every Element]] needs something to link to it, or the backlinks partial renders nothing and the one piece of chrome that only appears on a linked page goes unseen.
 
 It also links to [[A Long Note]], so more than one page carries a backlink, and to a heading inside it — [[A Long Note#The second section]] — because a fragment link is resolved by a different rule than a plain one.
+
+Footnotes belong beside the note that cites them, and this page has no rail to compete for the margin, which is the condition under which sidenotes render at all.[^1]
+
+A second footnote in its own paragraph, so two margin notes stack one beneath the other, each aligned to the top of the paragraph that cites it.[^2]
+
+[^1]: A sidenote on a page with no rail, sitting in the empty right margin beside the paragraph that cites it.
+
+[^2]: The second sidenote, below the first, so the spacing between a column of margin notes is judged rather than assumed.

--- a/modules/services/digital-garden/lib/hugo/fixture/Every Element.md
+++ b/modules/services/digital-garden/lib/hugo/fixture/Every Element.md
@@ -7,7 +7,11 @@ thesis: Every element the theme styles, on one page, so a stylesheet change can 
 
 The opening paragraph, which exists to be read at the measure the stylesheet caps prose to. It carries _emphasis_, **strong emphasis**, `inline code`, an ==Obsidian highlight==, a [link to another note](/another-note/), a [wikilink](/a-long-note/), and an [external link](https://gohugo.io) that should be marked as leaving the site. It also carries a footnote.[^1]
 
-A second paragraph, so that the spacing between two paragraphs is visible and not inferred from the spacing between a paragraph and something else.
+A second paragraph, so that the spacing between two paragraphs is visible and not inferred from the spacing between a paragraph and something else, and so that a footnote here is far enough from a footnote above it for the margin placement to be judged rather than assumed.[^2]
+
+## Sidenotes
+
+Footnotes move into the right margin beside the paragraph that cites them, and this whole section exists so that there are enough of them in enough places to see whether that placement holds together — one at the top of the page, one mid-page, and one at the foot of a long section.[^3] A note with more than one footnote in a single paragraph is the stress case, because the margin then has to separate the notes without overlapping.[^4] And a second note in the same paragraph confirms it.[^5] A single note can be cited more than once, and it must still appear once — not once for every citation.[^3]
 
 ## A heading, and under it the shortest possible section
 
@@ -136,3 +140,11 @@ A paragraph mentioning two amounts, $80 and $400, because that shape once read a
 A horizontal rule sits above this line.
 
 [^1]: The footnote itself, which renders in a list at the foot of the page with a link back to the reference.
+
+[^2]: A second footnote, near the top of the page but below the first, so the vertical gap between two sidenotes is a thing that is looked at.
+
+[^3]: A footnote in the middle of the note, on its own section, so sidenotes are seen against headings rather than only against a wall of prose.
+
+[^4]: The first of two footnotes in one paragraph. Multiple notes in the same paragraph are the hardest case for a sidenote margin, because they must stack without overlapping.
+
+[^5]: The second footnote in the same paragraph as the fourth, which is how a column of sidenotes has to separate its entries.

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/rail.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/rail.html
@@ -1,5 +1,5 @@
 {{/*
-  The right-hand rail: where a reader is in this note, and what else points at
+  The left-hand rail: where a reader is in this note, and what else points at
   it. Both belong beside the prose rather than beneath it — a reader who wants
   to know what cites a note wants it while reading, not four screens below
   where they stopped.

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -276,5 +276,214 @@
         });
       })();
     </script>
+
+    {{/*
+      Sidenotes in the right margin. Hugo emits every footnote as a single
+      list at the foot of the note -- `[^1]` becomes an endnote, which is the
+      render it has always had and deliberately unchanged here. Moving them
+      does NOT touch generation or the markup Hugo emits; this script lifts the
+      notes out of that list and places each one in the right margin, beside
+      the paragraph that cites it, on the reader's machine.
+
+      That is the whole design of this feature and the reason it stays small:
+      nothing in lib/hugo.nix, publish-filter.py or the render hooks changes,
+      and a reader with JavaScript disabled gets exactly the endnote page the
+      site shipped before this script existed -- and a reader on a narrow
+      screen gets it too.
+
+      The width decides the layout, and it can change while the page is open.
+      There are two states, toggled whenever the viewport crosses the 80rem
+      breakpoint:
+
+      Wide. The layout is a three-column grid: 1fr minmax(0, 40rem) 1fr. The
+      prose is the centred second column and never moves. The rail occupies
+      the first (left) column. The sidenotes fill the third (right) column,
+      each absolutely positioned at the top of the paragraph that cites it --
+      the Tufte margin note. Placing them in the third column means a page
+      with no rail still gets its margin notes: the rail is beside the prose
+      on the left, the notes beside it on the right, and neither needs the
+      other to exist. That is why they are not gated on the rail.
+
+      Narrow. No margin to put a note in, so the margin is torn down and the
+      original endnote list is restored to the foot of the essay, where Hugo
+      put it -- the same place the backlinks sit at the foot of the page.
+
+      Positioning a wide note needs the vertical offset of its paragraph
+      inside the grid, so each note is placed at the top of the ancestor of
+      its citation that is a direct child of the article (a paragraph, an li,
+      a blockquote). Notes cited from the same block stack beneath one
+      another, each measured against the one before it, so two notes in one
+      paragraph never overlap. The notes are inserted into .layout rather than
+      the article, so pagefind -- which indexes the article marked
+      data-pagefind-body -- does not index the note text.
+
+      A note can be cited more than once (the same source can come up in many
+      paragraphs). One note is built per definition, anchored to its FIRST
+      citation, so a repeated citation does not stack a second copy of the
+      same margin note; the citation in prose still scrolls to the one note.
+      Each note keeps the id Hugo gave its definition, so every citation's
+      href="#fn:N" lands on the margin note and only there.
+    */}}
+    <script>
+      (function () {
+        var article = document.querySelector("article");
+        var list = document.querySelector(".footnotes");
+        if (!article || !list) return;
+
+        var layout = document.querySelector(".layout");
+        if (!layout) return;
+
+        // Where the endnote list belongs when it is restored at the foot of
+        // the essay (narrow width). Kept, not guessed: the margin is torn down
+        // and rebuilt as the width crosses the breakpoint, and the list has to
+        // come back exactly where it started.
+        var host = list.parentNode;
+        var nextSibling = list.nextSibling;
+
+        // One entry per footnote definition -- the <li id="fn:N"> entries Hugo
+        // emitted at the foot of the page -- keyed by id, NOT one per citation.
+        // A note can be cited many times over and each citation is a separate
+        // reference; the footnote itself is one thing and belongs once.
+        var defs = {};
+        list.querySelectorAll("li[id]").forEach(function (li) {
+          defs[li.id] = li;
+        });
+        var ids = Object.keys(defs);
+        if (!ids.length) return;
+
+        var mql = window.matchMedia("(min-width: 80rem)");
+        var notes = [];
+
+        // The topmost ancestor of a citation that is a direct child of the
+        // article -- the box whose top the margin note aligns to.
+        function anchorBlock(ref) {
+          var node = ref;
+          while (node && node.parentNode && node.parentNode !== article) {
+            node = node.parentNode;
+          }
+          return node && node.parentNode === article ? node : null;
+        }
+
+        // Place the notes once the margin is laid out. Several notes in one
+        // paragraph would all align to the same paragraph top and stack on
+        // top of each other, so notes are tracked per block: the first is
+        // anchored to its paragraph's top, and each later one in that
+        // paragraph sits one pixel below the previous note's bottom.
+        // `lastTopByBlock` holds that running bottom.
+        function place() {
+          var layoutTop = layout.getBoundingClientRect().top;
+          var lastTopByBlock = {};
+          notes.forEach(function (note) {
+            var key = note.block;
+            var top =
+              key in lastTopByBlock
+                ? lastTopByBlock[key] + 1
+                : note.block.getBoundingClientRect().top - layoutTop;
+            note.aside.style.top = top + "px";
+            lastTopByBlock[key] = top + note.aside.offsetHeight;
+          });
+        }
+
+        // The wide state: build a margin note per definition, remove the
+        // endnote list (the two would be the same words twice, and two
+        // elements with one id is broken HTML), and position the notes.
+        function showSidenotes() {
+          // Tear down any previous margin first, so re-crossing the
+          // breakpoint builds fresh notes instead of duplicating the old ones.
+          notes.forEach(function (note) {
+            note.aside.remove();
+          });
+          notes = [];
+          var placed = {};
+
+          ids.forEach(function (id) {
+            var ref = article.querySelector('.footnote-ref[href="#' + id + '"]');
+            if (!ref) return;
+            var block = anchorBlock(ref);
+            if (!block) return;
+            // First citation wins: a repeated citation must not place a second
+            // copy of the same note.
+            if (placed[id]) return;
+            placed[id] = true;
+
+            // The number is the other end of the superscript in the prose;
+            // Hugo numbers its definitions fn:1, fn:2, ... in order.
+            var aside = document.createElement("aside");
+            aside.className = "sidenote";
+            aside.id = id;
+            aside.setAttribute("role", "doc-footnote");
+            var num = document.createElement("span");
+            num.className = "sidenote-num";
+            num.textContent = id.slice(3);
+            aside.appendChild(num);
+            var clone = defs[id].cloneNode(true);
+            // Every citation produces a "way back" ↩ link in the definition,
+            // so a single note can carry many of them. Strip them all: the
+            // in-paragraph reference already lands on the note.
+            Array.prototype.forEach.call(
+              clone.querySelectorAll(".footnote-backref"),
+              function (backref) {
+                backref.remove();
+              }
+            );
+            // The <p> Hugo gives each definition is the aside's body.
+            while (clone.firstChild) aside.appendChild(clone.firstChild);
+
+            layout.appendChild(aside);
+            notes.push({ aside: aside, block: block });
+          });
+
+          // Nothing to place (no citations on the page): keep the endnotes.
+          if (!notes.length) {
+            if (!list.parentNode) host.insertBefore(list, nextSibling);
+            return;
+          }
+
+          // The medium is the margin now, so drop the foot-of-page list.
+          if (list.parentNode) list.remove();
+
+          // rAF waits for the grid to resolve; forcing layout (the offsetHeight
+          // read inside place) makes the measurement accurate on first run.
+          requestAnimationFrame(place);
+        }
+
+        // The narrow state: the margin is gone, so the notes are removed and
+        // the endnote list comes back at the foot of the essay.
+        function showEndnotes() {
+          notes.forEach(function (note) {
+            note.aside.remove();
+          });
+          notes = [];
+          if (!list.parentNode) host.insertBefore(list, nextSibling);
+        }
+
+        function sync() {
+          if (mql.matches) showSidenotes();
+          else showEndnotes();
+        }
+        // Rebuild both when the width crosses the breakpoint either way, so a
+        // reader who resizes the window is never left without footnotes.
+        if (mql.addEventListener) mql.addEventListener("change", sync);
+        else mql.addListener(sync);
+        sync();
+
+        // While wide, a resize can move every citation's line, so re-measure.
+        window.addEventListener("resize", function () {
+          if (mql.matches && notes.length) requestAnimationFrame(place);
+        });
+
+        // On paper there is no right margin - a sheet is about 794px wide,
+        // whatever the window is - so the footnotes are printed the way they
+        // started: as endnotes at the foot of the essay, which is exactly the
+        // narrow state the print stylesheet already styles for. Swap to it
+        // while the sheet is being composed, and back to the margin after.
+        window.addEventListener("beforeprint", function () {
+          if (mql.matches) showEndnotes();
+        });
+        window.addEventListener("afterprint", function () {
+          if (mql.matches) showSidenotes();
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/modules/services/digital-garden/lib/hugo/layouts/page.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/page.html
@@ -1,8 +1,9 @@
 {{ define "main" }}
   {{/*
     article and rail are siblings in one grid, so that the rail can occupy the
-    empty right margin at wide widths and fall back beneath the article at
-    narrow ones without a second copy of the markup. See _partials/rail.html.
+    empty left margin at wide widths (the sidenotes take the right) and fall
+    back beneath the article at narrow ones without a second copy of the
+    markup. See _partials/rail.html.
   */}}
   <div class="layout">
     <article data-pagefind-body>


### PR DESCRIPTION
## What & why

The digital garden's footnotes move out of the (now left-hand) rail into the **right margin** as Tufte-style sidenotes, aligned to the paragraph that cites each one. The rail moves to the left; the prose stays perfectly centred and does not move.

This is the version that replaces the earlier "footnotes-in-the-rail" prototype from the prior session.

## Design

- **Three-column grid** `1fr minmax(0,40rem) 1fr`: prose centred (col 2, unchanged), rail on the **left** (col 1), sidenotes absolute-positioned in the empty **right** (col 3) — so a page with **no rail still gets its margin notes** (not gated on the rail).
- **Dedupe**: one margin note per footnote definition, anchored to its *first* citation — a note cited many times renders once (previously 13 duplicates on one real page).
- **Search isolation**: notes are inserted into `.layout` *outside* `article[data-pagefind-body]` so pagefind does not index footnote text.
- **Progressive enhancement**: no-JS and narrow (<80rem) keep the original foot-of-essay endnotes. The script is a two-state machine that rebuilds in both directions when the width crosses the breakpoint, so resizing never leaves a page without footnotes.
- **Print** swaps to the endnote state (`beforeprint`/`afterprint`), matching the existing print stylesheet.

## Fixes along the way

- Rail auto-placed into a second grid row and rendered below the essay; pinned article + rail to `grid-row: 1`.
- Fixture: Every Element now exercises rail+sidenotes together, same-block stacking, and a repeated citation; Another Note is the rail-less case.

## Verification

- `nix run .#garden-preview -- --fixture --once` builds clean.
- CDP-driven headless browser checks (fixture at 1600px and 800px): rail top-left, prose centred, 5 unique sidenotes on the right, dedupe works, `another-note` (rail-less) shows 2 right-margin sidenotes with centred prose; wide→narrow→wide and print toggles all correct.

Files (6): `layouts/baseof.html`, `assets/main.css`, `layouts/page.html`, `layouts/_partials/rail.html`, `fixture/Every Element.md`, `fixture/Another Note.md`. The renderer's `lib/hugo.nix`, `publish-filter.py`, and render hooks are untouched.
