### PR TITLE
fix(garden): place sidenotes without waiting for a frame

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -731,11 +731,18 @@
         # once -- so it reads the notes after the re-placement that images,
         # fonts and window load trigger, not the first pass.
         #
-        # The virtual-time budget below has to cover the SLOWEST runner this
-        # ever executes on. At 8000 it passed on a workstation in 9s of wall
-        # clock and expired on a CI runner that took 17s, dumping a DOM with no
-        # marker in it -- which the assertion could only report as "the probe
-        # never ran".
+        # Neither the probe nor the page it measures may depend on a frame
+        # being produced. Under --virtual-time-budget chromium advances the
+        # clock for pending timers, but rAF callbacks need frames, and in this
+        # VM they sometimes never arrive: the same tree passed on a branch and
+        # failed on master with "the probe never ran", because the poll loop
+        # stalled before its first tick and the DOM was dumped with no marker
+        # in it. The loop below polls on setTimeout for that reason, and the
+        # placement it measures now runs straight away rather than from a rAF.
+        #
+        # The budget still has to cover the slowest runner rather than the
+        # fastest -- 8000 passed here in 9s of wall clock and expired on a CI
+        # runner that took 17.
         machine.succeed(
             "cat > /tmp/sn/probe.js <<'PROBE'\n"
             'var marker = document.createElement("div");\n'
@@ -758,17 +765,27 @@
             '  var notes = document.querySelectorAll(".sidenote");\n'
             '  var placed = notes.length > 0 && Array.prototype.every.call(notes, function (n) { return n.style.top !== ""; });\n'
             '  var settled = document.readyState === "complete";\n'
-            "  if (placed && settled) { measure(); return; }\n"
+            "  // One more beat after both are true, so the measurement is the\n"
+            "  // one that survives the re-placement fonts and window load\n"
+            "  // trigger, not an earlier pass that is about to be rewritten.\n"
+            "  if (placed && settled) { setTimeout(measure, 500); return; }\n"
             "  // Give up loudly rather than by producing nothing: a probe that\n"
             "  // never appends its marker is indistinguishable from one that\n"
             "  // never parsed, and says nothing about which.\n"
-            "  if (tries > 600) {\n"
+            "  if (tries > 200) {\n"
             '    marker.textContent = "@@GAVEUP placed=" + placed + " settled=" + settled + " notes=" + notes.length + "@@";\n'
             "    document.body.appendChild(marker);\n"
             "    return;\n"
             "  }\n"
-            "  requestAnimationFrame(maybeMeasure);\n"
+            "  setTimeout(maybeMeasure, 50);\n"
             "}\n"
+            "// setTimeout, not requestAnimationFrame. Under --virtual-time-budget\n"
+            "// the clock is advanced for pending timers, but frames are only\n"
+            "// produced if something drives them, and in this VM rAF sometimes\n"
+            "// never fires at all -- which stalled this loop before its first\n"
+            "// tick and dumped a DOM with no marker in it. That is also why the\n"
+            "// page itself no longer waits on a frame to place its notes.\n"
+            "//\n"
             "// Polling starts here rather than from the load event: the page can\n"
             "// already be complete by the time this script parses, and a load\n"
             "// listener added after the event has fired never runs at all.\n"

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -406,6 +406,22 @@
           });
         }
 
+        // Place now, and again on the next frame once the grid has resolved.
+        //
+        // The second call is the accurate one: rAF lets the grid settle, and
+        // the offsetHeight read inside place() forces the layout it measures.
+        // The FIRST call is what stops the margin depending on a frame ever
+        // being produced. requestAnimationFrame does not fire in a background
+        // tab, so a reader who opens the essay in one -- middle-click, "open
+        // in new tab", a restored session -- would otherwise meet a column of
+        // notes still stacked where they were built, and see them snap into
+        // place only when they finally looked at the page. Placing straight
+        // away costs one extra layout and removes that.
+        function placeNowAndNextFrame() {
+          place();
+          requestAnimationFrame(place);
+        }
+
         // The wide state: build a margin note per definition, remove the
         // endnote list (the two would be the same words twice, and two
         // elements with one id is broken HTML), and position the notes.
@@ -462,9 +478,7 @@
           // The medium is the margin now, so drop the foot-of-page list.
           if (list.parentNode) list.remove();
 
-          // rAF waits for the grid to resolve; forcing layout (the offsetHeight
-          // read inside place) makes the measurement accurate on first run.
-          requestAnimationFrame(place);
+          placeNowAndNextFrame();
         }
 
         // The narrow state: the margin is gone, so the notes are removed and
@@ -489,7 +503,7 @@
 
         // While wide, a resize can move every citation's line, so re-measure.
         window.addEventListener("resize", function () {
-          if (mql.matches && notes.length) requestAnimationFrame(place);
+          if (mql.matches && notes.length) placeNowAndNextFrame();
         });
 
         // The margin is measured against the laid-out article, but images and
@@ -501,7 +515,7 @@
         // else that grew), and when the fonts are ready. Each pass only
         // rewrites the notes' `top`, so re-running it is idempotent.
         function placeWhenSettled() {
-          requestAnimationFrame(place);
+          placeNowAndNextFrame();
         }
         var settlingImages = article.querySelectorAll("img");
         var settlingLeft = settlingImages.length;


### PR DESCRIPTION
`deploy` is stuck at `fcec285` because the post-merge `flake check` on master failed, so `promote to deploy` never ran. The failure is a flake, not a regression from #83 — the same tree passed on the branch and failed on master minutes later.

## Why it failed

`AssertionError: the sidenote probe never ran`, at `--virtual-time-budget=30000` with chromium running 16.5s. Note what is *absent*: no `GAVEUP` marker, which the probe emits after 600 polls. The poll loop never advanced past its first tick.

Every route to `place()` went through `requestAnimationFrame` — `showSidenotes`, the resize handler, and `placeWhenSettled` — and so did the probe's own loop. Under `--virtual-time-budget` chromium advances the clock for pending timers, but a rAF callback needs a *frame* to be produced, and in this VM frames sometimes never arrive. So nothing placed the notes, the probe stalled waiting for tops that would never be written, and the DOM was dumped with no marker in it. Raising the budget could not have helped: no amount of time produces a frame that nothing is driving.

## The evidence

Rendering the lighting writeup with `window.requestAnimationFrame` stubbed to never call back:

| | notes built | carrying an inline `top` |
| --- | --- | --- |
| before | 13 | **0** |
| after | 13 | **13**, none overlapping |

The "before" column is precisely the state the probe sat waiting on.

## The fix

`place()` runs directly, then again from a rAF:

```js
function placeNowAndNextFrame() {
  place();
  requestAnimationFrame(place);
}
```

The second call stays the accurate one — rAF lets the grid resolve before the `offsetHeight` read measures it — but the margin no longer depends on a frame existing.

This is worth having outside the test. **rAF does not fire in a background tab**, so a reader opening the essay in one — middle-click, "open in new tab", a restored session — met a column of notes still stacked where they were built, snapping into position only once they looked at the page. Placing straight away costs one extra layout and removes that.

The probe polls on `setTimeout` for the same reason, waits one beat past `readyState` so it measures what survives the font/load re-placement, and caps its loop with a `GAVEUP` marker naming what it was still waiting for — a probe that emits nothing cannot be told apart from one that never parsed, which is why the original failure said so little.

## Verification

`nix build .#checks.x86_64-linux.digital-garden` passes locally, and the rAF-stubbed measurement above is the direct evidence that the dependency is gone rather than merely less likely to bite.
