### PR TITLE
fix(boot-counting): stop a redundant re-bless from failing applies with status 4

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -120,6 +120,99 @@ in
         mkdir $out
       '';
 
+  # Boot counting wraps systemd-bless-boot in a guard so that a redundant
+  # mid-session re-bless - a nixpkgs bump restarts the packaged unit, and the
+  # boot decision was already made - cannot leave the unit failed and turn
+  # every switch into an exit-4 apply failure. The whole decision is a
+  # case-statement over bless-boot's output, so the risk is a branch
+  # misclassified: a benign re-bless going red, or a real ESP error swallowed.
+  # Neither shows up in a build, and both would take a failing night to
+  # notice, so this pins the mapping the way the VM checks pin services.
+  #
+  # It is a unit test rather than a VM for the same reason the benign failure
+  # is rare: bless-boot produces it only under EFI against a consumed boot
+  # counter, which the QEMU harness does not model. What is testable is the
+  # string -> exit-code function itself, so the script under test is taken
+  # from the module's own evaluated ExecStart (never a copy) with only the
+  # bless-boot binary swapped for a stand-in emitting each branch. The
+  # stand-in fails with distinct exit codes so the "propagate everything not
+  # recognised" fall-through is asserted exactly, not just as non-zero.
+  bless-boot-guard =
+    let
+      eval = inputs.nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          ../modules/nixos/boot-counting.nix
+          {
+            boot.loader.systemd-boot.enable = true;
+            boot.loader.efi.canTouchEfiVariables = true;
+            cg.boot-counting.enable = true;
+          }
+        ];
+      };
+      execStart = builtins.filter (
+        s: s != ""
+      ) eval.config.systemd.services."systemd-bless-boot".serviceConfig.ExecStart;
+      guardScript = builtins.elemAt execStart 0;
+
+      # Messages and exit codes follow the real tool's paths in
+      # <systemd>/src/bless-boot/bless-boot.c: a successful or already
+      # performed blessing (0), and failures that are either the three benign
+      # "nothing left to bless" states (exit 1) or genuine ESP/rename errors
+      # (distinct codes, so propagation is asserted exact).
+      fakeBlessBoot = pkgs.writeShellScript "fake-systemd-bless-boot" ''
+        case "$CASE" in
+          blessed)          echo "Marked boot as 'good'. (Boot attempt counter is at 1.)" ; exit 0 ;;
+          already-blessed)  echo "Operation already executed before, not doing anything." ; exit 0 ;;
+          no-counting)      echo "Not booted with boot counting in effect." >&2 ; exit 1 ;;
+          stale-counter)    echo "Path read from LoaderBootCountPath does not contain a counter, refusing: /loader/entries/nixos+0.conf" >&2 ; exit 1 ;;
+          pruned)           echo "Can't find boot counter source file for '/loader/entries/nixos-b6320f7.conf'." >&2 ; exit 1 ;;
+          esp-missing)      echo "Couldn't find $BOOT partition. It is recommended to mount it to /boot." >&2 ; exit 3 ;;
+          esp-open)         echo "Failed to open $BOOT partition '/boot': No such file or directory" >&2 ; exit 5 ;;
+          rename-fail)      echo "Failed to rename '/loader/entries/x+3-1.conf' to '/loader/entries/x.conf': Input/output error" >&2 ; exit 7 ;;
+          *)                echo "unexpected CASE=$CASE" >&2 ; exit 9 ;;
+        esac
+      '';
+    in
+    pkgs.runCommand "check-bless-boot-guard"
+      { guard = builtins.toString guardScript; }
+      ''
+        mkdir -p fakebin
+        ln -s ${fakeBlessBoot} fakebin/systemd-bless-boot
+
+        # Swap only the binary the guard invokes; everything else in the unit
+        # is shipped verbatim.
+        sed 's|^bless=".*"$|bless="'"$PWD"'/fakebin/systemd-bless-boot"|' "$guard" > guard
+        chmod +x guard
+
+        assert_rc() {
+          name=$1
+          want=$2
+          export CASE="$name"
+          set +e
+          got=$(./guard 2>&1)
+          rc=$?
+          set -e
+          if [ "$rc" -ne "$want" ]; then
+            echo "FAIL: bless-boot-guard: $name exited $rc, expected $want" >&2
+            printf '%s\n' "$got" >&2
+            exit 1
+          fi
+          echo "ok: $name -> $rc"
+        }
+
+        assert_rc blessed 0
+        assert_rc already-blessed 0
+        assert_rc no-counting 0
+        assert_rc stale-counter 0
+        assert_rc pruned 0
+        assert_rc esp-missing 3
+        assert_rc esp-open 5
+        assert_rc rename-fail 7
+
+        touch $out
+      '';
+
   digital-garden = testLib.mkTest ./digital-garden.nix;
   digital-garden-sync-health = import ./digital-garden-sync-health.nix {
     inherit pkgs;

--- a/modules/nixos/boot-counting.nix
+++ b/modules/nixos/boot-counting.nix
@@ -11,9 +11,14 @@
 #      `nixos-<hash>+<tries>.conf` on the ESP.
 #   2. systemd-boot decrements that counter before handing off to the kernel,
 #      renaming the file to `+<left>-<done>`.
-#   3. `systemd-bless-boot-generator` sees the counter in the EFI variables and
-#      pulls `systemd-bless-boot.service` into the boot, which strips the
-#      counter once `boot-complete.target` is reached.
+#   3. `systemd-bless-boot-generator` pulls `systemd-bless-boot.service` into
+#      the boot whenever the counter EFI variable is present; the service then
+#      strips the counter once `boot-complete.target` is reached. On a legacy,
+#      uncounted boot there is no variable, so the generator emits nothing and
+#      the unit never runs. (Its concern in this module is the switch-restart
+#      path below, not the boot path: a nixpkgs bump rewrites the packaged unit
+#      and switch-to-configuration restarts it mid-session, when blessing has
+#      already happened.)
 #   4. An entry that reaches zero tries is sorted last, and systemd-boot's
 #      `default nixos-*` glob then resolves to the newest entry that is not
 #      bad. Both this and the `preferred` directive that pairs with it need
@@ -27,15 +32,64 @@
 # only catches a kernel or initrd that cannot come up at all, which is the
 # failure that otherwise needs someone standing in front of the machine.
 #
+# A nixpkgs bump rewrites every packaged systemd unit, so on each such
+# `switch` the systemd-bless-boot ExecStart path changes and
+# switch-to-configuration stops and restarts the unit. Re-running `bless-boot
+# good` mid-session is almost always a no-op: the boot decision was already
+# made at boot-complete, so the counter file was already consumed (renamed to
+# the plain entry) or pruned, and the re-run fails with "Can't find boot
+# counter source file for ...". That failure leaves the unit failed, and the
+# switch's final scan flags any failed unit, turning a healthy activation into
+# an exit-4 apply failure. The ExecStart below tolerates exactly those
+# benign redundant re-blesses while genuine ESP/rename errors still fail the
+# unit. The failure strings this guards against are systemd's stable,
+# user-facing messages; if upstream rephrases one, the guard loses sensitivity
+# and the apply failure returns - visibly, in the same journal that first
+# exposed this.
+#
 # Only meaningful with `boot.loader.systemd-boot`; the assertion below says so
 # rather than letting the setting be silently inert.
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 let
   cfg = config.cg.boot-counting;
+
+  # `good` exits 0 when the entry was counted and just got blessed, and also
+  # when it was *already* blessed and the target exists ("Operation already
+  # executed before"). It fails only when (a) the current boot had no counter
+  # to bless, (b) the counter variable is stale or malformed, (c) the
+  # counter file and its plain target are both gone - the entry was blessed
+  # and then pruned, exactly what a `switch` mid-session sees - or (d) there
+  # is a real ESP/rename/read problem. (a)-(c) mean the boot outcome was
+  # already decided and there is nothing to say; (d) must keep failing.
+  blessBootGuard = pkgs.writeShellScript "systemd-bless-boot-guard" ''
+    bless="${pkgs.systemd}/lib/systemd/systemd-bless-boot"
+
+    set +e
+    out="$("$bless" good 2>&1)"
+    ret=$?
+    set -e
+
+    if [ "$ret" -eq 0 ]; then
+      exit 0
+    fi
+
+    # Never hide the reason: it is already on stderr from bless-boot itself;
+    # echo it so the journal makes the outcome attributable.
+    printf '%s\n' "$out" >&2
+    case "$out" in
+      *"Not booted with boot counting in effect."* | *"does not contain a counter"* | *"Can't find boot counter source file for"*)
+        exit 0
+        ;;
+      *)
+        exit "$ret"
+        ;;
+    esac
+  '';
 in
 {
   options.cg.boot-counting = {
@@ -67,6 +121,13 @@ in
     boot.loader.systemd-boot.bootCounting = {
       enable = true;
       inherit (cfg) tries;
+    };
+
+    systemd.services."systemd-bless-boot" = {
+      serviceConfig.ExecStart = [
+        ""
+        "${blessBootGuard}"
+      ];
     };
   };
 }


### PR DESCRIPTION
## What & why

`nixos-upgrade-apply` on xps15 started exiting with status 4. Diagnosis: a
nixpkgs bump (systemd 261.1 → 261.2) rewrites the packaged
`systemd-bless-boot.service`, so `switch-to-configuration.pl` stops and
restarts the unit. With `cg.boot-counting.enable` the boot decision was
already made at `boot-complete.target`: the counter was consumed and the entry
pruned, so the re-run of `bless-boot good` fails with

```
Can't find boot counter source file for '/loader/entries/nixos-<hash>+2-1.conf'.
```

The unit is left `failed`, and the switch's final scan flags *any* failed
unit, so a healthy activation reports exit 4.

## The fix

`modules/nixos/boot-counting.nix` overrides the unit's `ExecStart` with a
guard that runs the shipped binary and returns 0 for exactly the benign
"nothing left to bless" messages (not booted with boot counting / stale or
malformed counter / counter file pruned). Genuine ESP open, read, or rename
failures still propagate their exit code, so a real problem cannot be
swallowed. The next switch after this fix re-runs the unit; the benign code
exits 0 and clears the stale `failed` state, so applies return to 0 without
operator intervention.

The override lands as a drop-in (`asDropinIfExists`), so the packaged unit's
`Requires=boot-complete.target`, `OnFailure`, and `Type=oneshot` semantics are
preserved; `ExecStart=` is list-appended, hence the empty reset line emitted
first. The wrapper is deliberately *not* `RefuseManualStop`, so the failed
state self-heals on the next activation.

## Tests

New `bless-boot-guard` check in `checks/default.nix` (part of `nix flake
check`): it evaluates the module in a minimal machine, takes the guard from
its own evaluated `ExecStart`, swaps only the bless-boot binary for a stand-in
emitting each branch, and asserts:

- `blessed`, `already-blessed`, no-counting, stale-counter, pruned → **0**
- ESP missing → 3, ESP open → 5, rename failure → 7 (propagated exactly)
- unrecognised output → backing exit code propagated, never swallowed

It is a unit test rather than a VM because the benign path exists only under
EFI with a consumed counter, which the QEMU harness does not model (documented
in the check). Residual risk: the tolerated strings are systemd's stable
user-facing messages; an upstream rephrasing would de-sensitise the guard and
the apply failure would return — visibly, in the journal that surfaced it.

## Files

- `modules/nixos/boot-counting.nix`
- `checks/default.nix`

Verified: `nix build .#checks.x86_64-linux.bless-boot-guard` (all 8
assertions), `nix build --dry-run .#nixosConfigurations.{xps15,homelab01,homelab02}.config.system.build.toplevel`.