### PR TITLE
style(garden): centre the wide layout's margin columns

### DIFF
--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -56,6 +56,15 @@
     system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji";
   --measure: 40rem;
+  /* The margin columns either side of the prose: the rail on the left, the
+   * sidenotes on the right. One value for both, because they are the same
+   * margin seen from two sides, and a reader notices at once when the two
+   * halves of a symmetric page are not symmetric. */
+  --margin-col: 15rem;
+  /* Between a margin column and the prose. Wide enough that the margin reads
+   * as a column of its own, narrow enough that a note still reads as
+   * belonging to the paragraph beside it. */
+  --gutter: 3rem;
   color-scheme: light;
 }
 
@@ -652,19 +661,35 @@ h4:hover > .heading-anchor,
   color: var(--muted);
 }
 
-/* Wide enough for a rail that is a full 15rem AND leaves the prose centred:
- * the two outer tracks are equal, so the article sits exactly where it does at
- * every narrower width and the rail fills space that was empty. Below this the
- * whole block above applies unchanged and nothing has moved. */
+/* Wide enough for a rail that is a full margin column AND leaves the prose
+ * centred: the two outer tracks are equal, so the article sits exactly where
+ * it does at every narrower width and the rail fills space that was empty.
+ * Below this the whole block above applies unchanged and nothing has moved.
+ *
+ * The grid is capped at the width it needs and no wider. Letting the outer
+ * tracks absorb the surplus is correct at the breakpoint and then gets worse
+ * with every pixel of monitor after it: `1fr` spends the whole surplus on the
+ * margins, so at 2560px the rail sits against the left bezel and a footnote
+ * against the right one, with some 40rem of empty page — a second measure's
+ * worth — between a sentence and the note that annotates it. That is not a
+ * margin note any more. The point
+ * of moving a footnote into the margin is that the eye can hold the prose and
+ * the note at once; past a certain distance the reader is making the same
+ * journey they would have made to the foot of the page, without even the
+ * page's own edge to help them. So the cap freezes the layout at the
+ * proportions it has at the breakpoint, and `margin-inline: auto` — already on
+ * .layout from the rule above — centres the whole assembly from there on.
+ * Past 80rem the page stops growing and starts centring. */
 @media (min-width: 80rem) {
   .layout {
-    max-width: none;
+    /* The prose, both margins, and both gutters. Nothing else. */
+    max-width: calc(var(--measure) + 2 * (var(--margin-col) + var(--gutter)));
     display: grid;
     /* minmax(0, …) on the centre track rather than a bare value: a wide table
      * or a long code line inside the article would otherwise widen the track
      * past the measure and push the rail off the page. */
     grid-template-columns: 1fr minmax(0, var(--measure)) 1fr;
-    column-gap: 3rem;
+    column-gap: var(--gutter);
     align-items: start;
   }
 
@@ -685,7 +710,7 @@ h4:hover > .heading-anchor,
     /* Aligned to the top of the prose, not stretched down the page: `start`
      * on the grid keeps it the height of its own content, which is what
      * sticky needs. */
-    width: min(15rem, 100%);
+    width: min(var(--margin-col), 100%);
     position: sticky;
     top: 2rem;
     /* A rail longer than the window scrolls inside itself. A nested scrollbar
@@ -774,9 +799,11 @@ h4:hover > .heading-anchor,
     display: block;
     position: absolute;
     right: 0;
-    /* The margin is at least this wide at every width the grid builds at
-     * (>80rem), so the note never collides with the prose. */
-    width: min(14rem, 100%);
+    /* The full margin column — the same one the rail fills on the other
+     * side. With the grid capped, that column is exactly this wide at every
+     * width the wide layout builds at, so the note fills its track and the
+     * two margins are mirror images rather than two nearly-equal numbers. */
+    width: min(var(--margin-col), 100%);
     border-left: 1px solid var(--border);
     padding-left: 1rem;
     font-size: 0.8rem;

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -690,7 +690,23 @@ h4:hover > .heading-anchor,
      * past the measure and push the rail off the page. */
     grid-template-columns: 1fr minmax(0, var(--measure)) 1fr;
     column-gap: var(--gutter);
-    align-items: start;
+    /* Baseline, not `start`. Both size the columns to their own content -
+     * which is what the sticky rail needs - but `start` aligns the two
+     * BOXES, and the top of a box is not where a reader sees a line begin.
+     * The rail's label is 0.8rem and the title is 1.75rem, so aligning their
+     * tops left the label stranded in the leading above the title's
+     * letterforms: too low to read as part of the masthead, too high to read
+     * as part of the title, and belonging to neither.
+     *
+     * Baseline alignment sets those two first lines on one line instead, and
+     * the browser derives the offset from the fonts' own metrics rather than
+     * from a number measured off a screenshot - so it survives a change to
+     * either size, to the font stack, and to a title long enough to wrap,
+     * since it is the FIRST baseline that aligns and the rail still starts at
+     * the top. The alternative was a measured `margin-top` dropping the rail
+     * to the first line of prose, which looks a shade better and is correct
+     * only for as long as every title fits on one line. */
+    align-items: baseline;
   }
 
   .layout > article {

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -295,14 +295,17 @@
       There are two states, toggled whenever the viewport crosses the 80rem
       breakpoint:
 
-      Wide. The layout is a three-column grid: 1fr minmax(0, 40rem) 1fr. The
-      prose is the centred second column and never moves. The rail occupies
-      the first (left) column. The sidenotes fill the third (right) column,
-      each absolutely positioned beside the line that cites it -- the Tufte
-      margin note. Placing them in the third column means a page with no rail
-      still gets its margin notes: the rail is beside the prose on the left,
-      the notes beside it on the right, and neither needs the other to exist.
-      That is why they are not gated on the rail.
+      Wide. The layout is a three-column grid: 1fr minmax(0, 40rem) 1fr,
+      capped at the width those three tracks need and centred in the window,
+      so that the margins stay beside the prose instead of drifting out to the
+      bezels of a large monitor. The prose is the centred second column and
+      never moves. The rail occupies the first (left) column. The sidenotes
+      fill the third (right) column, each absolutely positioned beside the
+      line that cites it -- the Tufte margin note. Placing them in the third
+      column means a page with no rail still gets its margin notes: the rail
+      is beside the prose on the left, the notes beside it on the right, and
+      neither needs the other to exist. That is why they are not gated on the
+      rail.
 
       Narrow. No margin to put a note in, so the margin is torn down and the
       original endnote list is restored to the foot of the essay, where Hugo

--- a/modules/services/digital-garden/lib/hugo/layouts/home.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/home.html
@@ -4,8 +4,10 @@
     publish-filter.py has already annotated each bare link with the target's
     thesis, so what is authored is what should be shown.
   */}}
-  {{/* .layout carries the measure cap; it is a grid only where there is a
-       rail to put in it, and the landing page has none. */}}
+  {{/* Same wrapper as a note, with nothing in the margins to put there. The
+       wide grid builds either way and the article is always its centre
+       column, so the landing page's prose lands exactly where every note's
+       prose lands - which is the point of using the same wrapper. */}}
   <div class="layout">
     <article data-pagefind-body>
       <h1>{{ .Title }}</h1>


### PR DESCRIPTION
The rail and the sidenotes both sat against the bezels of a large monitor rather than beside the prose they annotate. Two commits, both confined to the wide (≥80rem) layout.

## Cap the wide grid

`.layout` is `1fr minmax(0, --measure) 1fr` with `max-width: none`, so the outer tracks absorbed every pixel of window past the breakpoint. The prose stayed centred, but the surplus went entirely to the margins: at 2560px each outer track is about 55rem, leaving some 40rem of empty page between a sentence and the footnote annotating it.

That distance defeats the point of a margin note — it only earns its place over an endnote because the eye can hold the prose and the note at once. The rail has the same problem from the other side.

The fix caps `.layout` at the width the three tracks need and lets the `margin-inline: auto` it already carries centre the assembly. The cap resolves to exactly the geometry the layout already had at the breakpoint, so nothing moves as it is crossed — past 80rem the page stops growing and starts centring.

This also lifts `--margin-col` and `--gutter` into `:root` (replacing four hardcoded numbers) and widens the sidenote from `14rem` to the shared `--margin-col`, so the two margins are mirror images rather than two nearly-equal values.

## Sit the rail's heading on the title's baseline

`align-items: start` aligned the two columns by their boxes. With a 0.8rem label beside a 1.75rem title, that left the label about 14px above the title's baseline — too low to belong to the masthead, too high to belong to the title.

`align-items: baseline` puts the two first lines on one line, with the offset derived from the fonts' own metrics rather than a number measured off a screenshot, so it holds through a change to either size, to the font stack, or to a title long enough to wrap.

`start` was there so the rail stays the height of its own content, which its sticky positioning needs. Baseline alignment does not stretch either — confirmed by rendering the long note with a temporary outline on `.rail` and checking the box still ends after the backlinks.

The alternative — a measured `margin-top` dropping the rail to the first line of prose — looks marginally better and is correct only while every title fits on one line. It is recorded in the comment and not taken.

## Verification

- `garden-preview --fixture` plus headless screenshots at 1100, 1280, 1300 and 2560px, on both fixture notes and the landing page. The narrow layout is unchanged, and nothing overflows at the breakpoint.
- `nix build .#checks.x86_64-linux.digital-garden` passes.

## Notes

- No new check. Both changes are CSS-only geometry with no observable service behaviour to assert on; the existing VM check still covers the sidenote markup and the `@media` gate. The verification here was visual, which is what `docs/plans/digital-garden-design.md` calls for.
- On a note with a rail but no footnotes, the right margin is empty, so the visual mass sits left of centre while the prose stays centred. Centring within the occupied columns instead would move the prose between pages and break the invariant that the masthead, prose and footer agree — so the asymmetry is deliberate.