### PR TITLE
fix(garden): keep sidenotes from overlapping across paragraphs

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -726,9 +726,16 @@
             "cp /var/lib/digital-garden/public/main.*.css /tmp/sn/"
         )
 
-        # The probe sits between the notes' first placement and any later
-        # re-placement, waiting in a requestAnimationFrame loop until every
-        # .sidenote has an inline top, then measuring once.
+        # The probe waits in a requestAnimationFrame loop until the document
+        # is complete AND every .sidenote carries an inline top, then measures
+        # once -- so it reads the notes after the re-placement that images,
+        # fonts and window load trigger, not the first pass.
+        #
+        # The virtual-time budget below has to cover the SLOWEST runner this
+        # ever executes on. At 8000 it passed on a workstation in 9s of wall
+        # clock and expired on a CI runner that took 17s, dumping a DOM with no
+        # marker in it -- which the assertion could only report as "the probe
+        # never ran".
         machine.succeed(
             "cat > /tmp/sn/probe.js <<'PROBE'\n"
             'var marker = document.createElement("div");\n'
@@ -745,12 +752,27 @@
             '  marker.textContent = "@@" + parts.join("|") + "@@";\n'
             "  document.body.appendChild(marker);\n"
             "}\n"
+            "var tries = 0;\n"
             "function maybeMeasure() {\n"
+            "  tries++;\n"
             '  var notes = document.querySelectorAll(".sidenote");\n'
             '  var placed = notes.length > 0 && Array.prototype.every.call(notes, function (n) { return n.style.top !== ""; });\n'
-            "  if (placed) measure(); else requestAnimationFrame(maybeMeasure);\n"
+            '  var settled = document.readyState === "complete";\n'
+            "  if (placed && settled) { measure(); return; }\n"
+            "  // Give up loudly rather than by producing nothing: a probe that\n"
+            "  // never appends its marker is indistinguishable from one that\n"
+            "  // never parsed, and says nothing about which.\n"
+            "  if (tries > 600) {\n"
+            '    marker.textContent = "@@GAVEUP placed=" + placed + " settled=" + settled + " notes=" + notes.length + "@@";\n'
+            "    document.body.appendChild(marker);\n"
+            "    return;\n"
+            "  }\n"
+            "  requestAnimationFrame(maybeMeasure);\n"
             "}\n"
-            'window.addEventListener("load", function () { requestAnimationFrame(maybeMeasure); });\n'
+            "// Polling starts here rather than from the load event: the page can\n"
+            "// already be complete by the time this script parses, and a load\n"
+            "// listener added after the event has fired never runs at all.\n"
+            "maybeMeasure();\n"
             "PROBE"
         )
 
@@ -771,12 +793,15 @@
         dom = machine.succeed(
             "chromium --headless=new --no-sandbox --disable-gpu "
             "--disable-dev-shm-usage --allow-file-access-from-files "
-            "--virtual-time-budget=8000 --window-size=1600,1200 "
+            "--virtual-time-budget=30000 --window-size=1600,1200 "
             "--dump-dom file:///tmp/sn/page.html 2>/dev/null"
         )
 
         m = re.search(r'id="SN-MEAS">@@(.*?)@@', dom, re.S)
         assert m, "the sidenote probe never ran"
+        assert not m.group(1).startswith("GAVEUP"), (
+            f"the sidenote probe timed out waiting for placement: {m.group(1)}"
+        )
         parts = m.group(1).split("|")
         cites = {}
         notes = {}

--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -132,15 +132,22 @@
         NOTE
 
         # A note that exercises the sidenote (_right-margin footnote_)
-        # positioning, with the geometry that used to put the notes out of
-        # order. Two footnotes live in DIFFERENT paragraphs that sit right on
-        # top of each other, and the first note is deliberately long so its
-        # margin note is tall. The placement loop keys its "don't overlap"
-        # bookkeeping by block; when it used a DOM node as an object key, every
-        # element stringified to the same value and these two independent
-        # paragraphs were wrongly coupled, pushing the second note below the
-        # tall first one instead of beside its own citation. The check on the
-        # served page asserts each note sits exactly beside its citation.
+        # positioning, built to pin BOTH ways it has been got wrong.
+        #
+        # The first two footnotes live in DIFFERENT paragraphs that sit right
+        # on top of each other, and the first note is deliberately long so its
+        # margin note is tall enough to reach past the second citation. They
+        # share one margin column, so the second note MUST be pushed down to
+        # clear the first: scoping the overlap bookkeeping per block let it
+        # land on top of the first instead, because two citations a few lines
+        # apart have notes that are not.
+        #
+        # The third footnote is cited far below both, with nothing above it to
+        # clear, so it MUST sit exactly beside its own citation. That is the
+        # other failure: keying the bookkeeping by a DOM node as an object key
+        # stringified every element to the same value, coupled every paragraph
+        # on the page into one bucket, and dragged notes like this one far from
+        # the text that cites them.
         cat > $out/essays/on-sidenotes.md <<'NOTE'
         ---
         publish: true
@@ -167,6 +174,36 @@
         note.[^2]
 
         [^2]: A second note in its own, separate paragraph.
+
+        ## Far below
+
+        This paragraph exists to put distance between the crowded pair above
+        and the free note below, so that the last citation has nothing above it
+        to clear and must therefore land exactly beside its own line.
+
+        Another paragraph of filler, for the same reason: the margin column has
+        to be empty here for the assertion below it to mean anything.
+
+        More filler still. The point of the distance is that a note placed here
+        is constrained by nothing except the position of its own citation.
+
+        The distance has to be real rather than nominal: the second note's
+        bottom, plus the gap a pushed note must clear it by, has to fall well
+        above the third citation, or the third note is still being pushed and
+        the assertion below it proves nothing.
+
+        So there are several paragraphs here rather than one. They say nothing
+        in particular; their only job is to be tall enough that the margin
+        beside the last citation is genuinely empty.
+
+        A fourth paragraph of the same, for the same reason.
+
+        A fifth, and that is enough: the margin above the next citation is now
+        clear by a wide margin at any window this test runs at.
+
+        The final paragraph cites a note with clear margin above it.[^3]
+
+        [^3]: A third note, far enough down the page that nothing crowds it.
         NOTE
 
         # A real landing page, because it is the one note whose handling is
@@ -702,7 +739,8 @@
             '    parts.push("c" + a.getAttribute("href").replace("#", "") + "=" + Math.round(a.getBoundingClientRect().top));\n'
             "  });\n"
             '  document.querySelectorAll(".sidenote").forEach(function (s) {\n'
-            '    parts.push("n" + s.id + "=" + Math.round(s.getBoundingClientRect().top));\n'
+            "    var r = s.getBoundingClientRect();\n"
+            '    parts.push("n" + s.id + "=" + Math.round(r.top) + "," + Math.round(r.height));\n'
             "  });\n"
             '  marker.textContent = "@@" + parts.join("|") + "@@";\n'
             "  document.body.appendChild(marker);\n"
@@ -744,22 +782,70 @@
         notes = {}
         for part in parts:
             key, _, value = part.rpartition("=")
+            # Strip only the c/n tag, so the keys stay the footnote ids Hugo
+            # gave them ("fn:2") and the assertions below name what they mean.
             if key.startswith("cfn:"):
-                cites[key[4:]] = int(value)
+                cites[key[1:]] = int(value)
             elif key.startswith("nfn:"):
-                notes[key[4:]] = int(value)
+                top, _, height = value.partition(",")
+                notes[key[1:]] = (int(top), int(height))
         assert cites, f"no sidenote citations measured: {parts}"
-        assert len(cites) <= len(notes), (
-            f"some citations got no sidenote: {sorted(cites)} vs {sorted(notes)}"
-        )
-        displaced = [
-            (fid, cite_top, notes.get(fid))
-            for fid, cite_top in cites.items()
-            if notes.get(fid) is None or abs(notes[fid] - cite_top) > 3
+        missing = sorted(set(cites) - set(notes))
+        assert not missing, f"some citations got no sidenote: {missing}"
+
+        # Down the page in citation order, which is the order the notes were
+        # built in and the order the placement pass walks them.
+        order = sorted(cites, key=lambda fid: cites[fid])
+
+        # Nothing may sit above its own citation: a note is either beside the
+        # line that cites it or below that line, never floating up the page.
+        above = [
+            (fid, cites[fid], notes[fid][0])
+            for fid in order
+            if notes[fid][0] < cites[fid] - 3
         ]
-        assert not displaced, (
-            f"sidenotes not beside their citations {displaced} "
-            f"(cites={sorted(cites)}, notes={sorted(notes)})"
+        assert not above, f"sidenotes above their citations (fid, cite, note): {above}"
+
+        # Nothing may overlap the note before it: they share one margin column.
+        overlaps = []
+        previous = None
+        for fid in order:
+            top, height = notes[fid]
+            if previous is not None and top < previous[1]:
+                overlaps.append((previous[0], fid, previous[1] - top))
+            previous = (fid, top + height)
+        assert not overlaps, (
+            f"sidenotes overlapping in the margin (above, below, px): {overlaps}"
+        )
+
+        # And a note is moved only as far as clearing the one above it needs.
+        # Without this, "push everything to the bottom" would satisfy the two
+        # assertions above, and so would the object-key bug that coupled every
+        # paragraph on the page into a single bucket.
+        slack = []
+        previous_bottom = None
+        for fid in order:
+            top, height = notes[fid]
+            floor = cites[fid] if previous_bottom is None else max(cites[fid], previous_bottom)
+            if top > floor + 16:
+                slack.append((fid, top, floor))
+            previous_bottom = top + height
+        assert not slack, (
+            f"sidenotes pushed further than clearing required (fid, top, floor): {slack}"
+        )
+
+        # Finally, the specific geometry on-sidenotes.md was built for: the
+        # tall first note reaches past the second citation, so fn:2 must have
+        # been pushed clear of it, while fn:3 -- far below, with an empty
+        # margin above it -- must be exactly beside its own line. One of these
+        # fails under each of the two bugs this has had.
+        assert notes["fn:2"][0] > cites["fn:2"] + 3, (
+            "fn:2 was not pushed clear of the tall note above it: "
+            f"note={notes['fn:2']} cite={cites['fn:2']}"
+        )
+        assert abs(notes["fn:3"][0] - cites["fn:3"]) <= 3, (
+            "fn:3 has an empty margin above it and must sit on its citation: "
+            f"note={notes['fn:3']} cite={cites['fn:3']}"
         )
   '';
 }

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -298,24 +298,24 @@
       Wide. The layout is a three-column grid: 1fr minmax(0, 40rem) 1fr. The
       prose is the centred second column and never moves. The rail occupies
       the first (left) column. The sidenotes fill the third (right) column,
-      each absolutely positioned at the top of the paragraph that cites it --
-      the Tufte margin note. Placing them in the third column means a page
-      with no rail still gets its margin notes: the rail is beside the prose
-      on the left, the notes beside it on the right, and neither needs the
-      other to exist. That is why they are not gated on the rail.
+      each absolutely positioned beside the line that cites it -- the Tufte
+      margin note. Placing them in the third column means a page with no rail
+      still gets its margin notes: the rail is beside the prose on the left,
+      the notes beside it on the right, and neither needs the other to exist.
+      That is why they are not gated on the rail.
 
       Narrow. No margin to put a note in, so the margin is torn down and the
       original endnote list is restored to the foot of the essay, where Hugo
       put it -- the same place the backlinks sit at the foot of the page.
 
       Positioning a wide note needs the vertical offset of its citation inside
-      the grid, so each note is anchored to the line that cites it, within the
-      ancestor of that citation that is a direct child of the article (a
-      paragraph, an li, a blockquote). Two notes from the same block must not
-      overlap, so when a second note would land on top of the first it is
-      pushed just below the previous note's bottom. The notes are inserted into
-      .layout rather than the article, so pagefind -- which indexes the article
-      marked data-pagefind-body -- does not index the note text.
+      the grid, so each note is anchored to the line that cites it. No two
+      notes may overlap, and they all share one margin column running the
+      length of the page, so a note whose citation falls behind the bottom of
+      the note above it is pushed down to clear it -- whatever paragraphs the
+      two citations happen to live in. The notes are inserted into .layout
+      rather than the article, so pagefind -- which indexes the article marked
+      data-pagefind-body -- does not index the note text.
 
       A note can be cited more than once (the same source can come up in many
       paragraphs). One note is built per definition, anchored to its FIRST
@@ -354,15 +354,12 @@
         var mql = window.matchMedia("(min-width: 80rem)");
         var notes = [];
 
-        // The topmost ancestor of a citation that is a direct child of the
-        // article -- the box whose top the margin note aligns to.
-        function anchorBlock(ref) {
-          var node = ref;
-          while (node && node.parentNode && node.parentNode !== article) {
-            node = node.parentNode;
-          }
-          return node && node.parentNode === article ? node : null;
-        }
+        // What a pushed-apart note must clear the one above it by. A single
+        // pixel ends the overlap arithmetically and still reads as one block
+        // of text, because each note carries a left border that joins into an
+        // unbroken rule when they touch. This is the gap between two notes
+        // that had to be separated, not the gap between every note.
+        var noteGap = 12;
 
         // Place the notes once the margin is laid out. A note sits beside the
         // line that cites it rather than at the top of the block that holds
@@ -379,26 +376,29 @@
         // stay where they are. Measure every note first, in a read-only pass,
         // and only then apply the measured tops.
         //
-        // Two notes from the same block share one margin column and must not
-        // overlap, so each block remembers the bottom of the most recently
-        // placed note and pushes a later one just below it. The block must be
-        // tracked by identity, not as an object key: every element stringifies
-        // to "[object HTMLElement]", so an object map would collapse all
-        // paragraphs (and all list items, all blockquotes) into one bucket and
-        // wrongly couple notes that live in different blocks.
+        // Notes must not overlap, and the thing they can overlap in is the
+        // margin column -- which is ONE column for the whole page, not one per
+        // paragraph. So the running bottom is page-wide: each note is placed
+        // at its citation, or just below the previous note when its citation
+        // sits too close behind a tall one. Scoping this per block (by node
+        // identity, in a Map) looks tidier and is wrong: two citations in
+        // adjacent paragraphs are a few lines apart, their notes are not, and
+        // nothing then stopped the second from landing on top of the first.
+        //
+        // `notes` is in first-citation order, because Hugo emits its
+        // definitions in that order and `showSidenotes` walks them as it found
+        // them, so a single pass down the page is enough.
         function place() {
           var layoutTop = layout.getBoundingClientRect().top;
-          var lastTopByBlock = new Map();
+          var previousBottom = null;
           var positions = [];
           notes.forEach(function (note) {
-            var block = note.block;
             var desired = note.ref.getBoundingClientRect().top - layoutTop;
-            var previous = lastTopByBlock.get(block);
             var top =
-              previous === undefined
+              previousBottom === null
                 ? desired
-                : Math.max(desired, previous + 1);
-            lastTopByBlock.set(block, top + note.aside.offsetHeight);
+                : Math.max(desired, previousBottom + noteGap);
+            previousBottom = top + note.aside.offsetHeight;
             positions.push({ aside: note.aside, top: top });
           });
           positions.forEach(function (position) {
@@ -421,8 +421,6 @@
           ids.forEach(function (id) {
             var ref = article.querySelector('.footnote-ref[href="#' + id + '"]');
             if (!ref) return;
-            var block = anchorBlock(ref);
-            if (!block) return;
             // First citation wins: a repeated citation must not place a second
             // copy of the same note.
             if (placed[id]) return;
@@ -452,7 +450,7 @@
             while (clone.firstChild) aside.appendChild(clone.firstChild);
 
             layout.appendChild(aside);
-            notes.push({ aside: aside, block: block, ref: ref });
+            notes.push({ aside: aside, ref: ref });
           });
 
           // Nothing to place (no citations on the page): keep the endnotes.


### PR DESCRIPTION
Follow-up to #82. Sidenotes cited from adjacent paragraphs could still land on top of each other.

## The bug

`place()` kept its "don't overlap" running bottom in a `Map` keyed by the block holding the citation. Two notes cited from *different* blocks each started their own bucket, so nothing ever compared them — but they all sit in one absolutely-positioned margin column that runs the length of the page. Overlap is a property of that column, not of a paragraph.

Measured on `/riverview-lighting-upgrade-writeup/` at a 1600px viewport, after fonts and images settle:

| note | top | height | bottom | citation | delta |
| --- | --- | --- | --- | --- | --- |
| `fn:2` | 3258 | 63 | 3321 | 3258 | 0 |
| `fn:3` | 3303 | 44 | 3347 | 3303 | 0 |

Both land exactly on their citations — which is what #82 asked for — and `fn:3` covers `fn:2` by 18px. The Phase 2 and Phase 3 citations are consecutive paragraphs 45px apart; the first of the two notes is 63px tall.

This is the object-key bug one scope out. That bug stringified every element to `"[object HTMLElement]"` and so compared every note against every other — page-wide by accident, which is exactly why it never produced an overlap. Scoping per block was a correction past the right answer rather than to it.

## The fix

One page-wide running bottom, in `baseof.html`:

```js
var top = previousBottom === null ? desired
        : Math.max(desired, previousBottom + noteGap);
previousBottom = top + note.aside.offsetHeight;
```

`notes` is already in first-citation order, so a single pass down the page is enough. `noteGap` is 12px rather than the previous single pixel, because each note carries a `border-left` that joins into one unbroken rule when two of them touch — a 1px separation ends the overlap arithmetically and still reads as one block of text.

`anchorBlock` and the `block` field go with it. Placement is no longer block-relative, and that guard could never fire anyway: the citation always comes from `article.querySelector`, so it is always inside the article.

After:

```
fn:2  top 3258  cite 3258    0
fn:3  top 3333  cite 3303  +30  pushed down to clear fn:2
fn:4  top 3389  cite 3374  +15  pushed down to clear fn:3
```

Every note not blocked by one above it still lands exactly on its citation. No overlaps anywhere on the page.

## The check asserted the bug

The behaviour check added in #82 required every note to be within 3px of its citation — which forbids the displacement resolving an overlap requires — and never measured overlap at all. Its fixture was deliberately built so the tall first note reaches past the second citation, and then asserted that was correct.

It now pins the invariant from both sides, since the two failures are opposite scope errors:

- nothing overlaps the note above it;
- nothing floats above its own citation;
- a note moves **only** as far as clearing requires — this is the one that fails on the object-key bug, which "push everything to the bottom" would otherwise satisfy;
- `fn:2` must be pushed clear of the tall note above it, and `fn:3`, far below with an empty margin, must sit exactly on its citation.

The probe now reports note heights so overlap is computable, and the fixture gains a third note far enough down the page that its margin is genuinely empty. (My first attempt at that put it only 6px inside the gap, so it was still being pushed and proved nothing.)

## Verification

`nix build .#checks.x86_64-linux.digital-garden` passes. Reverting `place()` to per-block scoping fails it with `sidenotes overlapping in the margin (above, below, px): [('fn:1', 'fn:2', 247)]`, so the check catches the bug it is named for. Also confirmed by rendering the real page and screenshotting the affected region.
