### PR TITLE
build(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -185,11 +185,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787750582,
-        "narHash": "sha256-FfIAV44k33i+IjC1+new2KyjyVGUzGtV89VHVP4eK1U=",
+        "lastModified": 1787797243,
+        "narHash": "sha256-8+Q7NOB7RPajRjA4pbCDLzqH+MTjnG9x6LUPLfL2joA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0a364342a66bcecfc8a00d2fc38c6c29eee7bc5e",
+        "rev": "99c9ec63390f1d8c14d95d9e8b17cc29cfbd4e11",
         "type": "github"
       },
       "original": {
@@ -213,11 +213,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1787640266,
-        "narHash": "sha256-MrkfE5hF5xx4L/0h5NyJ3xQkKVftwSuKSkFSrvlTxGY=",
+        "lastModified": 1787753485,
+        "narHash": "sha256-BZWCi9ZRJiARTuKTbbtvFTj7t1TK4G3UEckT3HyNfRg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f4f698677b11021a8f84f452e23ae9ef2427bec3",
+        "rev": "062346a6d85bc4b49dfaa61c986e9c5be21217d1",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1787724554,
-        "narHash": "sha256-1MlNGoDNOgFn/SFuqmdVRdqEXnGNbtg8jwBisiqIH4I=",
+        "lastModified": 1787848627,
+        "narHash": "sha256-t3XgpB1iCGH5mR6cXVbwC9II2JdajaPqnlIHvh/unlI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d3eb569db65130561d1e654a07efe526889a177b",
+        "rev": "7e0fb958bbf98c835549713f15243aabcf9ce741",
         "type": "github"
       },
       "original": {
@@ -245,11 +245,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1787498568,
-        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
         "type": "github"
       },
       "original": {
@@ -336,11 +336,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1787175104,
-        "narHash": "sha256-tzNjlb0loxeWlipvxSNAUUihloeTZoyGFhEen87yM9k=",
+        "lastModified": 1787771653,
+        "narHash": "sha256-DkkJSBOXWV/mja5Vy8az5g1KpZlsbUwlmH0BsQhowaQ=",
         "owner": "nix-community",
         "repo": "stylix",
-        "rev": "a9e5a76a1b75b137f266e4f445e1eaba82e9783e",
+        "rev": "5e3809851f486e7fc7e84b40f174c74b60ecc784",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `flake.lock` update.

The per-host deltas below are recorded in the commit body so they
land in `git log` on merge (ADR 0001).

Each host was built at the current lock and at the updated one, and
the closures compared. All three builds passing is a precondition of
this PR existing at all — but the `nixos ci` gate still has to pass
before it can merge, and merging is what promotes `deploy`.

### homelab01

ada: 3.4.4 → 4.0.0, -152.2 KiB
alertmanager: 16.5 KiB
autobrr: 8.6 KiB
caddy: 128.1 KiB
chromaprint: 1.6.0 → 1.6.1
cloudflared: 2026.7.3 → 2026.8.2, 358.1 KiB
cryptsetup: 2.8.6 → 2.8.7, 132.9 KiB
delve: 8.3 KiB
expat: 2.8.2 → 2.8.3
ffmpeg: 9.0 → 9.0.1
ffmpeg-headless: 9.0 → 9.0.1
getent-glibc: 2.42-67 → 2.42-84
gh: 148.1 KiB
glibc: 2.42-67 → 2.42-84
glibc-locales: 2.42-67 → 2.42-84
go: 1.26.5 → 1.26.7, 81.8 KiB
gotools: 63.2 KiB
grafana: 2.2 MiB
gst-plugins-bad: 1.28.5 → 1.28.6, 8.8 KiB
gst-plugins-base: 1.28.5 → 1.28.6
gstreamer: 1.28.5 → 1.28.6
hugo: 140.1 KiB
initrd-linux: 6.18.45 → 6.18.46, -135.5 KiB
kavita-frontend: 20.0 KiB
kguiaddons: -8.1 KiB
libarchive: 3.8.8 → 3.8.9, 8.4 KiB
libblake3: 1.8.5 → 1.8.6
libcamera: 0.7.0 → 0.7.2, 340.5 KiB
libffi: 3.7.1 → 3.8.0
libpcap: 19.6 KiB
libpq: 18.4 → 18.6
libsodium: 1.0.22-unstable-2026-07-08 → 1.0.22-unstable-2026-07-31
libyuv: 1908 added, 3.9 MiB
linux: 6.18.45 → 6.18.46, 19.9 KiB
lmdb: 0.9.35 → 0.9.36
luajit: 2.1.1774638290 → 2.1.1785763465, 36.4 KiB
neovim: 0.12.4 → 0.12.5
neovim-unwrapped: 0.12.4 → 0.12.5
nghttp2: 1.69.0 → 1.70.0, 632.6 KiB
nixos-manual: 95.8 KiB
nixos-system-homelab01: 26.11.20260823.56c02bc → 26.11.20260826.9fbb54b
nodejs-slim: 35.6 KiB
nspr: 4.39 → 4.40
pagefind-extended: -80.0 KiB
perl: 5.42.0 → 5.42.3, 82.6 KiB
perl5.42.0-Archive-Cpio: 0.10 removed, -22.3 KiB
perl5.42.0-Archive-Zip: 1.68 removed, -219.4 KiB
perl5.42.0-Authen-SASL: 2.1900 removed, -84.5 KiB
perl5.42.0-CGI: 4.59 removed, -316.7 KiB
perl5.42.0-CGI-Fast: 2.16 removed, -13.1 KiB
perl5.42.0-Clone: 0.46 removed, -22.0 KiB
perl5.42.0-Compress-Raw-Bzip2: 2.218 removed, -56.7 KiB
perl5.42.0-Compress-Raw-Zlib: 2.222 removed, -130.3 KiB
perl5.42.0-Config-IniFiles: 3.002000 removed, -91.2 KiB
perl5.42.0-Crypt-URandom: 0.55 removed, -32.5 KiB
perl5.42.0-Digest-HMAC: 1.05 removed, -9.2 KiB
perl5.42.0-Encode-Locale: 1.05 removed, -15.1 KiB
perl5.42.0-FCGI: 0.82 removed, -80.4 KiB
perl5.42.0-FCGI-ProcManager: 0.28 removed, -27.6 KiB
perl5.42.0-File-BaseDir: 0.09 removed, -18.9 KiB
perl5.42.0-File-DesktopEntry: 0.22 removed, -27.2 KiB
perl5.42.0-File-Listing: 6.16 removed, -17.2 KiB
perl5.42.0-File-MimeInfo: 0.33 removed, -78.8 KiB
perl5.42.0-File-Slurp: 9999.32 removed, -33.5 KiB
perl5.42.0-HTML-Parser: 3.85 removed, -154.2 KiB
perl5.42.0-HTML-TagCloud: 0.38 removed, -12.8 KiB
perl5.42.0-HTML-Tagset: 3.20 removed, -15.7 KiB
perl5.42.0-HTTP-CookieJar: 0.014 removed, -25.5 KiB
perl5.42.0-HTTP-Cookies: 6.10 removed, -40.4 KiB
perl5.42.0-HTTP-Daemon: 6.17 removed, -34.5 KiB
perl5.42.0-HTTP-Date: 6.06 removed, -15.1 KiB
perl5.42.0-HTTP-Message: 7.02 removed, -142.4 KiB
perl5.42.0-HTTP-Negotiate: 6.01 removed, -19.2 KiB
perl5.42.0-IO-Compress: 2.221 removed, -885.9 KiB
perl5.42.0-IO-HTML: 1.004 removed, -22.2 KiB
perl5.42.0-IO-Socket-SSL: 2.083 removed, -481.4 KiB
perl5.42.0-IO-Stringy: 2.113 removed, -77.5 KiB
perl5.42.0-IPC-System-Simple: 1.30 removed, -36.5 KiB
perl5.42.0-JSON: 4.10 removed, -174.7 KiB
perl5.42.0-LWP-MediaTypes: 6.04 removed, -58.8 KiB
perl5.42.0-Mozilla-CA: 20230821 removed, -466.0 KiB
perl5.42.0-Net-DBus: 1.2.0 removed, -461.2 KiB
perl5.42.0-Net-HTTP: 6.23 removed, -37.8 KiB
perl5.42.0-Net-SMTP-SSL: 1.04 removed
perl5.42.0-Net-SSLeay: 1.92 removed, -1.1 MiB
perl5.42.0-SUPER: 1.20190531 removed, -9.3 KiB
perl5.42.0-Sub-Identify: 0.14 removed, -23.3 KiB
perl5.42.0-Sub-Override: 0.09 removed, -11.1 KiB
perl5.42.0-TermReadKey: 2.38 removed, -47.3 KiB
perl5.42.0-Test-Fatal: 0.017 removed, -18.5 KiB
perl5.42.0-Test-MockModule: 0.177.0 removed, -18.5 KiB
perl5.42.0-Test-Needs: 0.002010 removed, -11.5 KiB
perl5.42.0-Test-RequiresInternet: 0.05 removed
perl5.42.0-TimeDate: 2.33 removed, -88.1 KiB
perl5.42.0-Try-Tiny: 0.31 removed, -23.6 KiB
perl5.42.0-URI: 5.21 removed, -158.1 KiB
perl5.42.0-WWW-RobotRules: 6.02 removed, -18.5 KiB
perl5.42.0-X11-Protocol: 0.56 removed, -244.5 KiB
perl5.42.0-XML-Parser: 2.46 removed, -428.6 KiB
perl5.42.0-XML-Twig: 3.52 removed, -503.0 KiB
perl5.42.0-libnet: 3.15 removed, -211.0 KiB
perl5.42.0-libwww-perl: 6.83 removed, -298.5 KiB
perl5.42.0-strip-nondeterminism: 1.14.1 removed, -90.6 KiB
perl5.42.3-Archive-Cpio: 0.10 added, 22.3 KiB
perl5.42.3-Archive-Zip: 1.68 added, 219.4 KiB
perl5.42.3-Authen-SASL: 2.1900 added, 84.5 KiB
perl5.42.3-CGI: 4.59 added, 316.7 KiB
perl5.42.3-CGI-Fast: 2.16 added, 13.1 KiB
perl5.42.3-Clone: 0.46 added, 22.0 KiB
perl5.42.3-Compress-Raw-Bzip2: 2.218 added, 56.7 KiB
perl5.42.3-Compress-Raw-Zlib: 2.222 added, 130.3 KiB
perl5.42.3-Config-IniFiles: 3.002000 added, 91.2 KiB
perl5.42.3-Crypt-URandom: 0.55 added, 32.5 KiB
perl5.42.3-Digest-HMAC: 1.05 added, 9.2 KiB
perl5.42.3-Encode-Locale: 1.05 added, 15.1 KiB
perl5.42.3-FCGI: 0.82 added, 80.4 KiB
perl5.42.3-FCGI-ProcManager: 0.28 added, 27.6 KiB
perl5.42.3-File-BaseDir: 0.09 added, 18.9 KiB
perl5.42.3-File-DesktopEntry: 0.22 added, 27.2 KiB
perl5.42.3-File-Listing: 6.16 added, 17.2 KiB
perl5.42.3-File-MimeInfo: 0.33 added, 78.8 KiB
perl5.42.3-File-Slurp: 9999.32 added, 33.5 KiB
perl5.42.3-HTML-Parser: 3.85 added, 154.2 KiB
perl5.42.3-HTML-TagCloud: 0.38 added, 12.8 KiB
perl5.42.3-HTML-Tagset: 3.20 added, 15.7 KiB
perl5.42.3-HTTP-CookieJar: 0.014 added, 25.5 KiB
perl5.42.3-HTTP-Cookies: 6.10 added, 40.4 KiB
perl5.42.3-HTTP-Daemon: 6.17 added, 34.5 KiB
perl5.42.3-HTTP-Date: 6.08 added, 16.5 KiB
perl5.42.3-HTTP-Message: 7.02 added, 142.4 KiB
perl5.42.3-HTTP-Negotiate: 6.01 added, 19.2 KiB
perl5.42.3-IO-Compress: 2.221 added, 885.9 KiB
perl5.42.3-IO-HTML: 1.004 added, 22.2 KiB
perl5.42.3-IO-Socket-SSL: 2.083 added, 481.4 KiB
perl5.42.3-IO-Stringy: 2.113 added, 77.5 KiB
perl5.42.3-IPC-System-Simple: 1.30 added, 36.5 KiB
perl5.42.3-JSON: 4.10 added, 174.7 KiB
perl5.42.3-LWP-MediaTypes: 6.04 added, 58.8 KiB
perl5.42.3-Mozilla-CA: 20230821 added, 466.0 KiB
perl5.42.3-Net-DBus: 1.2.0 added, 461.2 KiB
perl5.42.3-Net-HTTP: 6.23 added, 37.8 KiB
perl5.42.3-Net-SMTP-SSL: 1.04 added
perl5.42.3-Net-SSLeay: 1.92 added, 1.1 MiB
perl5.42.3-SUPER: 1.20190531 added, 9.3 KiB
perl5.42.3-Sub-Identify: 0.14 added, 23.3 KiB
perl5.42.3-Sub-Override: 0.09 added, 11.1 KiB
perl5.42.3-TermReadKey: 2.38 added, 47.3 KiB
perl5.42.3-Test-Fatal: 0.017 added, 18.5 KiB
perl5.42.3-Test-MockModule: 0.177.0 added, 18.5 KiB
perl5.42.3-Test-Needs: 0.002010 added, 11.5 KiB
perl5.42.3-Test-RequiresInternet: 0.05 added
perl5.42.3-TimeDate: 2.33 added, 88.1 KiB
perl5.42.3-Try-Tiny: 0.31 added, 23.6 KiB
perl5.42.3-URI: 5.21 added, 158.1 KiB
perl5.42.3-WWW-RobotRules: 6.02 added, 18.5 KiB
perl5.42.3-X11-Protocol: 0.56 added, 244.5 KiB
perl5.42.3-XML-Parser: 2.46 added, 428.6 KiB
perl5.42.3-XML-Twig: 3.52 added, 503.0 KiB
perl5.42.3-libnet: 3.15 added, 211.0 KiB
perl5.42.3-libwww-perl: 6.83 added, 298.5 KiB
perl5.42.3-strip-nondeterminism: 1.14.1 added, 90.6 KiB
podman: 32.8 KiB
procps: 4.0.6 → 4.0.7
prometheus: 1.5 MiB
publicsuffix-list: 0-unstable-2026-07-25 → 0-unstable-2026-08-14
python3: -39.9 KiB
qtbase: 6.11.1, 6.11.1-only-plugins → 6.11.2, 6.11.2-only-plugins, -183.5 KiB
qtdeclarative: 6.11.1 → 6.11.2, 1.3 MiB
qtsvg: 6.11.1 → 6.11.2
qttranslations: 6.11.1 → 6.11.2, 62.1 KiB
qtwayland: 6.11.1 → 6.11.2, 17.2 KiB
rclone: 20.1 KiB
rdma-core: 64.0 added, 4.2 MiB
rsync: 3.4.4 → 3.5.0, 75.5 KiB
ruff: 0.16.3 → 0.16.4, -2.8 MiB
samba: 11.6 KiB
sdl3: 3.4.12 → 3.4.14
shadow: 4.20.0 → 4.20.2
sops: 12.1 KiB
source: 293.5 KiB
strace: 7.1 → 7.2, -1.2 MiB
systemd: 261.1 → 261.2, -588.9 KiB
systemd-minimal: 261.1 → 261.2, 16.9 KiB
systemd-minimal-libs: 261.1 → 261.2
texinfo-interactive: 7.2 → 7.3, 1.6 MiB
tree-sitter: 0.26.9 → 0.26.11, 39.1 KiB
tree-sitter-c-neovim: 0.12.4 → 0.12.5
tree-sitter-lua-neovim: 0.12.4 → 0.12.5
tree-sitter-markdown-neovim: 0.12.4 → 0.12.5
tree-sitter-markdown_inline-neovim: 0.12.4 → 0.12.5
tree-sitter-query-neovim: 0.12.4 → 0.12.5
tree-sitter-vim-neovim: 0.12.4 → 0.12.5
tree-sitter-vimdoc-neovim: 0.12.4 → 0.12.5
unbound: 1.25.2 → 1.26.0, 8.5 KiB
zvbi: 0.2.44 → 0.2.45

### homelab02

ada: 3.4.4 → 4.0.0, -152.2 KiB
alertmanager: 16.5 KiB
caddy: 128.1 KiB
cryptsetup: 2.8.6 → 2.8.7, 132.9 KiB
delve: 8.3 KiB
expat: 2.8.2 → 2.8.3
getent-glibc: 2.42-67 → 2.42-84
gh: 148.1 KiB
glibc: 2.42-67 → 2.42-84
glibc-locales: 2.42-67 → 2.42-84
go: 1.26.5 → 1.26.7, 81.8 KiB
gotools: 63.2 KiB
initrd-linux: 6.18.45 → 6.18.46, -163.3 KiB
kguiaddons: -8.1 KiB
libarchive: 3.8.8 → 3.8.9, 8.4 KiB
libblake3: 1.8.5 → 1.8.6
libffi: 3.7.1 → 3.8.0
libpcap: 19.6 KiB
libpq: 18.4 → 18.6
libsodium: 1.0.22-unstable-2026-07-08 → 1.0.22-unstable-2026-07-31
linux: 6.18.45 → 6.18.46, 20.2 KiB
luajit: 2.1.1774638290 → 2.1.1785763465, 36.4 KiB
neovim: 0.12.4 → 0.12.5
neovim-unwrapped: 0.12.4 → 0.12.5
nghttp2: 1.69.0 → 1.70.0, 632.6 KiB
nixos-manual: 95.8 KiB
nixos-system-homelab02: 26.11.20260823.56c02bc → 26.11.20260826.9fbb54b
nodejs-slim: 17.8 KiB
nspr: 4.39 → 4.40
openjdk-headless: 27.9 KiB
perl: 5.42.0 → 5.42.3, 82.6 KiB
perl5.42.0-Archive-Cpio: 0.10 removed, -22.3 KiB
perl5.42.0-Archive-Zip: 1.68 removed, -219.4 KiB
perl5.42.0-Authen-SASL: 2.1900 removed, -84.5 KiB
perl5.42.0-CGI: 4.59 removed, -316.7 KiB
perl5.42.0-CGI-Fast: 2.16 removed, -13.1 KiB
perl5.42.0-Clone: 0.46 removed, -22.0 KiB
perl5.42.0-Compress-Raw-Bzip2: 2.218 removed, -56.7 KiB
perl5.42.0-Compress-Raw-Zlib: 2.222 removed, -130.3 KiB
perl5.42.0-Config-IniFiles: 3.002000 removed, -91.2 KiB
perl5.42.0-Crypt-URandom: 0.55 removed, -32.5 KiB
perl5.42.0-Digest-HMAC: 1.05 removed, -9.2 KiB
perl5.42.0-Encode-Locale: 1.05 removed, -15.1 KiB
perl5.42.0-FCGI: 0.82 removed, -80.4 KiB
perl5.42.0-FCGI-ProcManager: 0.28 removed, -27.6 KiB
perl5.42.0-File-BaseDir: 0.09 removed, -18.9 KiB
perl5.42.0-File-DesktopEntry: 0.22 removed, -27.2 KiB
perl5.42.0-File-Listing: 6.16 removed, -17.2 KiB
perl5.42.0-File-MimeInfo: 0.33 removed, -78.8 KiB
perl5.42.0-File-Slurp: 9999.32 removed, -33.5 KiB
perl5.42.0-HTML-Parser: 3.85 removed, -154.2 KiB
perl5.42.0-HTML-TagCloud: 0.38 removed, -12.8 KiB
perl5.42.0-HTML-Tagset: 3.20 removed, -15.7 KiB
perl5.42.0-HTTP-CookieJar: 0.014 removed, -25.5 KiB
perl5.42.0-HTTP-Cookies: 6.10 removed, -40.4 KiB
perl5.42.0-HTTP-Daemon: 6.17 removed, -34.5 KiB
perl5.42.0-HTTP-Date: 6.06 removed, -15.1 KiB
perl5.42.0-HTTP-Message: 7.02 removed, -142.4 KiB
perl5.42.0-HTTP-Negotiate: 6.01 removed, -19.2 KiB
perl5.42.0-IO-Compress: 2.221 removed, -885.9 KiB
perl5.42.0-IO-HTML: 1.004 removed, -22.2 KiB
perl5.42.0-IO-Socket-SSL: 2.083 removed, -481.4 KiB
perl5.42.0-IO-Stringy: 2.113 removed, -77.5 KiB
perl5.42.0-IPC-System-Simple: 1.30 removed, -36.5 KiB
perl5.42.0-JSON: 4.10 removed, -174.7 KiB
perl5.42.0-LWP-MediaTypes: 6.04 removed, -58.8 KiB
perl5.42.0-Mozilla-CA: 20230821 removed, -466.0 KiB
perl5.42.0-Net-DBus: 1.2.0 removed, -461.2 KiB
perl5.42.0-Net-HTTP: 6.23 removed, -37.8 KiB
perl5.42.0-Net-SMTP-SSL: 1.04 removed
perl5.42.0-Net-SSLeay: 1.92 removed, -1.1 MiB
perl5.42.0-SUPER: 1.20190531 removed, -9.3 KiB
perl5.42.0-Sub-Identify: 0.14 removed, -23.3 KiB
perl5.42.0-Sub-Override: 0.09 removed, -11.1 KiB
perl5.42.0-TermReadKey: 2.38 removed, -47.3 KiB
perl5.42.0-Test-Fatal: 0.017 removed, -18.5 KiB
perl5.42.0-Test-MockModule: 0.177.0 removed, -18.5 KiB
perl5.42.0-Test-Needs: 0.002010 removed, -11.5 KiB
perl5.42.0-Test-RequiresInternet: 0.05 removed
perl5.42.0-TimeDate: 2.33 removed, -88.1 KiB
perl5.42.0-Try-Tiny: 0.31 removed, -23.6 KiB
perl5.42.0-URI: 5.21 removed, -158.1 KiB
perl5.42.0-WWW-RobotRules: 6.02 removed, -18.5 KiB
perl5.42.0-X11-Protocol: 0.56 removed, -244.5 KiB
perl5.42.0-XML-Parser: 2.46 removed, -428.6 KiB
perl5.42.0-XML-Twig: 3.52 removed, -503.0 KiB
perl5.42.0-libnet: 3.15 removed, -211.0 KiB
perl5.42.0-libwww-perl: 6.83 removed, -298.5 KiB
perl5.42.0-strip-nondeterminism: 1.14.1 removed, -90.6 KiB
perl5.42.3-Archive-Cpio: 0.10 added, 22.3 KiB
perl5.42.3-Archive-Zip: 1.68 added, 219.4 KiB
perl5.42.3-Authen-SASL: 2.1900 added, 84.5 KiB
perl5.42.3-CGI: 4.59 added, 316.7 KiB
perl5.42.3-CGI-Fast: 2.16 added, 13.1 KiB
perl5.42.3-Clone: 0.46 added, 22.0 KiB
perl5.42.3-Compress-Raw-Bzip2: 2.218 added, 56.7 KiB
perl5.42.3-Compress-Raw-Zlib: 2.222 added, 130.3 KiB
perl5.42.3-Config-IniFiles: 3.002000 added, 91.2 KiB
perl5.42.3-Crypt-URandom: 0.55 added, 32.5 KiB
perl5.42.3-Digest-HMAC: 1.05 added, 9.2 KiB
perl5.42.3-Encode-Locale: 1.05 added, 15.1 KiB
perl5.42.3-FCGI: 0.82 added, 80.4 KiB
perl5.42.3-FCGI-ProcManager: 0.28 added, 27.6 KiB
perl5.42.3-File-BaseDir: 0.09 added, 18.9 KiB
perl5.42.3-File-DesktopEntry: 0.22 added, 27.2 KiB
perl5.42.3-File-Listing: 6.16 added, 17.2 KiB
perl5.42.3-File-MimeInfo: 0.33 added, 78.8 KiB
perl5.42.3-File-Slurp: 9999.32 added, 33.5 KiB
perl5.42.3-HTML-Parser: 3.85 added, 154.2 KiB
perl5.42.3-HTML-TagCloud: 0.38 added, 12.8 KiB
perl5.42.3-HTML-Tagset: 3.20 added, 15.7 KiB
perl5.42.3-HTTP-CookieJar: 0.014 added, 25.5 KiB
perl5.42.3-HTTP-Cookies: 6.10 added, 40.4 KiB
perl5.42.3-HTTP-Daemon: 6.17 added, 34.5 KiB
perl5.42.3-HTTP-Date: 6.08 added, 16.5 KiB
perl5.42.3-HTTP-Message: 7.02 added, 142.4 KiB
perl5.42.3-HTTP-Negotiate: 6.01 added, 19.2 KiB
perl5.42.3-IO-Compress: 2.221 added, 885.9 KiB
perl5.42.3-IO-HTML: 1.004 added, 22.2 KiB
perl5.42.3-IO-Socket-SSL: 2.083 added, 481.4 KiB
perl5.42.3-IO-Stringy: 2.113 added, 77.5 KiB
perl5.42.3-IPC-System-Simple: 1.30 added, 36.5 KiB
perl5.42.3-JSON: 4.10 added, 174.7 KiB
perl5.42.3-LWP-MediaTypes: 6.04 added, 58.8 KiB
perl5.42.3-Mozilla-CA: 20230821 added, 466.0 KiB
perl5.42.3-Net-DBus: 1.2.0 added, 461.2 KiB
perl5.42.3-Net-HTTP: 6.23 added, 37.8 KiB
perl5.42.3-Net-SMTP-SSL: 1.04 added
perl5.42.3-Net-SSLeay: 1.92 added, 1.1 MiB
perl5.42.3-SUPER: 1.20190531 added, 9.3 KiB
perl5.42.3-Sub-Identify: 0.14 added, 23.3 KiB
perl5.42.3-Sub-Override: 0.09 added, 11.1 KiB
perl5.42.3-TermReadKey: 2.38 added, 47.3 KiB
perl5.42.3-Test-Fatal: 0.017 added, 18.5 KiB
perl5.42.3-Test-MockModule: 0.177.0 added, 18.5 KiB
perl5.42.3-Test-Needs: 0.002010 added, 11.5 KiB
perl5.42.3-Test-RequiresInternet: 0.05 added
perl5.42.3-TimeDate: 2.33 added, 88.1 KiB
perl5.42.3-Try-Tiny: 0.31 added, 23.6 KiB
perl5.42.3-URI: 5.21 added, 158.1 KiB
perl5.42.3-WWW-RobotRules: 6.02 added, 18.5 KiB
perl5.42.3-X11-Protocol: 0.56 added, 244.5 KiB
perl5.42.3-XML-Parser: 2.46 added, 428.6 KiB
perl5.42.3-XML-Twig: 3.52 added, 503.0 KiB
perl5.42.3-libnet: 3.15 added, 211.0 KiB
perl5.42.3-libwww-perl: 6.83 added, 298.5 KiB
perl5.42.3-strip-nondeterminism: 1.14.1 added, 90.6 KiB
podman: 32.8 KiB
procps: 4.0.6 → 4.0.7
prometheus: 1.5 MiB
publicsuffix-list: 0-unstable-2026-07-25 → 0-unstable-2026-08-14
python3: -39.9 KiB
qtbase: 6.11.1, 6.11.1-only-plugins → 6.11.2, 6.11.2-only-plugins, -183.5 KiB
qtdeclarative: 6.11.1 → 6.11.2, 1.3 MiB
qtsvg: 6.11.1 → 6.11.2
qttranslations: 6.11.1 → 6.11.2, 62.1 KiB
qtwayland: 6.11.1 → 6.11.2, 17.2 KiB
rclone: 20.1 KiB
rdma-core: 64.0 added, 4.2 MiB
rsync: 3.4.4 → 3.5.0, 75.5 KiB
ruff: 0.16.3 → 0.16.4, -2.8 MiB
shadow: 4.20.0 → 4.20.2
sops: 12.1 KiB
source: 293.5 KiB
strace: 7.1 → 7.2, -1.2 MiB
systemd: 261.1 → 261.2, -588.9 KiB
systemd-minimal: 261.1 → 261.2, 16.9 KiB
systemd-minimal-libs: 261.1 → 261.2
texinfo-interactive: 7.2 → 7.3, 1.6 MiB
tree-sitter: 0.26.9 → 0.26.11, 39.1 KiB
tree-sitter-c-neovim: 0.12.4 → 0.12.5
tree-sitter-lua-neovim: 0.12.4 → 0.12.5
tree-sitter-markdown-neovim: 0.12.4 → 0.12.5
tree-sitter-markdown_inline-neovim: 0.12.4 → 0.12.5
tree-sitter-query-neovim: 0.12.4 → 0.12.5
tree-sitter-vim-neovim: 0.12.4 → 0.12.5
tree-sitter-vimdoc-neovim: 0.12.4 → 0.12.5
unbound: 1.25.2 → 1.26.0, 8.5 KiB
zfs-kernel: 2.4.4-6.18.45 → 2.4.4-6.18.46

### xps15

ada: 3.4.4 → 4.0.0, -152.2 KiB
cfitsio: 4.6.4 → 4.7.0
chromaprint: 1.6.0 → 1.6.1
claude-code: 2.1.238 → 2.1.245, 50.6 MiB
cryptsetup: 2.8.6 → 2.8.7, 265.8 KiB
delve: 8.3 KiB
docker-buildx: 52.1 KiB
docker-compose: 40.2 KiB
docker-containerd: 16.5 KiB
expat: 2.8.2 → 2.8.3
ffmpeg: 9.0 → 9.0.1
ffmpeg-headless: 8.1.2, 9.0 → 9.0.1, -62.9 MiB
firefox: 154.0 → 154.0.1
firefox-unwrapped: 154.0 → 154.0.1, -151.3 KiB
gamescope: 140.0 KiB
geoclue: 2.8.1 → 2.8.2
getent-glibc: 2.42-67 → 2.42-84
gh: 148.1 KiB
glibc: 2.42-67 removed, -33.5 MiB
glibc-locales: 2.42-67 → 2.42-84
glibc-multi: 2.42-67 → 2.42-84
go: 1.26.5 → 1.26.7, 81.8 KiB
google-chrome: 151.0.7922.173 → 152.0.7977.64, 2.3 MiB
gotools: 63.2 KiB
graphviz: 15.1.0 → 15.1.1
grimblast: 0.1-unstable-2026-06-30 → 0.1-unstable-2026-08-21
gst-libav: 1.28.5 → 1.28.6
gst-plugins-bad: 1.28.5 → 1.28.6, 25.4 KiB
gst-plugins-base: 1.28.5 → 1.28.6
gst-plugins-good: 1.28.5 → 1.28.6, 12.3 KiB
gst-plugins-ugly: 1.28.5 → 1.28.6
gstreamer: 1.28.5 → 1.28.6
iana-etc: -557.8 KiB
initrd-linux: -131.2 KiB
kcompletion: 8.2 KiB
kcontacts: -20.5 KiB
kcoreaddons: -11.4 KiB
kdbusaddons: -11.9 KiB
kdeconnect-kde: -717.5 KiB
kguiaddons: -8.1 KiB
kio: -69.8 KiB
kirigami: 25.0 KiB
kirigami-addons: 20.5 KiB
kjobwidgets: -52.8 KiB
knotifications: -11.4 KiB
kstatusnotifieritem: -20.0 KiB
kwallet: -24.6 KiB
kwindowsystem: 16.6 KiB
libarchive: 3.8.8 → 3.8.9, 13.4 KiB
libblake3: 1.8.5 → 1.8.6
libcamera: 0.7.0 → 0.7.2, 673.5 KiB
libffi: 3.7.1 → 3.8.0
libidn2: -359.5 KiB
libpcap: 57.2 KiB
libpq: 18.4 → 18.6
libsodium: 1.0.22-unstable-2026-07-08 → 1.0.22-unstable-2026-07-31
libunistring: -2.0 MiB
lmdb: 0.9.35 → 0.9.36
luajit: 2.1.1774638290 → 2.1.1785763465, 36.4 KiB
mailcap: -116.6 KiB
moby: 48.4 KiB
modemmanager-qt: -76.0 KiB
neovim: 0.12.4 → 0.12.5
neovim-unwrapped: 0.12.4 → 0.12.5
nghttp2: 1.69.0 → 1.70.0, 632.8 KiB
nixos-manual: 95.8 KiB
nixos-system-xps15: 26.11.20260823.56c02bc → 26.11.20260826.9fbb54b
nodejs-slim: 35.6 KiB
nspr: 4.39 → 4.40
openjdk: -21.7 KiB
pandoc-cli: 172.0 KiB
perl: 5.42.0 → 5.42.3, 161.9 KiB
perl5.42.0-Archive-Cpio: 0.10 removed, -22.3 KiB
perl5.42.0-Archive-Zip: 1.68 removed, -219.4 KiB
perl5.42.0-Authen-SASL: 2.1900 removed, -84.5 KiB
perl5.42.0-CGI: 4.59 removed, -316.7 KiB
perl5.42.0-CGI-Fast: 2.16 removed, -13.1 KiB
perl5.42.0-Clone: 0.46 removed, -22.0 KiB
perl5.42.0-Compress-Raw-Bzip2: 2.218 removed, -56.7 KiB
perl5.42.0-Compress-Raw-Zlib: 2.222 removed, -130.3 KiB
perl5.42.0-Config-IniFiles: 3.002000 removed, -91.2 KiB
perl5.42.0-Crypt-URandom: 0.55 removed, -32.5 KiB
perl5.42.0-Digest-HMAC: 1.05 removed, -9.2 KiB
perl5.42.0-Encode-Locale: 1.05 removed, -15.1 KiB
perl5.42.0-FCGI: 0.82 removed, -80.4 KiB
perl5.42.0-FCGI-ProcManager: 0.28 removed, -27.6 KiB
perl5.42.0-File-BaseDir: 0.09 removed, -18.9 KiB
perl5.42.0-File-DesktopEntry: 0.22 removed, -27.2 KiB
perl5.42.0-File-Listing: 6.16 removed, -17.2 KiB
perl5.42.0-File-MimeInfo: 0.33 removed, -78.8 KiB
perl5.42.0-File-Slurp: 9999.32 removed, -33.5 KiB
perl5.42.0-GD: 2.86 removed, -313.5 KiB
perl5.42.0-HTML-Parser: 3.85 removed, -154.2 KiB
perl5.42.0-HTML-TagCloud: 0.38 removed, -12.8 KiB
perl5.42.0-HTML-Tagset: 3.20 removed, -15.7 KiB
perl5.42.0-HTTP-CookieJar: 0.014 removed, -25.5 KiB
perl5.42.0-HTTP-Cookies: 6.10 removed, -40.4 KiB
perl5.42.0-HTTP-Daemon: 6.17 removed, -34.5 KiB
perl5.42.0-HTTP-Date: 6.06 removed, -15.1 KiB
perl5.42.0-HTTP-Message: 7.02 removed, -142.4 KiB
perl5.42.0-HTTP-Negotiate: 6.01 removed, -19.2 KiB
perl5.42.0-IO-Compress: 2.221 removed, -885.9 KiB
perl5.42.0-IO-HTML: 1.004 removed, -22.2 KiB
perl5.42.0-IO-Socket-SSL: 2.083 removed, -481.4 KiB
perl5.42.0-IO-Stringy: 2.113 removed, -77.5 KiB
perl5.42.0-IPC-System-Simple: 1.30 removed, -36.5 KiB
perl5.42.0-JSON: 4.10 removed, -174.7 KiB
perl5.42.0-LWP-MediaTypes: 6.04 removed, -58.8 KiB
perl5.42.0-Mozilla-CA: 20230821 removed, -466.0 KiB
perl5.42.0-Net-DBus: 1.2.0 removed, -461.2 KiB
perl5.42.0-Net-HTTP: 6.23 removed, -37.8 KiB
perl5.42.0-Net-SMTP-SSL: 1.04 removed
perl5.42.0-Net-SSLeay: 1.92 removed, -1.1 MiB
perl5.42.0-SUPER: 1.20190531 removed, -9.3 KiB
perl5.42.0-Sub-Identify: 0.14 removed, -23.3 KiB
perl5.42.0-Sub-Override: 0.09 removed, -11.1 KiB
perl5.42.0-TermReadKey: 2.38 removed, -47.3 KiB
perl5.42.0-Test-Fatal: 0.017 removed, -18.5 KiB
perl5.42.0-Test-MockModule: 0.177.0 removed, -18.5 KiB
perl5.42.0-Test-Needs: 0.002010 removed, -11.5 KiB
perl5.42.0-Test-RequiresInternet: 0.05 removed
perl5.42.0-TimeDate: 2.33 removed, -88.1 KiB
perl5.42.0-Try-Tiny: 0.31 removed, -23.6 KiB
perl5.42.0-URI: 5.21 removed, -158.1 KiB
perl5.42.0-WWW-RobotRules: 6.02 removed, -18.5 KiB
perl5.42.0-X11-Protocol: 0.56 removed, -244.5 KiB
perl5.42.0-XML-Parser: 2.46 removed, -428.6 KiB
perl5.42.0-XML-Twig: 3.52 removed, -503.0 KiB
perl5.42.0-libnet: 3.15 removed, -211.0 KiB
perl5.42.0-libwww-perl: 6.83 removed, -298.5 KiB
perl5.42.0-strip-nondeterminism: 1.14.1 removed, -90.6 KiB
perl5.42.3-Archive-Cpio: 0.10 added, 22.3 KiB
perl5.42.3-Archive-Zip: 1.68 added, 219.4 KiB
perl5.42.3-Authen-SASL: 2.1900 added, 84.5 KiB
perl5.42.3-CGI: 4.59 added, 316.7 KiB
perl5.42.3-CGI-Fast: 2.16 added, 13.1 KiB
perl5.42.3-Clone: 0.46 added, 22.0 KiB
perl5.42.3-Compress-Raw-Bzip2: 2.218 added, 56.7 KiB
perl5.42.3-Compress-Raw-Zlib: 2.222 added, 130.3 KiB
perl5.42.3-Config-IniFiles: 3.002000 added, 91.2 KiB
perl5.42.3-Crypt-URandom: 0.55 added, 32.5 KiB
perl5.42.3-Digest-HMAC: 1.05 added, 9.2 KiB
perl5.42.3-Encode-Locale: 1.05 added, 15.1 KiB
perl5.42.3-FCGI: 0.82 added, 80.4 KiB
perl5.42.3-FCGI-ProcManager: 0.28 added, 27.6 KiB
perl5.42.3-File-BaseDir: 0.09 added, 18.9 KiB
perl5.42.3-File-DesktopEntry: 0.22 added, 27.2 KiB
perl5.42.3-File-Listing: 6.16 added, 17.2 KiB
perl5.42.3-File-MimeInfo: 0.33 added, 78.8 KiB
perl5.42.3-File-Slurp: 9999.32 added, 33.5 KiB
perl5.42.3-GD: 2.86 added, 313.5 KiB
perl5.42.3-HTML-Parser: 3.85 added, 154.2 KiB
perl5.42.3-HTML-TagCloud: 0.38 added, 12.8 KiB
perl5.42.3-HTML-Tagset: 3.20 added, 15.7 KiB
perl5.42.3-HTTP-CookieJar: 0.014 added, 25.5 KiB
perl5.42.3-HTTP-Cookies: 6.10 added, 40.4 KiB
perl5.42.3-HTTP-Daemon: 6.17 added, 34.5 KiB
perl5.42.3-HTTP-Date: 6.08 added, 16.5 KiB
perl5.42.3-HTTP-Message: 7.02 added, 142.4 KiB
perl5.42.3-HTTP-Negotiate: 6.01 added, 19.2 KiB
perl5.42.3-IO-Compress: 2.221 added, 885.9 KiB
perl5.42.3-IO-HTML: 1.004 added, 22.2 KiB
perl5.42.3-IO-Socket-SSL: 2.083 added, 481.4 KiB
perl5.42.3-IO-Stringy: 2.113 added, 77.5 KiB
perl5.42.3-IPC-System-Simple: 1.30 added, 36.5 KiB
perl5.42.3-JSON: 4.10 added, 174.7 KiB
perl5.42.3-LWP-MediaTypes: 6.04 added, 58.8 KiB
perl5.42.3-Mozilla-CA: 20230821 added, 466.0 KiB
perl5.42.3-Net-DBus: 1.2.0 added, 461.2 KiB
perl5.42.3-Net-HTTP: 6.23 added, 37.8 KiB
perl5.42.3-Net-SMTP-SSL: 1.04 added
perl5.42.3-Net-SSLeay: 1.92 added, 1.1 MiB
perl5.42.3-SUPER: 1.20190531 added, 9.3 KiB
perl5.42.3-Sub-Identify: 0.14 added, 23.3 KiB
perl5.42.3-Sub-Override: 0.09 added, 11.1 KiB
perl5.42.3-TermReadKey: 2.38 added, 47.3 KiB
perl5.42.3-Test-Fatal: 0.017 added, 18.5 KiB
perl5.42.3-Test-MockModule: 0.177.0 added, 18.5 KiB
perl5.42.3-Test-Needs: 0.002010 added, 11.5 KiB
perl5.42.3-Test-RequiresInternet: 0.05 added
perl5.42.3-TimeDate: 2.33 added, 88.1 KiB
perl5.42.3-Try-Tiny: 0.31 added, 23.6 KiB
perl5.42.3-URI: 5.21 added, 158.1 KiB
perl5.42.3-WWW-RobotRules: 6.02 added, 18.5 KiB
perl5.42.3-X11-Protocol: 0.56 added, 244.5 KiB
perl5.42.3-XML-Parser: 2.46 added, 428.6 KiB
perl5.42.3-XML-Twig: 3.52 added, 503.0 KiB
perl5.42.3-libnet: 3.15 added, 211.0 KiB
perl5.42.3-libwww-perl: 6.83 added, 298.5 KiB
perl5.42.3-strip-nondeterminism: 1.14.1 added, 90.6 KiB
procps: 4.0.6 → 4.0.7
publicsuffix-list: 0-unstable-2026-07-25 → 0-unstable-2026-08-14
python3: -40.5 KiB
python3.14-pyqt6: 34.9 KiB
qca: -23.0 KiB
qt5compat: 6.11.1 → 6.11.2
qtbase: 6.11.1, 6.11.1-only-plugins → 6.11.2, 6.11.2-only-plugins, -183.5 KiB
qtconnectivity: 6.11.1 → 6.11.2
qtdeclarative: 6.11.1 → 6.11.2, 1.3 MiB
qtmultimedia: 6.11.1 → 6.11.2, 92.2 KiB
qtpositioning: 6.11.1 → 6.11.2, -9.3 KiB
qtquick3d: 6.11.1 → 6.11.2, -51.5 KiB
qtserialport: 6.11.1 → 6.11.2
qtshadertools: 6.11.1 → 6.11.2
qtspeech: 6.11.1 → 6.11.2
qtsvg: 6.11.1 → 6.11.2
qttools: 6.11.1 → 6.11.2, -66.8 KiB
qttranslations: 6.11.1 → 6.11.2, 62.1 KiB
qtwayland: 6.11.1 → 6.11.2, 17.2 KiB
qtwebchannel: 6.11.1 → 6.11.2
qtwebengine: 6.11.1 → 6.11.2, 55.8 KiB
qtwebsockets: 6.11.1 → 6.11.2
rdma-core: 64.0 added, 8.4 MiB
rsync: 3.4.4 → 3.5.0, 75.5 KiB
ruff: 0.16.3 → 0.16.4, -2.8 MiB
samba: 23.1 KiB
sdl3: 3.4.12 → 3.4.14, 20.6 KiB
shadow: 4.20.0 → 4.20.2
solid: -8.1 KiB
sops: 12.1 KiB
source: 293.5 KiB
steam: 177.8 KiB
steam-run: 352.5 KiB
strace: 7.1 → 7.2, -1.2 MiB
systemd: 261.1 → 261.2, -1.2 MiB
systemd-minimal: 261.1 → 261.2, 49.5 KiB
systemd-minimal-libs: 261.1 → 261.2, 8.8 KiB
texinfo-interactive: 7.2 → 7.3, 1.6 MiB
texstudio: -75.7 KiB
tree-sitter: 0.26.9 → 0.26.11, 39.1 KiB
tree-sitter-c-neovim: 0.12.4 → 0.12.5
tree-sitter-lua-neovim: 0.12.4 → 0.12.5
tree-sitter-markdown-neovim: 0.12.4 → 0.12.5
tree-sitter-markdown_inline-neovim: 0.12.4 → 0.12.5
tree-sitter-query-neovim: 0.12.4 → 0.12.5
tree-sitter-vim-neovim: 0.12.4 → 0.12.5
tree-sitter-vimdoc-neovim: 0.12.4 → 0.12.5
tzdata: -2.0 MiB
umu-launcher: 180.0 KiB
unbound: 1.25.2 → 1.26.0, 20.8 KiB
vivaldi: 8.1.4087.66 → 8.1.4087.70, 63.4 KiB
wireshark-qt: -190.9 KiB
x86_energy_perf_policy: 6.18.45 → 6.18.46
xgcc: -193.0 KiB
zotero: 9.0.6 → 10.0.0, 13.6 MiB
zvbi: 0.2.44 → 0.2.45