### PR TITLE
style(garden): show sun/moon icon in system theme instead of monitor

### DIFF
--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -175,23 +175,11 @@ footer {
   outline-offset: 2px;
 }
 
-/* The glyph is the state, not the action: whichever of the three the page is
- * currently in. The system glyph is hidden by default and the two theme
- * glyphs are hidden when it is showing, so the rules stay in the order the
- * script sets the attributes in. */
+/* The glyph is the opposite of the current state: moon when dark, sun when
+ * light — whether the reader picked a theme or is following the OS. */
 :root[data-theme="dark"] .icon-sun,
-:root[data-theme="light"] .icon-moon,
-.icon-system {
+:root[data-theme="light"] .icon-moon {
   display: none;
-}
-
-:root[data-theme-source="system"] .icon-sun,
-:root[data-theme-source="system"] .icon-moon {
-  display: none;
-}
-
-:root[data-theme-source="system"] .icon-system {
-  display: block;
 }
 
 /* ── prose ──────────────────────────────────────────────────────────────── */

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/icon-theme.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/icon-theme.html
@@ -1,8 +1,8 @@
 {{/*
-  Three glyphs ship and CSS shows one. The sun and the moon are the theme the
-  reader chose; the third is the state where they have chosen nothing and the
-  page is following the operating system, which is where everyone starts and
-  which a two-glyph control has no way to say.
+  Two glyphs ship and CSS shows one. The visible icon is always the opposite
+  of the current state — moon when dark (click to go light), sun when light
+  (click to go dark) — whether the reader picked a theme or is following the
+  operating system.
 */}}
 <svg class="icon-sun" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
   <circle cx="12" cy="12" r="4.5" />
@@ -10,8 +10,4 @@
 </svg>
 <svg class="icon-moon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" aria-hidden="true">
   <path d="M20 14.5A8.5 8.5 0 0 1 9.5 4a8.5 8.5 0 1 0 10.5 10.5Z" />
-</svg>
-<svg class="icon-system" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-  <rect x="2.5" y="4" width="19" height="13" rx="2" />
-  <path d="M9 21h6M12 17v4" />
 </svg>


### PR DESCRIPTION
## What

When the digital garden is following the system theme, the toggle previously showed a monitor (screen) icon to signal that no explicit choice had been made. This replaces that third glyph so the toggle instead reflects the actual current state:

- **moon** visible in dark theme (and system-dark), meaning "click to go light"
- **sun** visible in light theme (and system-light), meaning "click to go dark"

## Files changed

- `modules/services/digital-garden/lib/hugo/layouts/_partials/icon-theme.html` — removed the `.icon-system` monitor SVG; two glyphs now ship.
- `modules/services/digital-garden/lib/hugo/assets/main.css` — removed the `data-theme-source="system"` icon rules; the sun/moon visibility is now driven by `data-theme` alone.

## Verification

- Reviewed locally via the garden preview; system theme remains the default, toggle behavior unchanged, live OS-theme switching still works.
- No checks run: cosmetic CSS/template-only change; does not touch service behavior, parsing, or the deployment gate.