### PR TITLE
fix(garden): place sidenotes beside their citations

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -131,6 +131,44 @@
         Roughly $80k on fixtures that last 5–7 years is a better position than ~$400k on fixtures that last 10+ years, because the second option locks you into decade-old technology you can no longer afford to replace.
         NOTE
 
+        # A note that exercises the sidenote (_right-margin footnote_)
+        # positioning, with the geometry that used to put the notes out of
+        # order. Two footnotes live in DIFFERENT paragraphs that sit right on
+        # top of each other, and the first note is deliberately long so its
+        # margin note is tall. The placement loop keys its "don't overlap"
+        # bookkeeping by block; when it used a DOM node as an object key, every
+        # element stringified to the same value and these two independent
+        # paragraphs were wrongly coupled, pushing the second note below the
+        # tall first one instead of beside its own citation. The check on the
+        # served page asserts each note sits exactly beside its citation.
+        cat > $out/essays/on-sidenotes.md <<'NOTE'
+        ---
+        publish: true
+        ---
+
+        # On Sidenotes
+
+        MARKER-SIDENOTES-BODY
+
+        The first paragraph cites a note that is deliberately long, so that its
+        margin note wraps across several lines and grows tall: the exact
+        condition under which a wrongly shared block would drag the following
+        note down out of place.[^1]
+
+        [^1]: This is a deliberately long sidenote. It continues to assert its
+              length across multiple lines so that the rendered note in the
+              margin is tall, wrapping well past the single line of its own
+              citation, and tall enough to reach the position of the next
+              note's citation below it. That reach is what exposes a shared
+              block: the note that follows must still sit beside its own
+              citation and not be pushed below this one.
+
+        The second paragraph follows the first immediately, and cites its own
+        note.[^2]
+
+        [^2]: A second note in its own, separate paragraph.
+        NOTE
+
         # A real landing page, because it is the one note whose handling is
         # special: it is excluded as a backlink SOURCE. Without it here, the
         # rule that keeps a table of contents from becoming every note's
@@ -197,10 +235,20 @@
       ];
 
       # Hugo and Pagefind are two static binaries rendering a handful of
-      # notes, so this needs very little. Still well above what the run uses,
-      # because a test that fails by running out of memory does not say so
-      # clearly.
-      virtualisation.memorySize = 2048;
+      # notes, so this needs very little - except that the sidenote check at
+      # the bottom runs the page's own Javascript in a headless Chromium and
+      # asks it where the notes landed. That is the only client-side behaviour
+      # on the site, and no amount of grep can assert it, so chromium is here
+      # and the memory allowance is sized for a browser rather than two
+      # static generators.
+      environment.systemPackages = [
+        pkgs.chromium
+        # For splicing the measurement probe into a copy of the served page;
+        # coreutils alone cannot insert a multi-line script before </body>.
+        pkgs.python3
+      ];
+
+      virtualisation.memorySize = 4096;
       virtualisation.diskSize = 4096;
     };
 
@@ -239,7 +287,13 @@
         # the URL, and a file staged under any other name would mean the
         # generator was deciding the address after all.
         staged = sorted(machine.succeed("ls /var/lib/digital-garden/content").split())
-        assert staged == ["index.md", "on-boundaries.md", "on-gates.md", "on-money.md"], staged
+        assert staged == [
+            "index.md",
+            "on-boundaries.md",
+            "on-gates.md",
+            "on-money.md",
+            "on-sidenotes.md",
+          ], staged
 
     with subtest("no unpublished content reaches the served site"):
         # Deliberately the whole tree rather than the rendered page. A leak
@@ -324,6 +378,7 @@
             ("on-gates", "MARKER-PUBLISHED-BODY"),
             ("on-boundaries", "MARKER-BOUNDARIES-BODY"),
             ("on-money", "MARKER-MONEY-BODY"),
+            ("on-sidenotes", "MARKER-SIDENOTES-BODY"),
         ]:
             assert marker in served(f"/{slug}"), f"{slug} was not rendered"
 
@@ -601,6 +656,110 @@
         machine.wait_until_succeeds(
             "curl -sf http://localhost:8086/on-triggers | grep -q MARKER-TRIGGERED-BODY",
             timeout=dt.timedelta(seconds=60),
+        )
+
+    with subtest("each sidenote sits beside its citation, not a shared block top"):
+        # The sidenotes are the site's one piece of client-side behaviour: a
+        # <script> in baseof.html turns each rendered footnote into an
+        # absolutely-positioned note in the right-hand margin and writes its
+        # `top` inline. No amount of grep can assert where a note lands, so the
+        # only faithful check is to run that script and read the layout.
+        #
+        # The page is copied off the served tree onto the filesystem, the
+        # measurement probe is appended, and the fingerprinted stylesheet link
+        # is rewritten from an absolute root path to a same-directory one (the
+        # @media (min-width: 80rem) rule that makes the notes position:absolute
+        # and the .layout relative must actually apply, and on file:// an
+        # absolute /main..css link would not resolve). Chromium is given a wide
+        # viewport so that rule matches: at a phone-width viewport there is no
+        # margin column and no sidenotes at all. The probe waits until the
+        # script has written every note's top, then records each citation's and
+        # each note's position.
+        #
+        # This is the regression test for on-sidenotes.md: two footnotes in two
+        # separate paragraphs that sit right on top of each other, one of them
+        # deliberately tall. When the placement loop keyed its overlap
+        # bookkeeping by the DOM node as an object key, both paragraphs
+        # stringified to the same value and the second note was pushed below
+        # the tall first one instead of beside its own citation. The fix keys
+        # by node identity, so each note must land exactly on its citation.
+        machine.succeed(
+            "mkdir -p /tmp/sn && "
+            "cp /var/lib/digital-garden/public/on-sidenotes/index.html /tmp/sn/page.html && "
+            "cp /var/lib/digital-garden/public/main.*.css /tmp/sn/"
+        )
+
+        # The probe sits between the notes' first placement and any later
+        # re-placement, waiting in a requestAnimationFrame loop until every
+        # .sidenote has an inline top, then measuring once.
+        machine.succeed(
+            "cat > /tmp/sn/probe.js <<'PROBE'\n"
+            'var marker = document.createElement("div");\n'
+            'marker.id = "SN-MEAS";\n'
+            "function measure() {\n"
+            "  var parts = [];\n"
+            '  document.querySelectorAll("a.footnote-ref").forEach(function (a) {\n'
+            '    parts.push("c" + a.getAttribute("href").replace("#", "") + "=" + Math.round(a.getBoundingClientRect().top));\n'
+            "  });\n"
+            '  document.querySelectorAll(".sidenote").forEach(function (s) {\n'
+            '    parts.push("n" + s.id + "=" + Math.round(s.getBoundingClientRect().top));\n'
+            "  });\n"
+            '  marker.textContent = "@@" + parts.join("|") + "@@";\n'
+            "  document.body.appendChild(marker);\n"
+            "}\n"
+            "function maybeMeasure() {\n"
+            '  var notes = document.querySelectorAll(".sidenote");\n'
+            '  var placed = notes.length > 0 && Array.prototype.every.call(notes, function (n) { return n.style.top !== ""; });\n'
+            "  if (placed) measure(); else requestAnimationFrame(maybeMeasure);\n"
+            "}\n"
+            'window.addEventListener("load", function () { requestAnimationFrame(maybeMeasure); });\n'
+            "PROBE"
+        )
+
+        machine.succeed(
+            "python3 - <<'PY'\n"
+            "import re\n"
+            'p = "/tmp/sn/page.html"\n'
+            "s = open(p).read()\n"
+            'probe = open("/tmp/sn/probe.js").read()\n'
+            'css = re.search(r"main\\.[0-9a-f]+\\.css", s)\n'
+            'assert css, "no fingerprinted stylesheet on the sidenote page"\n'
+            's = re.sub(r\'href="/main\\.[0-9a-f]+\\.css"\', \'href="\' + css.group(0) + \'"\', s)\n'
+            's = s.replace("</body>", "<script>" + probe + "</" + "script>" + "</body>", 1)\n'
+            'open(p, "w").write(s)\n'
+            "PY"
+        )
+
+        dom = machine.succeed(
+            "chromium --headless=new --no-sandbox --disable-gpu "
+            "--disable-dev-shm-usage --allow-file-access-from-files "
+            "--virtual-time-budget=8000 --window-size=1600,1200 "
+            "--dump-dom file:///tmp/sn/page.html 2>/dev/null"
+        )
+
+        m = re.search(r'id="SN-MEAS">@@(.*?)@@', dom, re.S)
+        assert m, "the sidenote probe never ran"
+        parts = m.group(1).split("|")
+        cites = {}
+        notes = {}
+        for part in parts:
+            key, _, value = part.rpartition("=")
+            if key.startswith("cfn:"):
+                cites[key[4:]] = int(value)
+            elif key.startswith("nfn:"):
+                notes[key[4:]] = int(value)
+        assert cites, f"no sidenote citations measured: {parts}"
+        assert len(cites) <= len(notes), (
+            f"some citations got no sidenote: {sorted(cites)} vs {sorted(notes)}"
+        )
+        displaced = [
+            (fid, cite_top, notes.get(fid))
+            for fid, cite_top in cites.items()
+            if notes.get(fid) is None or abs(notes[fid] - cite_top) > 3
+        ]
+        assert not displaced, (
+            f"sidenotes not beside their citations {displaced} "
+            f"(cites={sorted(cites)}, notes={sorted(notes)})"
         )
   '';
 }

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -308,14 +308,14 @@
       original endnote list is restored to the foot of the essay, where Hugo
       put it -- the same place the backlinks sit at the foot of the page.
 
-      Positioning a wide note needs the vertical offset of its paragraph
-      inside the grid, so each note is placed at the top of the ancestor of
-      its citation that is a direct child of the article (a paragraph, an li,
-      a blockquote). Notes cited from the same block stack beneath one
-      another, each measured against the one before it, so two notes in one
-      paragraph never overlap. The notes are inserted into .layout rather than
-      the article, so pagefind -- which indexes the article marked
-      data-pagefind-body -- does not index the note text.
+      Positioning a wide note needs the vertical offset of its citation inside
+      the grid, so each note is anchored to the line that cites it, within the
+      ancestor of that citation that is a direct child of the article (a
+      paragraph, an li, a blockquote). Two notes from the same block must not
+      overlap, so when a second note would land on top of the first it is
+      pushed just below the previous note's bottom. The notes are inserted into
+      .layout rather than the article, so pagefind -- which indexes the article
+      marked data-pagefind-body -- does not index the note text.
 
       A note can be cited more than once (the same source can come up in many
       paragraphs). One note is built per definition, anchored to its FIRST
@@ -364,23 +364,45 @@
           return node && node.parentNode === article ? node : null;
         }
 
-        // Place the notes once the margin is laid out. Several notes in one
-        // paragraph would all align to the same paragraph top and stack on
-        // top of each other, so notes are tracked per block: the first is
-        // anchored to its paragraph's top, and each later one in that
-        // paragraph sits one pixel below the previous note's bottom.
-        // `lastTopByBlock` holds that running bottom.
+        // Place the notes once the margin is laid out. A note sits beside the
+        // line that cites it rather than at the top of the block that holds
+        // that line: a paragraph can run for many lines and cite several
+        // "see also" notes, and pinning them all to the paragraph top would
+        // pile every one of them far from the text that cites it.
+        //
+        // There must be no interleaving of reading and writing here. Writing a
+        // note's `top` (and the first writes of each note's dimensions) force
+        // the browser to re-layout, and a `getBoundingClientRect` read after a
+        // write sees the new layout -- so a loop that reads and writes in one
+        // pass places every later note against positions that have already
+        // shifted, and the notes collapse toward the top while their citations
+        // stay where they are. Measure every note first, in a read-only pass,
+        // and only then apply the measured tops.
+        //
+        // Two notes from the same block share one margin column and must not
+        // overlap, so each block remembers the bottom of the most recently
+        // placed note and pushes a later one just below it. The block must be
+        // tracked by identity, not as an object key: every element stringifies
+        // to "[object HTMLElement]", so an object map would collapse all
+        // paragraphs (and all list items, all blockquotes) into one bucket and
+        // wrongly couple notes that live in different blocks.
         function place() {
           var layoutTop = layout.getBoundingClientRect().top;
-          var lastTopByBlock = {};
+          var lastTopByBlock = new Map();
+          var positions = [];
           notes.forEach(function (note) {
-            var key = note.block;
+            var block = note.block;
+            var desired = note.ref.getBoundingClientRect().top - layoutTop;
+            var previous = lastTopByBlock.get(block);
             var top =
-              key in lastTopByBlock
-                ? lastTopByBlock[key] + 1
-                : note.block.getBoundingClientRect().top - layoutTop;
-            note.aside.style.top = top + "px";
-            lastTopByBlock[key] = top + note.aside.offsetHeight;
+              previous === undefined
+                ? desired
+                : Math.max(desired, previous + 1);
+            lastTopByBlock.set(block, top + note.aside.offsetHeight);
+            positions.push({ aside: note.aside, top: top });
+          });
+          positions.forEach(function (position) {
+            position.aside.style.top = position.top + "px";
           });
         }
 
@@ -430,7 +452,7 @@
             while (clone.firstChild) aside.appendChild(clone.firstChild);
 
             layout.appendChild(aside);
-            notes.push({ aside: aside, block: block });
+            notes.push({ aside: aside, block: block, ref: ref });
           });
 
           // Nothing to place (no citations on the page): keep the endnotes.
@@ -471,6 +493,35 @@
         window.addEventListener("resize", function () {
           if (mql.matches && notes.length) requestAnimationFrame(place);
         });
+
+        // The margin is measured against the laid-out article, but images and
+        // web fonts load after first paint and push every later citation down
+        // the page. A note placed before they arrive hovers high, clumped with
+        // the notes above it instead of beside its own citation. So re-measure
+        // once the content has stopped growing: when every image in the essay
+        // has settled, when the window has fully loaded (covering anything
+        // else that grew), and when the fonts are ready. Each pass only
+        // rewrites the notes' `top`, so re-running it is idempotent.
+        function placeWhenSettled() {
+          requestAnimationFrame(place);
+        }
+        var settlingImages = article.querySelectorAll("img");
+        var settlingLeft = settlingImages.length;
+        if (settlingLeft === 0) {
+          window.addEventListener("load", placeWhenSettled);
+        } else {
+          Array.prototype.forEach.call(settlingImages, function (img) {
+            var oneDown = function () {
+              if (--settlingLeft === 0) placeWhenSettled();
+            };
+            img.addEventListener("load", oneDown);
+            img.addEventListener("error", oneDown);
+          });
+        }
+        window.addEventListener("load", placeWhenSettled);
+        if (document.fonts && document.fonts.ready) {
+          document.fonts.ready.then(placeWhenSettled);
+        }
 
         // On paper there is no right margin - a sheet is about 794px wide,
         // whatever the window is - so the footnotes are printed the way they


### PR DESCRIPTION
## What and why

The garden's right-margin sidenotes clumped near the top of the page, out of
order, instead of sitting beside the line that cites them. On the live site,
e.g. footnote 7 landed ~5900px above its citation.

Two defects in `place()` in `baseof.html`:

1. **Thrashing read/write interleaving.** Each iteration wrote a note's `top`
   (and read its dimensions), forcing a synchronous re-layout; every later
   note was then measured against already-shifted positions, so notes
   collapsed toward the top while citations stayed put.
2. **DOM node used as an object key.** `lastTopByBlock[block]` stringified the
   element, so every `<p>` (and every `<li>`, every `<blockquote>`) became the
   same key. Notes in *separate* paragraphs were wrongly treated as sharing a
   margin column and pushed below each other — the fix keying by identity
   resolved the remaining fn:3 displacement.

## The fix

- `place()` now does a read-only measurement pass over every note, then a
  write-only pass applying the measured tops — no read/write interleaving.
- Overlap tracking keys blocks by node identity via a `Map`.
- Added `placeWhenSettled()`, which re-measures on image settle, `window.load`
  and `font.ready` so notes track citations that grow after first paint.

## Verification

- Confirmed on the live preview that all 13 sidenotes sit exactly on their
  citations.
- **New VM behaviour check** (`checks/digital-garden.nix`): runs the page's own
  Javascript in a wide viewport headless Chromium and asserts each sidenote
  lands exactly on its citation. The fixture is built from two footnotes in
  separate adjacent paragraphs with a deliberately tall first note — the exact
  geometry the object-key bug broke.
- I confirmed the check is a genuine regression guard: with the buggy object-key
  code it fails (`sidenotes not beside their citations [('2', 367, 615)]`), and
  with the fix it passes.

`nix build .#checks.x86_64-linux.digital-garden` passes.
