### PR TITLE
fix(garden): the table that scrolled the page, and three smaller gaps

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -468,6 +468,16 @@
         assert ".table-container" in css, \
             ".table-container missing from the stylesheet"
 
+    with subtest("the page declares a tab icon"):
+        # Without one the browser asks for /favicon.ico on every visit and gets
+        # a 404 for it. Fingerprinted like the stylesheet, so it is read off the
+        # page and then fetched rather than guessed - a <link> pointing at an
+        # asset the renderer did not copy would look right in the HTML and 404
+        # for every reader, which is exactly how it first failed.
+        icon = re.search(r'<link rel="icon"[^>]*href="([^"]+)"', served("/"))
+        assert icon, "no icon linked from the home page"
+        machine.succeed(f"curl -sf -o /dev/null http://localhost:8086{icon.group(1)}")
+
     with subtest("search costs a reading page nothing until it is asked for"):
         # The bundle is ~46KB gzipped that a reader who never searches never
         # needs, so the page carries its URLs and fetches it on first use. The

--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -93,6 +93,10 @@
         # %% MARKER-IN-CODE %% - inside a fence, %% is code, not a comment
         x = 1
         ```
+
+        | Column | MARKER-TABLE-CELL |
+        | ------ | ----------------- |
+        | a      | b                 |
         NOTE
 
         # Named as Obsidian names things - spaces and capitals - because a
@@ -444,6 +448,25 @@
         # network, so nothing else would notice.
         assert "fonts.googleapis.com" not in css and "fonts.gstatic.com" not in css, \
             "the stylesheet fetches a font from a CDN"
+
+    with subtest("a table is wrapped in something that can scroll"):
+        # The other shape of the same failure the font assertion guards: a rule
+        # that is written and never reached. `.table-container { overflow-x:
+        # auto }` sat in the stylesheet for weeks with no hook to emit the div,
+        # so it matched nothing, and a table wider than the measure scrolled
+        # the PAGE - at 390px the document went to about twice the width of the
+        # phone, and every paragraph on it could be dragged sideways. Nothing
+        # failed: the build was clean, the CSS was there, the table rendered.
+        #
+        # So both halves are asserted, because either one alone is the bug: the
+        # selector exists in the stylesheet, AND the markup an actual table
+        # produces contains it.
+        page = served("/on-gates")
+        assert "MARKER-TABLE-CELL" in page, "the fixture table did not render"
+        assert re.search(r'<div class="table-container"[^>]*>\s*<table', page), \
+            "a table is not wrapped in .table-container"
+        assert ".table-container" in css, \
+            ".table-container missing from the stylesheet"
 
     with subtest("search costs a reading page nothing until it is asked for"):
         # The bundle is ~46KB gzipped that a reader who never searches never

--- a/docs/plans/digital-garden-design.md
+++ b/docs/plans/digital-garden-design.md
@@ -1,6 +1,6 @@
 # Plan: theme and navigation for the digital garden
 
-Status: proposed 2026-08-27; decisions taken the same day, see _Decisions_ below. Items 1, 2 and 4 were the agreed first pass; 5, 6 and 10 followed on the same day. Item 3 is the only one left that fixes something broken today. Two ideas asked for — a Kanagawa palette and a right-hand navigation column — plus seven more that came out of looking at what the site actually serves today. Everything below is scoped against `modules/services/digital-garden/lib/hugo/`, which is the whole design: four layouts, six partials, three render hooks and a 488-line stylesheet. There is no theme underneath to fight, so every item here is an edit to files this repository owns.
+Status: proposed 2026-08-27; decisions taken the same day, see _Decisions_ below. Items 1, 2 and 4 were the agreed first pass; 5, 6 and 10 followed on the same day. Item 11 came out of a review on 2026-08-28 and is done. Item 3 is the only one left that fixes something broken today. Two ideas asked for — a Kanagawa palette and a right-hand navigation column — plus seven more that came out of looking at what the site actually serves today. Everything below is scoped against `modules/services/digital-garden/lib/hugo/`, which is the whole design: four layouts, six partials, three render hooks and a 488-line stylesheet. There is no theme underneath to fight, so every item here is an edit to files this repository owns.
 
 | #   | Item                                | Size   | Depends on | Status      |
 | --- | ----------------------------------- | ------ | ---------- | ----------- |
@@ -14,6 +14,8 @@ Status: proposed 2026-08-27; decisions taken the same day, see _Decisions_ below
 | 8   | Footnotes as sidenotes              | large  | 4          | optional    |
 | 9   | Reading time in the dateline        | small  | -          | optional    |
 | 10  | Polish: print, selection, motion    | small  | 2          | **done** 2026-08-27 |
+| 11  | Rendering gaps found by review      | small  | 1          | **done** 2026-08-28 |
+| 12  | The dateline in the empty margin    | small  | 4          | not started |
 | -   | Graph view                          | -      | -          | **rejected**, see below |
 
 ## Decisions, 2026-08-27
@@ -258,6 +260,8 @@ Two hours to build and ten minutes to remove. The risk taken was page weight and
 
 Quartz's most-copied feature: hovering an internal link shows the target's opening. There is a cheap version here that nothing else has, because `publish-filter.py` already resolves the whole link graph and already knows every note's thesis. It can emit `data-thesis` on internal links at build time, and roughly thirty lines of CSS plus a small script turn that into a popover. No fetch, no second copy of the content, nothing at runtime that is not already in the HTML. A `title` attribute is the version with no JavaScript at all, if it turns out that is enough.
 
+Revised 2026-08-28: do the `title` version _first_ and treat the popover as a separate decision taken against it. The filter already resolves the graph and already knows every thesis, so the attribute is a few lines in `publish-filter.py` and nothing else — no CSS, no script, no new failure mode, and it works on a phone where a hover does not exist. If it turns out to be enough, the medium-sized half of this item never gets built; if it is not, the popover is built against something real rather than against a guess about what a reader wants from a link.
+
 ## 8. Footnotes as sidenotes (optional, depends on 4)
 
 Once the grid from item 4 exists, footnotes can be moved into the right margin beside the paragraph that cites them, Tufte-style, instead of collected at the bottom. The Lighting notes are heavily footnoted and this suits them. It is genuinely large: Hugo emits footnotes as a list at the end of the document, so they have to be relocated, and the vertical positioning of a sidenote against its reference is the part that never quite works. It also conflicts with item 4's rail — both want the right margin — so it would need a rule about which wins on a page that has both. Worth wanting, not worth doing before the rest of the list.
@@ -294,6 +298,86 @@ Verified by driving headless Chrome over the DevTools protocol — click the but
 
 Two hours, most of it in the printing. No risk taken: every rule here is inside a media query or behind an attribute the page already sets.
 
+## 11. Rendering gaps found by review, 2026-08-28
+
+### The problem
+
+Four things found by rendering the fixture and measuring it, none of which is visible from reading the stylesheet, and none of which the gate could fail on. They are grouped as one item because they share that property, not because they share a cause.
+
+**A wide table scrolled the page.** `.table-container { overflow-x: auto }` had been in the stylesheet since the single-column layout landed, and there was no render hook to emit the div, so the rule matched nothing. The container was never there. A table therefore had no box to scroll inside and did the only other thing available to it: at 390px the reference tables took the document to about twice the width of the phone, so every paragraph on the note could be dragged sideways and had to be dragged back. `width: 100%` on the table was the same bug seen from the other end — it guaranteed the table could never exceed the container, so `overflow-x` never had anything to scroll, and it guaranteed a table too wide for the measure was squeezed into it anyway. That is how a column of one-sentence theses came to be set one word per line at 1600px. The fixture has said _"a table wide enough to scroll inside its own container"_ since it was written, and it never did.
+
+**Wave's `--muted` was below the contrast floor for body text.** fujiGray `#727169` against sumiInk3 is 3.33:1, under the 4.5:1 that body text needs, and 2.88:1 where it lands on `--surface`. That would be defensible if `--muted` were decoration. It is not: it carries blockquote text, every sidenote at 0.8rem, the dateline, the backlink theses, the footer and every rail link that is not the current section. fujiGray is Kanagawa's _comment_ colour, and it was doing duty as reading text. Lotus needed nothing — lotusGray2 is 4.70:1.
+
+**No tab icon and no `theme-color`.** The site declared neither, so every visit asked for `/favicon.ico` and got a 404, the tab showed the browser's blank-page glyph, and on a phone a sumiInk3 page sat under a white address bar.
+
+**Task lists carried two markers.** An Obsidian `- [ ]` item rendered with a bullet _and_ a checkbox, a few pixels apart and aligned to neither the text nor each other. The fixture had said the stylesheet did not style these since the day it was written.
+
+### Approach
+
+Four commits, each independently revertible.
+
+A `_markup/render-table.html` hook, which is the missing half of a rule that was already written, plus `width: max-content; min-width: 100%` on the table so a wide one can be as wide as it needs and a narrow one still fills the measure. The container is a tab stop: Firefox makes an overflow box focusable on its own and Chrome does not, so without it a keyboard reader could reach every other part of the page and not the right-hand columns — a worse regression than the page-scrolling it replaces, since the page at least scrolled. Hugo already emits `tabindex="0"` on a `<pre>` for exactly this reason, which is the best evidence the decision is right. `role="region"` with a name is the usual companion and is not taken: the name would have to be invented, since these tables have no captions, and _"region: table"_ announced before every one of them is noise bought with nothing.
+
+`--muted` in Wave becomes springViolet1 `#938AA9`, 5.02:1. It is Wave's own, so the property this palette was built on holds: every hex is still traceable to the `colors.lua` that rides flake.lock, and none of it was picked off a screenshot.
+
+An `assets/icon.svg` seedling, drawn as three filled shapes rather than as strokes, because at the 16px a tab actually renders a hairline disappears and a filled leaf does not. It carries its own `prefers-color-scheme` rule, so it is lotusPink against a light tab strip and sakuraPink against a dark one. `theme-color` is a single tag driven by the theme script rather than the obvious pair of tags with media attributes: a media pair follows the operating system, and this site's theme is a toggle a reader can move off the system, so the only thing that knows the answer is the script that already decides `data-theme`.
+
+`li:has(> input[type="checkbox"])` for the task lists, which selects the item by what it contains and avoids a render hook whose only job would be to add a class. Scoped to the item rather than the list, so a list mixing tasks with plain items keeps its bullets on the plain ones.
+
+### What it cost that the plan did not price in
+
+One renderer change, and it is worth more than the icon that forced it. `lib/hugo.nix` copied only the stylesheet into the site's assets directory and not the theme's own assets, so any _second_ asset was invisible to `resources.Get`. Here that failed loudly, as a nil fingerprint at build time. The same shape in a template that guarded the lookup would have been a `<link>` to a file the renderer never copied: right in the HTML, 404 for every reader, and nothing to notice it. It now copies the directory and overlays the argument, which keeps `garden-preview`'s working-tree stylesheet working and needs no further change for the next asset.
+
+Two traps worth recording for the next person, both of which cost a rebuild to find. A new file under `layouts/` is invisible to the flake until it is `git add`-ed — the same trap `_partials/social.html` documents, met again from the other direction, and the symptom is a hook that silently does not run rather than an error. And XML forbids a double hyphen inside a comment, which is awkward in a repository whose colours are all named after CSS custom properties; the icon's comment says so, because writing `--brand` in it produces a file the browser renders as a broken image.
+
+### The regression guard
+
+Both of the new assertions are in `checks/digital-garden.nix`, and they are there because this is exactly the failure the check exists for: the build was clean, the CSS was present, the table rendered, and the page was wrong. The check's fixture grows a table, and the assertion has two halves because either one alone is the bug — the selector is in the stylesheet, _and_ a real table's markup contains it. Confirmed live by renaming the class in the hook and watching the check fail with `a table is not wrapped in .table-container`. The icon assertion reads the fingerprinted URL off the page and then fetches it, for the reason above: a link to an uncopied asset looks right and 404s.
+
+This is the same line item 6 drew between its two assertions. A rule that is written and never reached is the same class of failure as a stylesheet naming a font CDN, and neither is visible in a screenshot or a green gate.
+
+### The open question, not decided
+
+Lotus's `--brand` is 4.12:1 on the masthead. At 1.1rem and weight 600 that is 17.6px semibold, just under the 18.66px where the large-text allowance of 3:1 starts, so the 4.5:1 floor applies and it misses.
+
+Three ways out, and the choice is a taste decision rather than a measurement:
+
+- **Take the title to 1.2rem.** 19.2px semibold qualifies as large text, where 4.12:1 passes comfortably. Keeps sakuraPink and lotusPink, which were chosen deliberately on 2026-08-28, and costs a slightly heavier masthead.
+- **Change the hue.** lotusRed `#c84053` is 4.47:1 and still misses; lotusViolet3 `#5d57a3` is 5.75:1 and lotusViolet4 `#624c83` is 6.70:1, both of which reverse the pink decision back toward the violet it came from.
+- **Leave it.** One word of chrome at 4.12:1, on a masthead, is the mildest instance of this problem on the site, and it is now the only one.
+
+The first is the recommendation. Nothing is blocked on it.
+
+### Deliberately not changed
+
+The Chroma comment rule keeps fujiGray at 3.67:1 against sumiInk0. That one is genuinely a comment, on code the stylesheet already sets at lower contrast on purpose — the syntax block says so in as many words — and changing it would cost more editor parity than it buys.
+
+The light-ground SVG diagram still glares on the dark page. Item 5 settled that on 2026-08-27 and the answer has not changed: the fix for a glaring diagram is to export it with a transparent ground, which fixes it for every reader and every theme, and nothing in CSS can tell a diagram from a photograph.
+
+There is still no skip link, and there should not be one. The masthead is one link and two buttons; a skip link saves nobody a keystroke.
+
+### Cost and risk
+
+Half a day, most of it in finding the table bug rather than fixing it. No risk: every rule is a stylesheet edit or a render hook, the publish boundary is untouched, and the two new assertions fail loudly if any of it is undone.
+
+## 12. The dateline in the empty margin (optional)
+
+### The problem
+
+The rail renders on six of nineteen notes. On the other thirteen, a wide screen shows a 15rem left column of nothing while the dateline sits above the prose in the measure. The layout therefore reads as _"this site has a rail when it has one"_ rather than _"this site has margins"_, and the widest, emptiest version of the page is the one a reader on a large monitor gets.
+
+### Approach
+
+Move the dateline into the left column at the wide breakpoint, on the title's baseline where the rail's heading already sits, and leave it above the prose below it. The grid, the baseline alignment and the sticky behaviour all exist already; this is a second element placed in a column that is already built, and the narrow layout is the one the site has always served.
+
+Item 9's reading time, if it is ever taken, belongs in the same place and is the reason to do these two together rather than separately.
+
+The thing to check by looking, and the reason this is not obviously right: on a page that _does_ have a rail, the dateline and the rail's first heading are then both in the left column, and two small grey blocks stacked in a margin may read as a sidebar — which is the thing the single-column layout was chosen to avoid.
+
+### Cost and risk
+
+An hour, and it is entirely reversible. The risk is the one above, and it is a judgement that can only be made against the rendered pages.
+
 ## Rejected: a graph view
 
 The canonical Quartz feature, and it should not be built here. Nineteen nodes with six edges is not a graph, it is a list with extra steps — the rendered picture would be five connected Lighting notes and thirteen dots. It needs a rendering library, which means either a build-time network fetch or vendoring a canvas library into a site that currently ships zero bytes of framework, and it works badly on the phones that most of this site's readers will use. Items 3 and 4 deliver what a reader actually wants from a graph view, which is "what else is near this", at a fraction of the cost. Revisit at a hundred notes if the link density has gone up with them.
@@ -309,3 +393,7 @@ Item 3 is out of the first pass by choice, not by dependency; it can be taken at
 Each item is its own PR, per the usual gate. Item 2 will not change the VM test's assertions — the test looks for a stylesheet, not for its contents — which is worth stating explicitly, because it means the gate is not evidence for any of this and the screenshots are.
 
 That held for items 2, 4 and 5, and stopped holding at item 6, which added two assertions: a webfont is not a colour — the file either is served from this site or it is not, and if it is not, nothing fails, every reader silently gets their own serif. When the face was reverted one of the two went with it and one stayed, which is the useful line between them. The file being served was a fact about a decision that got reversed; **the stylesheet naming no font CDN** is a fact about the property this whole toolchain exists to hold, and it holds whether or not there is ever a webfont again. The rest of the judgement is still the screenshots'.
+
+Item 11 was not sequenced at all — it came out of a review on 2026-08-28 and every part of it was a defect or a gap rather than a design decision, so it was taken immediately and in four commits rather than one PR per item. It moved the line above again, in the same direction item 6 moved it: two more assertions now guard properties the screenshots cannot, because _"the build was clean, the CSS was present, the table rendered, and the page was wrong"_ is the failure this project keeps meeting and the only one the gate can be taught to catch.
+
+Item 12 depends on item 4 and on nothing else, and is worth doing at the same time as item 9 if item 9 is ever taken, since both put a small grey line in the same place. Item 3 remains the one item that fixes something broken today: fourteen of nineteen notes are still reachable only by search or by a backlink.

--- a/modules/services/digital-garden/lib/hugo.nix
+++ b/modules/services/digital-garden/lib/hugo.nix
@@ -147,7 +147,20 @@ in
         trap 'rm -rf "$work"' EXIT
 
         cp -r ${theme}/layouts "$work/layouts"
+        # The theme's own assets, and then the stylesheet over the top of them.
+        # The stylesheet is the one asset that arrives as an argument, because
+        # garden-preview hands in the working-tree copy so that editing it
+        # re-renders with no Nix evaluation in the loop; everything else here
+        # (the tab icon) has no reason to be swappable and lives in the theme.
+        # Copying the directory first and the argument second is what keeps
+        # both true, and means the next asset needs no change to this file.
         mkdir -p "$work/assets"
+        cp -r ${theme}/assets/. "$work/assets/"
+        # Store paths copy out read-only, and the theme's assets already hold a
+        # main.css - so the overlay below is an overwrite of a file with no
+        # write bit on it. Same reason the static and content trees are chmod-ed
+        # after their copies rather than at the end.
+        chmod -R u+w "$work/assets"
         cp "$css" "$work/assets/main.css"
         cp ${config} "$work/hugo.toml"
         chmod -R u+w "$work"

--- a/modules/services/digital-garden/lib/hugo/assets/icon.svg
+++ b/modules/services/digital-garden/lib/hugo/assets/icon.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!--
+    The tab icon. A seedling, because that is what the site is, drawn as three
+    filled shapes rather than as thin strokes: at the 16px a tab actually
+    renders it, a hairline disappears and a filled leaf does not.
+
+    Coloured in the brand role, both halves of it. An SVG favicon carries its
+    own stylesheet, and prefers-color-scheme inside one is honoured, so the
+    mark follows the tab strip's own light or dark the same way the page
+    follows the reader's: lotusPink against a light chrome, sakuraPink against
+    a dark one. It cannot follow the site's theme TOGGLE, since nothing outside
+    the document can, and the OS preference is the better cue here anyway: the
+    thing this has to stay legible against is the browser, not the page.
+
+    Note for editing: XML forbids a double hyphen inside a comment, which is
+    awkward in a repository whose colours are all named after CSS custom
+    properties. Spell them out here rather than writing one.
+  -->
+  <style>
+    path { fill: #b35b79; }           /* lotusPink  */
+    @media (prefers-color-scheme: dark) {
+      path { fill: #d27e99; }         /* sakuraPink */
+    }
+  </style>
+  <path d="M14 29V16a2 2 0 0 1 4 0v13a2 2 0 0 1-4 0Z"/>
+  <path d="M16 21c-6 0-10-4.5-10-10.5 6 0 10 4.5 10 10.5Z"/>
+  <path d="M16 17c0-6.5 4.5-11 11-11 0 6.5-4.5 11-11 11Z"/>
+</svg>

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -76,7 +76,19 @@
   --code-bg: #16161d;  /* sumiInk0 — the code well goes DARKER than the page
                         * here and lighter than it in Lotus, because in both
                         * directions that is away from the reading surface. */
-  --muted: #727169;    /* fujiGray  */
+  /* springViolet1, not fujiGray. fujiGray #727169 is Kanagawa's COMMENT
+   * colour, and it reads as one against sumiInk3: 3.33:1, under the 4.5:1
+   * that body text needs, and 2.88:1 on --surface. That would be defensible
+   * if --muted were decoration, but it is not — it carries blockquote text,
+   * every sidenote (at 0.8rem, where it matters most), the dateline, the
+   * backlink theses, the footer and every rail link that is not the current
+   * one. Those are things a reader reads. springViolet1 is 5.02:1 and is
+   * Wave's own, so the "every hex is traceable to a pinned colors.lua"
+   * property is unchanged. Lotus needed nothing: lotusGray2 is 4.70:1.
+   *
+   * The one place fujiGray survives is the Chroma comment rule below, which
+   * is genuinely a comment on genuinely lower-contrast-by-design code. */
+  --muted: #938aa9;    /* springViolet1 */
   --text: #dcd7ba;     /* fujiWhite */
   /* Deliberately the same as --text. fujiWhite is the brightest foreground
    * Wave has, so a heading cannot be brighter than the prose without leaving

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -560,9 +560,26 @@ mark {
 }
 
 /* Wide content must scroll inside its own box rather than making the page
- * scroll sideways. */
+ * scroll sideways. The box is put there by _markup/render-table.html; for a
+ * while this rule was written and the hook was not, so it matched nothing and
+ * the page did the scrolling — see that file. */
 .table-container {
   overflow-x: auto;
+}
+
+/* Both of the page's scrollable boxes, showing that they have been reached.
+ * The table container is a tab stop because the hook makes it one; `pre` is
+ * one because Hugo has always emitted `tabindex="0"` on a code block, for the
+ * same reason and without being asked - which is the best evidence that the
+ * hook's decision is the right one. They were drawing two different rings, the
+ * accent one here and the browser's default there, so this names both.
+ *
+ * :focus-visible rather than :focus, so clicking a table or a code block to
+ * scroll it does not draw a ring. */
+.table-container:focus-visible,
+pre:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* The same rule, for a display-mode equation wider than the measure. */
@@ -572,9 +589,18 @@ mark {
   padding: 0.2rem 0;
 }
 
+/* Sized to its own content, with the measure as a floor rather than a ceiling.
+ * `width: 100%` was both halves of the same bug: it guaranteed the table could
+ * never overflow .table-container, so the container's `overflow-x` never had
+ * anything to scroll, and it guaranteed a table too wide for the measure would
+ * be squeezed into it instead — which is how a column of one-sentence theses
+ * came to be set one word per line. max-content lets a wide table be as wide as
+ * it needs and scroll; min-width keeps a narrow one filling the measure, which
+ * is what `width: 100%` was there for in the first place. */
 table {
   border-collapse: collapse;
-  width: 100%;
+  width: max-content;
+  min-width: 100%;
 }
 
 th,

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -294,6 +294,27 @@ footer a::after {
   content: none;
 }
 
+/* Obsidian's `- [ ]` task lists. Goldmark emits a bare <li> holding a disabled
+ * checkbox, with no class on either it or the list, so the item is selected by
+ * what it contains rather than by a hook that would have to exist only to add
+ * one. Without this an item carried a bullet AND a checkbox — two markers for
+ * one item, neither aligned to the other.
+ *
+ * Scoped to the item and not the list, so a list that mixes tasks with plain
+ * items keeps the bullets on the plain ones. */
+li:has(> input[type="checkbox"]) {
+  list-style: none;
+}
+
+/* Pulled back into the space the marker vacated, so a task list keeps the same
+ * left edge as the bulleted list above it. `accent-color` is the whole of the
+ * checkbox's styling: it is a native control, it is disabled, and the platform
+ * draws a better one than a hand-rolled box would. */
+li > input[type="checkbox"] {
+  margin: 0 0.4rem 0 -1.35rem;
+  accent-color: var(--accent);
+}
+
 blockquote {
   border-left: 3px solid var(--border);
   padding-left: 1rem;

--- a/modules/services/digital-garden/lib/hugo/fixture/Every Element.md
+++ b/modules/services/digital-garden/lib/hugo/fixture/Every Element.md
@@ -41,7 +41,7 @@ Headings wrap. The line-height they wrap at is set separately from the body's, a
 2. A second ordered item
 3. A third, so the widest marker is two characters wide
 
-- [ ] An unfinished task, which Obsidian writes and the stylesheet does not currently style
+- [ ] An unfinished task, which Obsidian writes as a checkbox and the stylesheet gives the marker column to
 - [x] A finished one
 
 ## Quotation

--- a/modules/services/digital-garden/lib/hugo/layouts/_markup/render-table.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_markup/render-table.html
@@ -1,0 +1,61 @@
+{{/*
+  A table, wrapped in the scroll container the stylesheet has always styled.
+
+  This hook exists for the wrapper and for nothing else: the cells below are
+  the markup Hugo emits without it. `.table-container { overflow-x: auto }` was
+  written when the single-column layout landed, but Hugo emits a bare <table>
+  and there was no hook to put the div around it, so the rule matched nothing
+  and a wide table had no box to scroll inside. It scrolled the PAGE instead —
+  at 390px the reference tables in the Lighting notes made the whole document
+  about twice the width of the phone, so every paragraph on the page could be
+  dragged sideways and had to be dragged back. That is the bug this fixes; the
+  desktop symptom of the same cause was a table pinned to the measure and
+  squeezing a prose column down to one word per line.
+
+  The alignment attribute is Goldmark's own (`|:---|---:|` in the markdown) and
+  is emitted as an inline style because that is where a per-cell, per-table
+  decision belongs — there is no class the stylesheet could name that would
+  know which column the author meant to right-align.
+
+  `.Attributes` carries any markdown attribute block written above the table.
+  Nothing in the vault uses one today; it is passed through so that adopting
+  this hook does not quietly drop a feature the bare renderer had.
+
+  tabindex="0" because a scrolling box has to be scrollable by keyboard.
+  Firefox makes an overflow container focusable on its own; Chrome does not, so
+  without this a reader on a keyboard could reach every other part of the page
+  and not the right-hand columns of a wide table - which would be a worse
+  regression than the page-scrolling this replaces, since the page at least
+  scrolled. The cost is one tab stop per table, and tables are rare here.
+
+  role and aria-label deliberately absent. The pattern usually pairs tabindex
+  with role="region" and a name, but the name would have to be invented - these
+  tables have no captions - and "region: table" announced before every one of
+  them is noise bought with nothing. A focusable box with no role is announced
+  as what it is, which is accurate.
+*/}}
+<div class="table-container" tabindex="0">
+  <table
+    {{- range $k, $v := .Attributes }}
+      {{- with $v }} {{ $k | safeHTMLAttr }}="{{ . }}"{{ end }}
+    {{- end }}>
+    <thead>
+      {{- range .THead }}
+        <tr>
+          {{- range . }}
+            <th{{ with .Alignment }} style="text-align: {{ . }}"{{ end }}>{{ .Text }}</th>
+          {{- end }}
+        </tr>
+      {{- end }}
+    </thead>
+    <tbody>
+      {{- range .TBody }}
+        <tr>
+          {{- range . }}
+            <td{{ with .Alignment }} style="text-align: {{ . }}"{{ end }}>{{ .Text }}</td>
+          {{- end }}
+        </tr>
+      {{- end }}
+    </tbody>
+  </table>
+</div>

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -8,6 +8,28 @@
     </title>
     {{ with partial "description.html" . }}<meta name="description" content="{{ . }}" />{{ end }}
     <link rel="canonical" href="{{ .Permalink }}" />
+    {{/*
+      Declaring an icon is also what stops the browser asking for /favicon.ico
+      on every visit and getting a 404 for it. One SVG and no raster fallback:
+      every browser that has shipped since 2020 takes an SVG icon, the file is
+      under a kilobyte, and it carries its own light/dark rule - see the
+      comment inside it. Fingerprinted like the stylesheet, so it can be cached
+      forever and still change when it changes.
+    */}}
+    {{ with resources.Get "icon.svg" | fingerprint }}
+      <link rel="icon" type="image/svg+xml" href="{{ .RelPermalink }}" />
+    {{ end }}
+    {{/*
+      The colour a mobile browser paints its own chrome - the address bar and
+      the status bar - so a dark page does not sit under a white strip. The
+      obvious spelling is a pair of these tags with prefers-color-scheme media
+      attributes, but that follows the OS, and this site's theme is a toggle
+      that a reader can move off the OS. So one tag with no media, set from the
+      same script that decides `data-theme`, which is the only thing that knows
+      the answer. The value here is the light ground, matching what :root paints
+      when no script has run.
+    */}}
+    <meta name="theme-color" id="theme-color" content="#f9f6e1" />
     {{ partial "social.html" . }}
     {{ with resources.Get "main.css" | fingerprint }}
       <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" />
@@ -40,6 +62,12 @@
 
       Anything other than the two words is read as no choice at all, which is
       also how a cleared localStorage reads.
+
+      The <meta name="theme-color"> above is set from the same decision, and
+      the two grounds are repeated here as literals rather than read back from
+      the stylesheet: getComputedStyle before first paint is exactly the work
+      this block exists to avoid, and these are the one pair of values in the
+      palette that a second file is allowed to know.
     */}}
     <script>
       (function () {
@@ -57,6 +85,14 @@
         )
           ? "dark"
           : "light";
+        window.__paintChrome = function () {
+          var meta = document.getElementById("theme-color");
+          if (meta) {
+            meta.content =
+              root.dataset.theme === "dark" ? "#1f1f28" : "#f9f6e1";
+          }
+        };
+        window.__paintChrome();
       })();
     </script>
   </head>
@@ -137,6 +173,10 @@
             if (source === "system") localStorage.removeItem("theme");
             else localStorage.setItem("theme", theme);
           } catch (e) {}
+          // The browser's own chrome follows the page, on every one of the
+          // three ways the theme can change: the button, the OS moving under a
+          // reader who is following it, and the first paint above.
+          if (window.__paintChrome) window.__paintChrome();
           label();
         }
 


### PR DESCRIPTION
Item 11 of [the design plan](docs/plans/digital-garden-design.md), which this PR also records — four gaps found by rendering the fixture and measuring it, none of which is visible from reading the stylesheet and none of which the gate could fail on.

## The one that is a defect

`.table-container { overflow-x: auto }` has been in the stylesheet since the single-column layout landed, and there was never a render hook to emit the div. **The rule matched nothing.** A table therefore had no box to scroll inside and did the only other thing available to it: at 390px the reference tables took the document to about **twice the width of the phone**, so every paragraph on the note could be dragged sideways and had to be dragged back.

`width: 100%` on the table was the same bug from the other end. It guaranteed the table could never exceed the container, so `overflow-x` never had anything to scroll — *and* it guaranteed a table too wide for the measure was squeezed into it anyway, which is how a column of one-sentence theses came to be set one word per line at 1600px.

The fixture has said *"a table wide enough to scroll inside its own container"* since the day it was written. It never did.

## What's here

- **`_markup/render-table.html`** — the missing half of a rule that was already written. `width: max-content; min-width: 100%` lets a wide table be as wide as it needs and scroll, and keeps a narrow one filling the measure.
- **The container is a tab stop.** Firefox makes an overflow box focusable on its own; Chrome does not. Without it a keyboard reader could reach every other part of the page and not the right-hand columns — a *worse* regression than the page-scrolling this replaces, since the page at least scrolled. Hugo already emits `tabindex="0"` on a `<pre>` for exactly this reason, and the two were drawing different focus rings, so the accent ring now names both.
- **Wave's `--muted` goes to springViolet1 `#938AA9`** — 5.02:1, up from fujiGray's **3.33:1**, which is under the 4.5:1 body-text floor (and 2.88:1 on `--surface`). That would be fine for decoration; `--muted` carries blockquote text, every sidenote at 0.8rem, the dateline, the backlink theses, the footer and every non-current rail link. fujiGray is Kanagawa's *comment* colour and it was doing duty as reading text. Still Wave's own, so every hex remains traceable to the `colors.lua` that rides `flake.lock`. Lotus needed nothing at 4.70:1.
- **A tab icon and a `theme-color`.** The site declared neither, so every visit asked for `/favicon.ico` and got a 404, and on a phone a sumiInk3 page sat under a white address bar. `theme-color` is a single tag driven by the theme script rather than the obvious pair of media-attribute tags — a media pair follows the OS, and this site's theme is a toggle a reader can move *off* the OS.
- **Task lists get the marker column.** An Obsidian `- [ ]` item rendered with a bullet *and* a checkbox, aligned to neither the text nor each other.

## One renderer change, worth more than the icon that forced it

`lib/hugo.nix` copied only the stylesheet into the site's assets directory, not the theme's own assets — so any *second* asset was invisible to `resources.Get`. Here that failed loudly, as a nil fingerprint at build time. The same shape in a template that guarded the lookup would have been a `<link>` to a file the renderer never copied: right in the HTML, 404 for every reader, and nothing to notice it.

## Verification

Rendered, not read — per the standing rule for this theme.

- **The 390px page-wide horizontal scrollbar is gone**, confirmed by screenshotting *without* `--hide-scrollbars` before and after. Before, the thumb covered about half the track.
- Both tables now scroll inside their own boxes; rows are one line each again at 1600px.
- Contrast ratios computed against the tokens rather than judged by eye.
- The icon rendered at 128, 32 and 16px on both grounds.
- **The new assertion was confirmed live** by renaming the class in the hook and watching the check fail with `a table is not wrapped in .table-container`, then restoring it. A guard that has never failed is not a guard.
- `nix build .#checks.x86_64-linux.digital-garden` and `.digital-garden-sync-health` pass; `nix fmt -- --ci` and `nix flake check --no-build` pass on this branch after rebasing onto the sharded-gate master.

Each fix carries its own regression guard rather than deferring them to one test commit, so a bisect lands on a commit that already knows how to fail.

## Left open, deliberately

**Lotus's `--brand` is 4.12:1** on the masthead — 17.6px semibold is just under the 18.66px where the large-text allowance of 3:1 begins, so the 4.5:1 floor applies and it misses. Not changed here, because the colour was chosen deliberately in #87 two days ago. The plan records three options; taking the title to `1.2rem` is the recommendation, since 19.2px semibold qualifies as large text and the hue survives. **Nothing is blocked on it.**

Three things measured and deliberately left alone, recorded in the plan so they read as decisions rather than oversights: Chroma's comment colour at 3.67:1 (genuinely a comment, on code the stylesheet already sets low on purpose); the light-ground diagram on the dark page (item 5 settled this — export with a transparent ground, since nothing in CSS can tell a diagram from a photograph); and the absence of a skip link past a masthead of one link and two buttons.

## Also in the plan

**Item 12**, new: the dateline in the left margin on the thirteen of nineteen notes that have no rail to put there — including the reason it might be wrong, which is that two grey blocks stacked in a margin may read as the sidebar this layout exists to avoid. Only the rendered page can settle that.

**Item 7**, revised: build the `title`-attribute version of wikilink previews *first* and treat the popover as a separate decision taken against it. The filter already resolves the graph and knows every thesis, so the cheap half may be the whole of it — and it works on a phone, where a hover does not exist.

Item 3 remains the only item that fixes something broken today: fourteen of nineteen notes are still reachable only by search or by a backlink.
