### PR TITLE
refactor: give the fleet one source of truth

### DIFF
--- a/checks/reverse-proxy.nix
+++ b/checks/reverse-proxy.nix
@@ -72,10 +72,23 @@
         })
       ];
 
+      # A fleet that is not this one. reverse-proxy.nix takes the domain it
+      # serves and the LAN it lets through from `config.cg.fleet`, and the
+      # option carries the real fleet as its default - so overriding it here
+      # is what keeps this test about the module rather than about
+      # gyarmathy.co, and it is why that option is not `readOnly`
+      # (modules/nixos/fleet.nix explains what that would have cost).
+      cg.fleet = {
+        domain = "example.test";
+        lan.cidr = "10.0.0.0/24";
+        hosts = { };
+        roles = { };
+      };
+
       cg.service.reverse-proxy = {
         enable = true;
         email = "test@example.invalid";
-        # Exactly how the hosts wire it (hosts/homelab01/default.nix:370), so
+        # Exactly how the hosts wire it (hosts/homelab01/default.nix:218), so
         # the test breaks if that indirection changes.
         cloudflareTokenFile = config.sops.templates."caddy-cloudflare-env".path;
 
@@ -154,25 +167,25 @@
         #
         # Without -f, so this waits on TLS alone and does not quietly double as
         # an assertion about the response.
-        for host in ["internal.gyarmathy.co", "public.gyarmathy.co"]:
+        for host in ["internal.example.test", "public.example.test"]:
             machine.wait_until_succeeds(curl(host, "-o /dev/null"), timeout=60)
 
     with subtest("a LAN-only service routes to its backend"):
-        body = get("internal.gyarmathy.co", "/some/path")
+        body = get("internal.example.test", "/some/path")
         assert body["path"] == "/some/path", body
 
     with subtest("the upstream sees the headers mkProxyHost sets"):
-        headers = get("internal.gyarmathy.co")["headers"]
+        headers = get("internal.example.test")["headers"]
         # header_up Host {host}: the backend must see the original vhost, not
         # 127.0.0.1. Getting this wrong breaks every service that builds an
         # absolute URL, which is most of them.
-        assert headers["host"] == "internal.gyarmathy.co", headers
+        assert headers["host"] == "internal.example.test", headers
         assert headers["x-forwarded-proto"] == "https", headers
         assert "x-real-ip" in headers, headers
         assert "x-forwarded-for" in headers, headers
 
     with subtest("an internet-facing service gets the security headers"):
-        response = headers_of("public.gyarmathy.co")
+        response = headers_of("public.example.test")
         for expected in [
             "x-frame-options: sameorigin",
             "x-content-type-options: nosniff",
@@ -185,10 +198,10 @@
         # Not pedantry: localOnly selects between two branches of mkProxyHost,
         # so a service silently flipping branch shows up as headers appearing
         # or disappearing rather than as anything failing outright.
-        response = headers_of("internal.gyarmathy.co")
+        response = headers_of("internal.example.test")
         assert "x-frame-options" not in response, response
 
     with subtest("an unconfigured host is not routed anywhere"):
-        machine.fail(curl("nothing-here.gyarmathy.co", "-f"))
+        machine.fail(curl("nothing-here.example.test", "-f"))
   '';
 }

--- a/docs/plans/structural-cleanup.md
+++ b/docs/plans/structural-cleanup.md
@@ -1,15 +1,15 @@
 # Plan: structural cleanup
 
-Status: drafted 2026-08-28. Item 0 landed the same day; nothing else started.
+Status: drafted 2026-08-28. Items 0 and 1 landed the same day; nothing else started.
 
-This is a refactoring plan, not a feature plan. Almost none of it changes what the fleet does; most of it changes where a fact is written down and who is allowed to read it. Two items are exceptions and are marked as such — the secrets re-key (item 4) and closing the service ports (item 5) both change behaviour on running machines.
+This is a refactoring plan, not a feature plan. Almost none of it changes what the fleet does; most of it changes where a fact is written down and who is allowed to read it. Two items are exceptions and are marked as such — the secrets re-key (item 4) and closing the service ports (item 5) both change behaviour on running machines. Item 1 is marked `minor`: it changed two lines of generated configuration, neither of which a running host can tell apart, and both are listed under what it landed.
 
 The pipeline, the checks harness and the documentation are in good shape and are not the subject here. What has not kept up is the boundary between a host and a module: hosts transcribe facts that modules already know, modules hardcode facts about specific hosts, and the same value is written down in three places with nothing to notice when the copies diverge. Every item below is an instance of that one problem.
 
 | #   | Item                              | Size   | Changes behaviour | Depends on | Status                |
 | --- | --------------------------------- | ------ | ----------------- | ---------- | --------------------- |
 | 0   | Gate hygiene and budget           | small  | no                | —          | **done** 2026-08-28   |
-| 1   | A fleet source of truth           | medium | no                | —          | not started           |
+| 1   | A fleet source of truth           | medium | minor             | —          | **done** 2026-08-28   |
 | 2   | Services publish themselves       | large  | no                | 1          | not started           |
 | 3   | Hosts become profiles + toggles   | medium | no                | 2          | not started           |
 | 4   | Per-host secret scoping           | large  | **yes**           | 1          | not started           |
@@ -142,6 +142,33 @@ No `.nix` file outside `fleet/` contains a literal fleet IP address, host name o
 ### Risks
 
 The temptation to make `fleet/` the place where everything is declared, at which point the host files are empty and the interesting content has just moved. The `Done when` above is deliberately narrow for that reason: it is about literals, not about volume.
+
+### What landed
+
+`fleet/default.nix` holds the domain, the LAN (CIDR and gateway), every host (`kind`, `system`, and an `address` for the two that have a reservation), and a two-entry `roles` map. `modules/nixos/fleet.nix` declares `cg.fleet` with that file as its default, `types.raw`, not `readOnly` — for the reasons the approach gives, both of which are written into that file rather than left here.
+
+**Three things the approach did not anticipate.**
+
+_`nixosConfigurations` is generated from `fleet.hosts`._ It had to be: the `Done when` forbids a literal host name in a `.nix` file, and `mkHost { hostname = "homelab01"; … }` is one. `mkHost` now takes a name and that host's fleet entry, and `nixpkgs.lib.mapAttrs mkHost fleet.hosts` is the whole `nixosConfigurations` output. The `extraModules` argument went with it: the nixos-hardware modules a machine needs are a property of that machine, so each `hosts/<name>/default.nix` imports its own. Adding a host is now an entry in `fleet/` and a directory beside it. The build matrix in `ci.yml` still names hosts explicitly, deliberately — a host that stops being built is exactly what the gate is for.
+
+_A module that reads the fleet imports the declaration itself._ Putting the data in the option's default gets a fleet into every module-system evaluation, but only where the option is *declared*, and the checks import single module files rather than `modules/nixos`. So the sixteen modules that read `config.cg.fleet` each carry `imports = [ ../nixos/fleet.nix ]`. Importing one path from several modules costs nothing — the module system keys on it — and it means a check instantiating one module gets the fleet with it, which is what kept `checks/lib.nix` from having to learn anything.
+
+_The override is exercised, not just left possible._ `checks/reverse-proxy.nix` now sets `cg.fleet` to a fleet that is not this one (`example.test`, a `10.0.0.0/24` LAN, no hosts) and asserts against `internal.example.test`. That is the reason the option is not `readOnly` stated as a passing test rather than as a comment, and it took the last of the domain literals out of `checks/`.
+
+**Two things fell out of the rewrite** and are behaviour changes, both small:
+
+- Root's SSH config for backups was `Host 10.20.2.*`. It is now the fleet's own addresses, one at a time. A glob offers the backup key to whatever else answers on the LAN; the addresses are ones this flake already knows.
+- The `cloudflared` scrape job is emitted only when `cloudflaredTarget` is set, which is what the option's `null to disable` always claimed — it used to emit `targets = [ null ]` and fail the type check. Its `instance` label is now taken from the target rather than hardcoded, so the peer scraping the tunnel host no longer labels the series with its own name.
+
+### Verified, 2026-08-28
+
+**Inert, not assumed.** For homelab01 and homelab02, every entry in the generated `/etc` was compared against the same host built from `43102b0` (the revision this branched from), and every systemd unit within it. One entry differs on each host: `ssh/ssh_config`, the deliberate change above. Caddy's config file, Prometheus' scrape config, AdGuard's settings, the NFS export and all four restic units are byte-identical.
+
+Five other derivations move — `system-path`, `dbus-1`, `user-units`, and the `nixos-upgrade`, `nixos-deploy-metrics`, `digital-garden-build`, `dbus-broker` and `polkit` units. Those are not this change: comparing `43102b0` against its own parent, a documentation-only commit, moves exactly the same set. They carry `system.configurationRevision`, directly or through `nixos-version` in the system path, so any commit moves them. Worth chasing down rather than waving at, because "some unrelated things also changed" is how a real difference gets missed.
+
+All ten checks pass, including the three VM tests that instantiate a module which now reads the fleet. `nix fmt -- --ci` is clean, and `devShells`, `packages` and `apps` — the three outputs the `lint` job evaluates by hand — still evaluate; `garden-preview` resolves to the same store path it did before, which is the check that the gateway lookup replacing `nixosConfigurations.homelab01` picks the same host.
+
+The `Done when` was checked by script rather than by eye. Four occurrences remain, all of them the host name inside an SSH public key's own comment field (`… coryg@xps15`). That is key material, not a transcribed fleet fact: editing it would change the key.
 
 ---
 
@@ -340,14 +367,14 @@ The in-app configuration is the part no check can cover — the same limitation 
 
 ### The problem
 
-Reusable modules carry knowledge of this specific installation, which is what makes them not reusable:
+Reusable modules carry knowledge of this specific installation, which is what makes them not reusable. Item 1 took the literals out; what it did not do is make the defaults right for a machine outside this fleet.
 
-- `modules/services/adguard-home.nix:32-33` — a literal map of host names to addresses.
-- `modules/services/adguard-home.nix:394` — `10.20.2.1` as a PTR upstream, commented "Your router".
-- `modules/services/media-stack/cross-seed.nix:198` — `prowlarrUrl` defaults to `http://10.20.2.85:9696`, i.e. the module defaults to another host in this fleet.
-- `modules/services/monitoring/monitoring.nix:330-341` — `scrapeTargets` defaults naming `homelab01` and `homelab02`.
+- `modules/services/adguard-home.nix` — the literal host-to-address map is gone, but the module now *requires* `cg.fleet.roles.gateway` and `.storage` to name real hosts, and its `gatewaySubdomains` / `storageSubdomains` lists are still this installation's service map living in a general-purpose DNS module. That is item 2's to move; what belongs here is that the module should say so rather than failing on a missing attribute.
+- `modules/services/media-stack/cross-seed.nix` — `prowlarrUrl` still defaults to the gateway host's address, i.e. the module still defaults to another machine in this fleet.
 - `modules/services/immich.nix:111` — `DB_PASSWORD=changeme-use-sops-for-real-deployment`. The service is disabled everywhere, so this is not live, but a literal password in a module is the kind of thing that survives being enabled.
 - `modules/services/digital-garden/digital-garden.nix` — adds a Caddy virtual host without enabling Caddy. Already noted in the hardening plan as "a coupling that is invisible until it bites"; it should be an assertion.
+
+Two entries the draft listed are already closed: `adguard-home`'s `10.20.2.1` PTR upstream is `cg.fleet.lan.gateway`, and `monitoring.nix`'s `scrapeTargets` and `smartctlTargets` already defaulted to `[ ]` with the fleet's names only as an `example`.
 
 ### Approach
 

--- a/flake.nix
+++ b/flake.nix
@@ -223,8 +223,12 @@
       # judged against - the vault is a poor test of a stylesheet, because it
       # contains whatever it happens to contain.
       #
-      # The renderer comes out of homelab01's own evaluated config rather than
-      # being rebuilt here, so the preview cannot drift from what is deployed.
+      # The renderer comes out of the serving host's own evaluated config
+      # rather than being rebuilt here, so the preview cannot drift from what
+      # is deployed. That host is the gateway: the garden is published to the
+      # internet, and the gateway is the machine that owns the tunnel
+      # everything public goes through. Item 2 of docs/plans/structural-
+      # cleanup.md replaces this with a lookup by publication.
       apps = forAllSystems (
         system:
         let
@@ -233,7 +237,7 @@
             overlays = builtins.attrValues self.overlays;
             config.allowUnfree = true;
           };
-          garden = self.nixosConfigurations.homelab01.config.cg.service.digital-garden;
+          garden = self.nixosConfigurations.${fleet.roles.gateway}.config.cg.service.digital-garden;
           # caddyConfig takes no settings, so importing serve.nix again for it
           # duplicates no configuration - unlike the renderer, which is read
           # out of the host's own evaluated config below.

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,6 @@
       nixpkgs-stable,
       nixpkgs-unstable-small,
       home-manager,
-      hardware,
       stylix,
       sops-nix,
       disko,
@@ -48,17 +47,30 @@
       ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
-      # Helper function to create a NixOS host configuration
+      # What this fleet is: ./fleet/default.nix. Read here as plain data
+      # because `nixosConfigurations` is generated from it, which happens
+      # before there is a module system to ask. Modules read the same data
+      # through `config.cg.fleet` - see modules/nixos/fleet.nix.
+      fleet = import ./fleet;
+
+      # Helper function to create a NixOS host configuration.
+      #
+      # Takes a host's name and its entry in `fleet.hosts`, so the set of
+      # hosts and the facts about each of them are stated once, in ./fleet,
+      # rather than restated here.
       mkHost =
-        {
-          hostname,
-          system ? "x86_64-linux",
-          extraModules ? [ ],
-        }:
+        hostname:
+        { system, ... }:
         nixpkgs.lib.nixosSystem {
           inherit system;
           specialArgs = {
             inherit inputs self;
+            # The fleet, for this flake's own leaves under ./hosts. They are
+            # never instantiated outside mkHost, so there is nothing for them
+            # to gain from going through the option. Reusable modules under
+            # ./modules do go through `config.cg.fleet`, so that a behaviour
+            # test can hand one a different fleet.
+            inherit fleet;
             # Make stable packages available as pkgs-stable
             pkgs-stable = import nixpkgs-stable {
               inherit system;
@@ -171,41 +183,14 @@
                 };
               }
             )
-          ]
-          ++ extraModules;
+          ];
         };
     in
     {
-      # NixOS configurations for each host
-      nixosConfigurations = {
-        # Desktop: Dell XPS 15 9500
-        xps15 = mkHost {
-          hostname = "xps15";
-          extraModules = [
-            hardware.nixosModules.dell-xps-15-9500-nvidia
-          ];
-        };
-
-        # Server: Dell Optiplex 5080
-        homelab01 = mkHost {
-          hostname = "homelab01";
-          extraModules = [
-            hardware.nixosModules.common-cpu-intel
-            hardware.nixosModules.common-pc
-            hardware.nixosModules.common-pc-ssd
-          ];
-        };
-
-        # Server: HP Elitedesk 800 G6 SFF
-        homelab02 = mkHost {
-          hostname = "homelab02";
-          extraModules = [
-            hardware.nixosModules.common-cpu-intel
-            hardware.nixosModules.common-pc
-            hardware.nixosModules.common-pc-ssd
-          ];
-        };
-      };
+      # One NixOS configuration per host in ./fleet. The nixos-hardware
+      # modules a given machine needs are a property of that machine, so they
+      # are imported by hosts/<name>/default.nix rather than listed here.
+      nixosConfigurations = nixpkgs.lib.mapAttrs mkHost fleet.hosts;
 
       # Overlays exported by this flake
       overlays = import ./overlays { inherit inputs; };

--- a/fleet/default.nix
+++ b/fleet/default.nix
@@ -1,0 +1,69 @@
+# What this fleet is.
+#
+# Host names, addresses, the domain and which machine owns which fleet-wide
+# duty were each written down in several files that had no way to notice when
+# they disagreed. This is the one place they are written down now; everything
+# else reads them.
+#
+# Plain data, deliberately. No `mkIf`, no options, no `config`, no `lib` - so
+# the flake can read it before the module system exists (it is what
+# `nixosConfigurations` is generated from) and a module can read it through
+# `config.cg.fleet`, which is declared with this file as its default in
+# ../modules/nixos/fleet.nix.
+#
+# WHAT BELONGS HERE. Fleet facts, not host choices. `homelab02`'s address is a
+# fleet fact: homelab01 mounts its export and cannot be configured without it.
+# That homelab02 runs qBittorrent is a host choice and belongs in
+# hosts/homelab02/. Moving the second kind in here rebuilds the monolith one
+# level up, which is the thing this file exists to undo.
+{
+  domain = "gyarmathy.co";
+
+  lan = {
+    # The trusted network. Caddy's LAN-only allowlist and gluetun's outbound
+    # firewall are both written against it.
+    cidr = "10.20.2.0/24";
+    # Router. Also the PTR resolver for the reverse zone, since it is the only
+    # thing that knows what DHCP handed out.
+    gateway = "10.20.2.1";
+  };
+
+  # Every machine this flake builds. `nixosConfigurations` is generated from
+  # this attrset, so adding a host here and a hosts/<name>/ directory is the
+  # whole change.
+  #
+  # `kind` is what the rest of the fleet may assume, not what the host runs: a
+  # `server` has a reserved address, is expected to be up, and is scraped,
+  # peered and backed up by the others. `xps15` is a laptop on DHCP and is
+  # none of those, which is why it has no address to give.
+  hosts = {
+    homelab01 = {
+      kind = "server";
+      system = "x86_64-linux";
+      address = "10.20.2.85";
+    };
+    homelab02 = {
+      kind = "server";
+      system = "x86_64-linux";
+      address = "10.20.2.130";
+    };
+    xps15 = {
+      kind = "workstation";
+      system = "x86_64-linux";
+    };
+  };
+
+  # The duties that are fleet-wide rather than host-local - the ones another
+  # host has to know the answer to before it can configure itself.
+  #
+  # This is a short list on purpose. A duty earns a name here when a *second*
+  # host needs to point at it; until then it is a host choice and stays in
+  # hosts/<name>/.
+  roles = {
+    # Owns the Cloudflare tunnel, the primary AdGuard instance, and the
+    # wildcard that every unlisted subdomain resolves to.
+    gateway = "homelab01";
+    # Owns the ZFS pool and the NFS export homelab01 mounts.
+    storage = "homelab02";
+  };
+}

--- a/hosts/homelab01/default.nix
+++ b/hosts/homelab01/default.nix
@@ -13,12 +13,35 @@
   config,
   lib,
   pkgs,
+  fleet,
   ...
 }:
+let
+  inherit (fleet) domain;
+
+  hostName = config.networking.hostName;
+
+  # The fleet's always-on machines: what gets scraped, peered and backed up.
+  # `peer` is the other one - this fleet has exactly two, and the day it has
+  # three is the day the things below that assume one peer need revisiting.
+  servers = lib.attrNames (lib.filterAttrs (_: host: host.kind == "server") fleet.hosts);
+  peers = lib.remove hostName servers;
+  peer = lib.head peers;
+
+  # Fleet-wide duties this host does not own. `gateway` is its own name, but
+  # reading it from ./fleet rather than assuming it keeps the two in step.
+  gateway = fleet.roles.gateway;
+  storage = fleet.hosts.${fleet.roles.storage};
+in
 {
   imports = [
     # Hardware configuration (generate with nixos-generate-config)
     ./hardware.nix
+
+    # Quirks for this exact machine, from nixos-hardware
+    inputs.hardware.nixosModules.common-cpu-intel
+    inputs.hardware.nixosModules.common-pc
+    inputs.hardware.nixosModules.common-pc-ssd
 
     # Server-specific service modules
     ../../modules/services
@@ -36,7 +59,7 @@
   # rollout (ADR 0002).
   system.autoUpgrade = {
     enable = true;
-    flake = "github:corygyarmathy/dotfiles/deploy#homelab01";
+    flake = "github:corygyarmathy/dotfiles/deploy#${hostName}";
     dates = "04:00";
     allowReboot = true;
     rebootWindow = {
@@ -100,8 +123,8 @@
     backup = {
       enable = true;
 
-      # homelab01 receives homelab02's cross-server backups here
-      incomingPath = "/srv/backups/homelab02";
+      # This host receives its peer's cross-server backups here
+      incomingPath = "/srv/backups/${peer}";
 
       paths = [
         # All arr service configs — backs up the whole directory so
@@ -145,14 +168,14 @@
       ];
 
       repositories = {
-        # Cross-server: back up to homelab02's ZFS pool
+        # Cross-server: back up to the peer's ZFS pool
         cross-server = {
-          repository = "sftp:coryg@10.20.2.130:/srv/backups/homelab01";
+          repository = "sftp:coryg@${fleet.hosts.${peer}.address}:/srv/backups/${hostName}";
           schedule = "02:30";
         };
         # Offsite: Google Drive via rclone
         gdrive = {
-          repository = "rclone:gdrive:backups/homelab/homelab01";
+          repository = "rclone:gdrive:backups/homelab/${hostName}";
           schedule = "03:00";
         };
       };
@@ -170,7 +193,7 @@
     digital-garden = {
       enable = true;
       port = 8086;
-      baseUrl = "garden.gyarmathy.co";
+      baseUrl = "garden.${domain}";
       siteTitle = "Cory Gyarmathy";
       footerLinks = {
         GitHub = "https://github.com/corygyarmathy";
@@ -191,7 +214,7 @@
     # -------------------------------------------------------------------------
     reverse-proxy = {
       enable = true;
-      email = "cory@gyarmathy.co";
+      email = "cory@${domain}";
       cloudflareTokenFile = config.sops.templates."caddy-cloudflare-env".path;
 
       services = {
@@ -248,7 +271,7 @@
           localOnly = true;
         };
 
-        # Infrastructure (homelab01's AdGuard)
+        # Infrastructure (this host's AdGuard)
         adguard = {
           subdomain = "adguard";
           port = 3080;
@@ -315,13 +338,14 @@
           localOnly = false; # listeners need external access for mobile apps
           rateLimitProfile = "media";
         };
-        # Runs on homelab02, where the library is on local disk rather than the
-        # NFS mount -- see the header of modules/services/media-stack/grimmory.nix.
-        # Proxied from here because homelab01 owns the Cloudflare tunnel.
+        # Runs on the storage host, where the library is on local disk rather
+        # than the NFS mount -- see the header of
+        # modules/services/media-stack/grimmory.nix. Proxied from here because
+        # this host owns the Cloudflare tunnel.
         grimmory = {
           subdomain = "grimmory";
           port = 6060;
-          upstream = "10.20.2.130"; # homelab02
+          upstream = storage.address;
           localOnly = false; # readers need external access
           rateLimitProfile = "media";
         };
@@ -333,99 +357,93 @@
       prometheus.enable = true;
       alertmanager = {
         enable = true;
-        clusterPeers = [ "homelab02" ];
+        clusterPeers = peers;
         ntfy.enable = true;
         email = {
-          to = "cory@gyarmathy.co";
-          from = "alerts@gyarmathy.co";
-          authUsername = "alerts@gyarmathy.co";
+          to = "cory@${domain}";
+          from = "alerts@${domain}";
+          authUsername = "alerts@${domain}";
           # smarthost uses the default (smtp.protonmail.ch:587)
         };
       };
 
       grafana.enable = true;
       zfs.enable = false;
-      scrapeTargets = [
-        "homelab01:9100"
-        "homelab02:9100"
-      ];
-      smartctlTargets = [
-        "homelab01:9633"
-        "homelab02:9633"
-      ];
-      cloudflaredTarget = "homelab01:20241";
+      scrapeTargets = map (host: "${host}:9100") servers;
+      smartctlTargets = map (host: "${host}:9633") servers;
+      cloudflaredTarget = "${gateway}:20241";
 
       httpProbes = [
         {
           name = "jellyfin";
-          url = "https://jellyfin.gyarmathy.co";
+          url = "https://jellyfin.${domain}";
         }
         {
           name = "requests";
-          url = "https://requests.gyarmathy.co";
+          url = "https://requests.${domain}";
         }
         {
           name = "sonarr";
-          url = "https://sonarr.gyarmathy.co";
+          url = "https://sonarr.${domain}";
         }
         {
           name = "radarr";
-          url = "https://radarr.gyarmathy.co";
+          url = "https://radarr.${domain}";
         }
         {
           name = "prowlarr";
-          url = "https://prowlarr.gyarmathy.co";
+          url = "https://prowlarr.${domain}";
         }
         {
           name = "downloads";
-          url = "https://downloads.gyarmathy.co";
+          url = "https://downloads.${domain}";
         }
         {
           name = "grafana";
-          url = "https://grafana.gyarmathy.co";
+          url = "https://grafana.${domain}";
         }
         {
           name = "adguard-01";
-          url = "https://adguard.gyarmathy.co";
+          url = "https://adguard.${domain}";
         }
         {
           name = "adguard-02";
-          url = "https://adguard2.gyarmathy.co";
+          url = "https://adguard2.${domain}";
         }
         {
           name = "autobrr";
-          url = "https://autobrr.gyarmathy.co";
+          url = "https://autobrr.${domain}";
         }
         {
           name = "miniflux";
-          url = "https://rss.gyarmathy.co";
+          url = "https://rss.${domain}";
         }
         {
           name = "wallabag";
-          url = "https://read.gyarmathy.co";
+          url = "https://read.${domain}";
         }
         {
           # /health rather than the bare root the other entries use: this is
           # the readiness endpoint cleanuparr's podman healthcheck used to hit,
           # so probing it keeps exactly the signal that healthcheck gave.
           name = "cleanuparr";
-          url = "https://cleanuparr.gyarmathy.co/health";
+          url = "https://cleanuparr.${domain}/health";
         }
         {
           name = "maintainerr";
-          url = "https://maintainerr.gyarmathy.co";
+          url = "https://maintainerr.${domain}";
         }
         {
           name = "kavita";
-          url = "https://kavita.gyarmathy.co";
+          url = "https://kavita.${domain}";
         }
         {
           name = "audiobookshelf";
-          url = "https://audiobookshelf.gyarmathy.co";
+          url = "https://audiobookshelf.${domain}";
         }
         {
           name = "garden";
-          url = "https://garden.gyarmathy.co";
+          url = "https://garden.${domain}";
         }
       ];
     };
@@ -447,7 +465,7 @@
       webPort = 3080;
       bindAddresses = [
         "127.0.0.1"
-        "10.20.2.85"
+        fleet.hosts.${hostName}.address
       ];
     };
 
@@ -463,10 +481,10 @@
       user = "coryg";
       group = "media";
 
-      # Mount from homelab02
+      # Mount from the fleet's storage host
       storage = {
         type = "nfs";
-        nfsServer = "10.20.2.130"; # homelab02
+        nfsServer = storage.address;
         nfsExportPath = "/srv/media";
         nfsMountOptions = [
           "nfsvers=4.2"
@@ -551,7 +569,6 @@
     # -------------------------------------------------------------------------
     cloudflare-tunnel = {
       enable = true;
-      domain = "gyarmathy.co";
 
       # Map reverse-proxy services to cloudflare-tunnel format
       # Only pass the fields that cloudflare-tunnel understands
@@ -616,9 +633,9 @@
   # Networking
   # ============================================================================
   networking = {
-    # IP reserved by DHCP server
+    # IP reserved by the DHCP server; the reservation itself is recorded in
+    # fleet/default.nix, and mkHost sets hostName from the same place.
     useDHCP = lib.mkForce true;
-    hostName = "homelab01";
     networkmanager.enable = true;
   };
 

--- a/hosts/homelab02/default.nix
+++ b/hosts/homelab02/default.nix
@@ -17,8 +17,24 @@
   config,
   lib,
   pkgs,
+  fleet,
   ...
 }:
+let
+  inherit (fleet) domain;
+
+  hostName = config.networking.hostName;
+
+  # The fleet's always-on machines: what gets scraped, peered and backed up.
+  # `peer` is the other one - this fleet has exactly two, and the day it has
+  # three is the day the things below that assume one peer need revisiting.
+  servers = lib.attrNames (lib.filterAttrs (_: host: host.kind == "server") fleet.hosts);
+  peers = lib.remove hostName servers;
+  peer = lib.head peers;
+
+  # The host that owns the tunnel, the primary DNS instance and the wildcard.
+  gateway = fleet.roles.gateway;
+in
 {
   imports = [
     # Declarative disk partitioning (manages OS + data disks)
@@ -26,6 +42,11 @@
 
     # Hardware configuration (generate with nixos-generate-config)
     ./hardware.nix
+
+    # Quirks for this exact machine, from nixos-hardware
+    inputs.hardware.nixosModules.common-cpu-intel
+    inputs.hardware.nixosModules.common-pc
+    inputs.hardware.nixosModules.common-pc-ssd
 
     # Server-specific service modules
     ../../modules/services
@@ -48,7 +69,7 @@
   # rebooting into a new kernel simultaneously is worth avoiding on its own.
   system.autoUpgrade = {
     enable = true;
-    flake = "github:corygyarmathy/dotfiles/deploy#homelab02";
+    flake = "github:corygyarmathy/dotfiles/deploy#${hostName}";
     dates = "04:15"; # Offset from homelab01
     allowReboot = true;
     rebootWindow = {
@@ -111,8 +132,8 @@
     backup = {
       enable = true;
 
-      # homelab02 receives homelab01's cross-server backups here
-      incomingPath = "/srv/backups/homelab01";
+      # This host receives its peer's cross-server backups here
+      incomingPath = "/srv/backups/${peer}";
 
       paths = [
         # All arr service configs
@@ -138,14 +159,14 @@
       ];
 
       repositories = {
-        # Cross-server: back up to homelab01
+        # Cross-server: back up to the peer
         cross-server = {
-          repository = "sftp:coryg@10.20.2.85:/srv/backups/homelab02";
+          repository = "sftp:coryg@${fleet.hosts.${peer}.address}:/srv/backups/${hostName}";
           schedule = "02:30";
         };
         # Offsite: Google Drive via rclone
         gdrive = {
-          repository = "rclone:gdrive:backups/homelab/homelab02";
+          repository = "rclone:gdrive:backups/homelab/${hostName}";
           schedule = "03:00";
         };
       };
@@ -159,8 +180,8 @@
       prometheus.enable = true;
       alertmanager = {
         enable = true;
-        clusterPeers = [ "homelab01" ];
-        # Push lane. The ntfy server itself lives on homelab01; this host runs
+        clusterPeers = peers;
+        # Push lane. The ntfy server itself lives on the gateway; this host runs
         # only the local alertmanager-ntfy bridge, so either host can still
         # deliver on its own if the other is down.
         #
@@ -173,78 +194,72 @@
           port = 8015;
         };
         email = {
-          to = "cory@gyarmathy.co";
-          from = "alerts@gyarmathy.co";
-          authUsername = "alerts@gyarmathy.co";
+          to = "cory@${domain}";
+          from = "alerts@${domain}";
+          authUsername = "alerts@${domain}";
           # smarthost uses the default (smtp.protonmail.ch:587)
         };
       };
       grafana.enable = false;
       zfs.enable = true;
-      scrapeTargets = [
-        "homelab01:9100"
-        "homelab02:9100"
-      ];
-      smartctlTargets = [
-        "homelab01:9633"
-        "homelab02:9633"
-      ];
-      cloudflaredTarget = "homelab01:20241";
+      scrapeTargets = map (host: "${host}:9100") servers;
+      smartctlTargets = map (host: "${host}:9633") servers;
+      cloudflaredTarget = "${gateway}:20241";
 
       vpn.enable = true;
 
       httpProbes = [
         {
           name = "jellyfin";
-          url = "https://jellyfin.gyarmathy.co";
+          url = "https://jellyfin.${domain}";
         }
         {
           name = "requests";
-          url = "https://requests.gyarmathy.co";
+          url = "https://requests.${domain}";
         }
         {
           name = "sonarr";
-          url = "https://sonarr.gyarmathy.co";
+          url = "https://sonarr.${domain}";
         }
         {
           name = "radarr";
-          url = "https://radarr.gyarmathy.co";
+          url = "https://radarr.${domain}";
         }
         {
           name = "prowlarr";
-          url = "https://prowlarr.gyarmathy.co";
+          url = "https://prowlarr.${domain}";
         }
         {
           name = "downloads";
-          url = "https://downloads.gyarmathy.co";
+          url = "https://downloads.${domain}";
         }
         {
           name = "grafana";
-          url = "https://grafana.gyarmathy.co";
+          url = "https://grafana.${domain}";
         }
         {
           name = "adguard-01";
-          url = "https://adguard.gyarmathy.co";
+          url = "https://adguard.${domain}";
         }
         {
           name = "adguard-02";
-          url = "https://adguard2.gyarmathy.co";
+          url = "https://adguard2.${domain}";
         }
         {
           name = "autobrr";
-          url = "https://autobrr.gyarmathy.co";
+          url = "https://autobrr.${domain}";
         }
         {
           name = "miniflux";
-          url = "https://rss.gyarmathy.co";
+          url = "https://rss.${domain}";
         }
         {
           name = "wallabag";
-          url = "https://read.gyarmathy.co";
+          url = "https://read.${domain}";
         }
         {
           name = "filebrowser";
-          url = "https://filebrowser.gyarmathy.co";
+          url = "https://filebrowser.${domain}";
         }
       ];
     };
@@ -274,9 +289,9 @@
       poolPath = "/srv/media";
       nfs = {
         enable = true;
-        # Only homelab01 mounts this export; scope it to that host rather than
+        # Only the peer mounts this export; scope it to that host rather than
         # the whole subnet so no other device can touch the media as root.
-        allowedNetwork = "10.20.2.85/32";
+        allowedNetwork = "${fleet.hosts.${peer}.address}/32";
         exportPath = "/srv/media";
       };
       user = "coryg";
@@ -288,7 +303,7 @@
     # -------------------------------------------------------------------------
     reverse-proxy = {
       enable = true;
-      email = "cory@gyarmathy.co";
+      email = "cory@${domain}";
       cloudflareTokenFile = config.sops.templates."caddy-cloudflare-env".path;
 
       services = {
@@ -308,7 +323,7 @@
           '';
         };
 
-        # homelab02's AdGuard instance
+        # This host's AdGuard instance
         adguard2 = {
           subdomain = "adguard2";
           port = 3080;
@@ -353,7 +368,7 @@
       webPort = 3080;
       bindAddresses = [
         "127.0.0.1"
-        "10.20.2.130"
+        fleet.hosts.${hostName}.address
       ];
     };
 
@@ -489,9 +504,9 @@
   # Networking
   # ============================================================================
   networking = {
-    # IP reserved by DHCP server
+    # IP reserved by the DHCP server; the reservation itself is recorded in
+    # fleet/default.nix, and mkHost sets hostName from the same place.
     useDHCP = lib.mkForce true;
-    hostName = "homelab02";
     networkmanager.enable = true;
   };
 

--- a/hosts/xps15/default.nix
+++ b/hosts/xps15/default.nix
@@ -12,6 +12,9 @@
     # Hardware configuration
     ./hardware.nix
 
+    # Quirks for this exact machine, from nixos-hardware
+    inputs.hardware.nixosModules.dell-xps-15-9500-nvidia
+
     # NixOS modules
     ../../modules/nixos
   ];

--- a/modules/nixos/fleet.nix
+++ b/modules/nixos/fleet.nix
@@ -1,0 +1,53 @@
+# The fleet, as an ordinary NixOS option.
+#
+# ../../fleet is the data; this is how a module reads it. A module that needs
+# the domain or another host's address reads `config.cg.fleet` like it reads
+# anything else and stays a normal NixOS module - no extra function argument,
+# no dependency on how it was instantiated.
+#
+# TWO THINGS HERE ARE LOAD-BEARING.
+#
+# The data is the option's *default*, not a definition set by `mkHost`. Those
+# look equivalent and are not: the behaviour tests in ../../checks instantiate
+# service modules directly and never go near `mkHost`, so as a definition the
+# first module to read `cg.fleet` would break every check containing it, and
+# the repair would be to teach checks/lib.nix to inject a fleet into every
+# test - a harness change caused entirely by where the value was put. As a
+# default, every evaluation of the module system gets the fleet, tests
+# included, and `mkHost` sets nothing.
+#
+# It is not `readOnly`, which is the obvious thing to reach for and silently
+# costs the property this exists for. `readOnly` counts the option's own
+# default among its definitions, so `readOnly` plus a `default` rejects *any*
+# override - "The option `cg.fleet' is read-only, but it's set multiple
+# times." - and every check would be permanently stuck with the production
+# fleet, unable to exercise a module against a different one. checks/
+# reverse-proxy.nix does exactly that. Single-sourcing is kept here by
+# convention; what the mechanism still buys is below.
+#
+# `types.raw` rather than an attrset type, so the option does not merge: two
+# modules both defining `cg.fleet` is a conflict error rather than a silent
+# union of two fleets. That is most of what `readOnly` was wanted for, at no
+# cost to the override.
+#
+# The shape is documented in ../../fleet/default.nix rather than in a
+# submodule type: the file is the schema, and a type here would be a second
+# copy of it to keep in step.
+#
+# Modules that read the fleet import this file themselves, so that a check
+# instantiating one module gets the declaration with it. Importing the same
+# path from several modules is free - the module system keys on the path.
+{ lib, ... }:
+{
+  options.cg.fleet = lib.mkOption {
+    type = lib.types.raw;
+    default = import ../../fleet;
+    defaultText = lib.literalExpression "import ./fleet";
+    description = ''
+      Facts about this fleet that more than one host has to agree on: the
+      domain, the LAN, every host's address and which host owns which
+      fleet-wide duty. See `fleet/default.nix` for the shape and for what
+      belongs in it.
+    '';
+  };
+}

--- a/modules/services/adguard-home.nix
+++ b/modules/services/adguard-home.nix
@@ -1,14 +1,14 @@
 # AdGuard Home - Local DNS Server with Ad Blocking
 #
 # Provides:
-# - Local DNS resolution for *.gyarmathy.co services
+# - Local DNS resolution for the fleet's own subdomains
 # - Ad and tracker blocking
 # - Encrypted DNS (DoH/DoT) upstream
 # - Query logging and statistics
 #
 # Architecture:
-# - Primary: homelab01 (10.20.2.85)
-# - Secondary: homelab02 (10.20.2.130) - same config, different bind address
+# - Primary: the host named by fleet.roles.gateway
+# - Secondary: another host running the same config on a different bind address
 #
 # Usage:
 #   cg.service.adguard-home = {
@@ -23,149 +23,86 @@
 }:
 let
   cfg = config.cg.service.adguard-home;
+  fleet = config.cg.fleet;
+  inherit (fleet) domain;
 
-  # Domain configuration - centralised for easy updates
-  domain = "gyarmathy.co";
+  # Where the two fleet-wide duties live. Everything below is expressed
+  # against these rather than against host names, so moving a duty to another
+  # machine is an edit to fleet/default.nix and nothing else.
+  gateway = fleet.hosts.${fleet.roles.gateway}.address;
+  storage = fleet.hosts.${fleet.roles.storage}.address;
 
-  # Server IPs - used for DNS rewrites
-  servers = {
-    homelab01 = "10.20.2.85";
-    homelab02 = "10.20.2.130";
+  # Every host that has a reserved address resolves by name. The laptop does
+  # not have one, which is why this filters rather than mapping the lot.
+  addressed = lib.filterAttrs (_: host: host ? address) fleet.hosts;
+
+  # DNS rewrites for local services.
+  #
+  # Subdomains are listed by the duty that serves them, not by host name.
+  # Add a new service to the list for whichever machine's Caddy fronts it.
+  gatewaySubdomains = [
+    "jellyfin"
+    "requests"
+    "invite"
+    "sonarr"
+    "radarr"
+    "autobrr"
+    "prowlarr"
+    "bazarr"
+    "huntarr"
+    "cleanuparr"
+    "grafana"
+    "prometheus"
+    "adguard"
+    "rss"
+    "read"
+    "kavita"
+    "audiobookshelf"
+  ];
+
+  # Services fronted by the storage host's own Caddy.
+  #
+  # These entries are load-bearing, not documentation. The wildcard at the
+  # bottom of the list sends every subdomain that is not named here to the
+  # gateway, so a service added to the storage host's reverse proxy without an
+  # entry here resolves to a machine whose Caddy has never heard of it. That
+  # fails as a TLS error rather than a 404, because Caddy has no certificate
+  # for a hostname it does not serve, which points suspicion at the
+  # certificate rather than at DNS.
+  #
+  # A service running on the storage host but proxied *by the gateway* (via
+  # the reverse proxy's `upstream` option, as grimmory is) belongs in the list
+  # above, not this one.
+  storageSubdomains = [
+    "downloads"
+    "adguard2"
+    "filebrowser"
+    "shelfmark"
+    "suwayomi"
+  ];
+
+  mkRewrite = answer: sub: {
+    domain = "${sub}.${domain}";
+    inherit answer;
   };
 
-  # The server that runs the reverse proxy (where services are accessed)
-  primaryServer = servers.homelab01;
-
-  # DNS rewrites for local services
-  # These map subdomains to the reverse proxy server
-  # Add new services here as you deploy them
-  dnsRewrites = [
+  dnsRewrites =
     # Server hostnames
-    {
-      domain = "homelab01.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "homelab02.${domain}";
-      answer = servers.homelab02;
-    }
-
-    # Services on homelab01
-    {
-      domain = "jellyfin.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "requests.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "invite.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "sonarr.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "radarr.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "autobrr.${domain}";
-      answer = servers.homelab01;
-    }
-
-    {
-      domain = "prowlarr.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "bazarr.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "huntarr.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "cleanuparr.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "grafana.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "prometheus.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "adguard.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "rss.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "read.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "kavita.${domain}";
-      answer = servers.homelab01;
-    }
-    {
-      domain = "audiobookshelf.${domain}";
-      answer = servers.homelab01;
-    }
-
-    # Services on homelab02.
-    #
-    # These entries are load-bearing, not documentation. The wildcard at the
-    # bottom of this list sends every subdomain that is not named here to
-    # homelab01, so a service added to homelab02's reverse proxy without a
-    # rewrite here resolves to a machine whose Caddy has never heard of it.
-    # That fails as a TLS error rather than a 404, because Caddy has no
-    # certificate for a hostname it does not serve, which points suspicion at
-    # the certificate rather than at DNS.
-    #
-    # A service on homelab02 that is proxied *by homelab01* (via the reverse
-    # proxy's `upstream` option, as grimmory is) belongs above, not here.
-    {
-      domain = "downloads.${domain}";
-      answer = servers.homelab02;
-    }
-    {
-      domain = "adguard2.${domain}";
-      answer = servers.homelab02;
-    }
-    {
-      domain = "filebrowser.${domain}";
-      answer = servers.homelab02;
-    }
-    {
-      domain = "shelfmark.${domain}";
-      answer = servers.homelab02;
-    }
-    {
-      domain = "suwayomi.${domain}";
-      answer = servers.homelab02;
-    }
-  ]
-  ++ cfg.extraRewrites # add supplied rewrites
-  ++ [
-    # Wildcard fallback - routes undefined subdomains to primary
-    {
-      domain = "*.${domain}";
-      answer = primaryServer;
-    }
-    {
-      domain = domain;
-      answer = primaryServer;
-    }
-  ];
+    lib.mapAttrsToList (name: host: mkRewrite host.address name) addressed
+    ++ map (mkRewrite gateway) gatewaySubdomains
+    ++ map (mkRewrite storage) storageSubdomains
+    ++ cfg.extraRewrites # add supplied rewrites
+    ++ [
+      # Wildcard fallback - routes undefined subdomains to the gateway
+      {
+        domain = "*.${domain}";
+        answer = gateway;
+      }
+      {
+        domain = domain;
+        answer = gateway;
+      }
+    ];
 
   # Upstream DNS servers - using encrypted DNS
   # These are queried for external domains (anything not in rewrites)
@@ -236,6 +173,9 @@ let
 
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../nixos/fleet.nix ];
+
   options.cg.service.adguard-home = {
     enable = lib.mkEnableOption "AdGuard Home DNS server";
 
@@ -247,8 +187,8 @@ in
       default = "primary";
       description = ''
         Role of this AdGuard Home instance.
-        - primary: Main DNS server (homelab01)
-        - secondary: Backup DNS server (homelab02)
+        - primary: Main DNS server
+        - secondary: Backup DNS server
         Both use identical configuration for failover.
       '';
     };
@@ -385,13 +325,13 @@ in
           ratelimit = 100; # queries per second per client
           ratelimit_whitelist = [
             "127.0.0.1"
-            "${servers.homelab01}"
-            "${servers.homelab02}"
-          ];
+          ]
+          ++ lib.mapAttrsToList (_: host: host.address) addressed;
 
-          # Local PTR resolvers for reverse DNS
+          # Local PTR resolvers for reverse DNS - the router is the only thing
+          # that knows what DHCP handed out.
           local_ptr_upstreams = [
-            "10.20.2.1" # Your router for local reverse lookups
+            fleet.lan.gateway
           ];
           use_private_ptr_resolvers = true;
 

--- a/modules/services/backup.nix
+++ b/modules/services/backup.nix
@@ -39,6 +39,12 @@ let
     mapAttrsToList (_: v: v) cfg.repositories
   );
 
+  # Every fleet machine with a reserved address; the laptop has none and is
+  # never an SFTP backup target.
+  fleetAddresses = mapAttrsToList (_: host: host.address) (
+    filterAttrs (_: host: host ? address) config.cg.fleet.hosts
+  );
+
   # Submodule type for individual repository targets
   repositoryModule = types.submodule {
     options = {
@@ -106,6 +112,9 @@ let
     '';
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../nixos/fleet.nix ];
+
   options.cg.service.backup = {
     enable = mkEnableOption "Restic backup to defined repositories";
 
@@ -231,10 +240,12 @@ in
       mode = "0600";
     };
 
-    # Configure root's SSH to use the backup key and accept host keys
-    # for known homelab hosts
+    # Configure root's SSH to use the backup key and accept host keys for the
+    # fleet's own machines. Named one at a time rather than as a subnet glob:
+    # every address here is one this flake already knows, and a glob offers the
+    # backup key to whatever else happens to answer on the LAN.
     programs.ssh.extraConfig = mkIf hasSftpRepo ''
-      Host 10.20.2.*
+      Host ${lib.concatStringsSep " " fleetAddresses}
         IdentityFile /root/.ssh/id_backup
         StrictHostKeyChecking accept-new
     '';

--- a/modules/services/cloudflare-tunnel.nix
+++ b/modules/services/cloudflare-tunnel.nix
@@ -6,7 +6,7 @@
 # - Protection against DDoS and direct IP exposure
 #
 # Architecture:
-# - cloudflared daemon runs on homelab01
+# - cloudflared daemon runs on the fleet's gateway host
 # - Registers DNS routes in Cloudflare
 # - Creates outbound tunnel to Cloudflare
 # - Cloudflare routes traffic based on hostname to local services
@@ -41,12 +41,16 @@ let
   '';
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../nixos/fleet.nix ];
+
   options.cg.service.cloudflare-tunnel = {
     enable = lib.mkEnableOption "Cloudflare Tunnel for zero-trust access";
 
     domain = lib.mkOption {
       type = lib.types.str;
-      default = "gyarmathy.co";
+      default = config.cg.fleet.domain;
+      defaultText = lib.literalExpression "config.cg.fleet.domain";
       description = "Domain name for services";
     };
 

--- a/modules/services/digital-garden/digital-garden.nix
+++ b/modules/services/digital-garden/digital-garden.nix
@@ -286,6 +286,9 @@ let
   };
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../../nixos/fleet.nix ];
+
   options.cg.service.digital-garden = {
     enable = lib.mkEnableOption "Digital garden (published subset of the Obsidian vault)";
 
@@ -347,7 +350,8 @@ in
 
     baseUrl = lib.mkOption {
       type = lib.types.str;
-      default = "garden.gyarmathy.co";
+      default = "garden.${config.cg.fleet.domain}";
+      defaultText = lib.literalExpression ''"garden.''${config.cg.fleet.domain}"'';
       description = "Public base URL, without scheme; the scheme is added by the renderer";
     };
 

--- a/modules/services/media-stack/cross-seed.nix
+++ b/modules/services/media-stack/cross-seed.nix
@@ -184,6 +184,9 @@ let
   '';
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../../nixos/fleet.nix ];
+
   options.cg.service.cross-seed = {
     enable = lib.mkEnableOption "cross-seed for private tracker ratio building";
 
@@ -195,7 +198,8 @@ in
 
     prowlarrUrl = lib.mkOption {
       type = lib.types.str;
-      default = "http://10.20.2.85:9696";
+      default = "http://${config.cg.fleet.hosts.${config.cg.fleet.roles.gateway}.address}:9696";
+      defaultText = lib.literalExpression "the gateway host's address on port 9696";
       example = "http://prowlarr:9696";
       description = ''
         Base URL for Prowlarr's Torznab feeds. An address, not a hostname, and
@@ -203,9 +207,10 @@ in
 
         Under VPN this container lives in Gluetun's network namespace, where
         DNS is Gluetun's own DoT resolver pointed at a public upstream. The
-        internal zone does not exist there: prowlarr.gyarmathy.co resolves only
-        on AdGuard and has no public record, so every Torznab request failed to
-        resolve and every search silently skipped its indexers. Reaching
+        internal zone does not exist there: the Prowlarr hostname resolves
+        only on AdGuard and has no public record, so every Torznab request
+        failed to resolve and every search silently skipped its indexers.
+        Reaching
         Prowlarr by address avoids resolution entirely, and Gluetun's
         FIREWALL_OUTBOUND_SUBNETS already permits the LAN.
       '';

--- a/modules/services/media-stack/jellyfin.nix
+++ b/modules/services/media-stack/jellyfin.nix
@@ -35,6 +35,9 @@ let
   stack = config.cg.service.media-stack;
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../../nixos/fleet.nix ];
+
   options.cg.service.jellyfin = {
     enable = lib.mkEnableOption "Jellyfin media server";
 
@@ -107,7 +110,7 @@ in
     };
 
     systemd.services.jellyfin.environment = {
-      JELLYFIN_PublishedServerUrl = "https://jellyfin.gyarmathy.co";
+      JELLYFIN_PublishedServerUrl = "https://jellyfin.${config.cg.fleet.domain}";
     };
 
     # Recording post-processing pipeline

--- a/modules/services/media-stack/qbittorrent.nix
+++ b/modules/services/media-stack/qbittorrent.nix
@@ -37,6 +37,9 @@ let
   stack = config.cg.service.media-stack;
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../../nixos/fleet.nix ];
+
   options.cg.service.qbittorrent = {
     enable = lib.mkEnableOption "qBittorrent torrent client";
 
@@ -100,7 +103,7 @@ in
           VPN_TYPE = "wireguard";
           SERVER_COUNTRIES = cfg.vpn.serverCountry;
           VPN_PORT_FORWARDING = "on";
-          FIREWALL_OUTBOUND_SUBNETS = "10.89.0.0/24,10.20.2.0/24";
+          FIREWALL_OUTBOUND_SUBNETS = "10.89.0.0/24,${config.cg.fleet.lan.cidr}";
           TZ = config.time.timeZone;
         };
         environmentFiles = [

--- a/modules/services/media-stack/recyclarr.nix
+++ b/modules/services/media-stack/recyclarr.nix
@@ -67,7 +67,7 @@ let
   # the series and movie quality definitions exactly once.
   defaultSettings = {
     sonarr.shows = {
-      base_url = "https://sonarr.gyarmathy.co";
+      base_url = "https://sonarr.${config.cg.fleet.domain}";
       api_key._secret = config.sops.secrets."media-stack/sonarr/api".path;
       delete_old_custom_formats = true;
 
@@ -100,7 +100,7 @@ let
     };
 
     radarr.movies = {
-      base_url = "https://radarr.gyarmathy.co";
+      base_url = "https://radarr.${config.cg.fleet.domain}";
       api_key._secret = config.sops.secrets."media-stack/radarr/api".path;
       delete_old_custom_formats = true;
 
@@ -129,6 +129,9 @@ let
   };
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../../nixos/fleet.nix ];
+
   options.cg.service.recyclarr = {
     enable = lib.mkEnableOption "Recyclarr TRaSH Guide sync";
 

--- a/modules/services/media-stack/unpackerr.nix
+++ b/modules/services/media-stack/unpackerr.nix
@@ -23,8 +23,8 @@ let
   cfg = config.cg.service.unpackerr;
   stack = config.cg.service.media-stack;
 
-  sonarrUrl = "https://sonarr.gyarmathy.co";
-  radarrUrl = "https://radarr.gyarmathy.co";
+  sonarrUrl = "https://sonarr.${config.cg.fleet.domain}";
+  radarrUrl = "https://radarr.${config.cg.fleet.domain}";
 
   # Generate the TOML config file
   configFile = pkgs.writeText "unpackerr.conf" ''
@@ -77,6 +77,9 @@ let
   '';
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../../nixos/fleet.nix ];
+
   options.cg.service.unpackerr = {
     enable = lib.mkEnableOption "Archived release unpacker";
   };

--- a/modules/services/miniflux.nix
+++ b/modules/services/miniflux.nix
@@ -25,7 +25,7 @@
 #
 # Mobile clients:
 # - Enable the Fever or Google Reader API in Miniflux Settings > Integrations
-# - Connect Reeder / NetNewsWire to https://rss.gyarmathy.co
+# - Connect Reeder / NetNewsWire to https://rss.<domain>
 #
 # Secrets required in secrets/homelab.yaml:
 #   miniflux/admin-credentials: |
@@ -43,6 +43,9 @@ let
   cfg = config.cg.service.miniflux;
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../nixos/fleet.nix ];
+
   options.cg.service.miniflux = {
     enable = lib.mkEnableOption "Miniflux RSS reader";
 
@@ -54,7 +57,8 @@ in
 
     baseUrl = lib.mkOption {
       type = lib.types.str;
-      default = "https://rss.gyarmathy.co";
+      default = "https://rss.${config.cg.fleet.domain}";
+      defaultText = lib.literalExpression ''"https://rss.''${config.cg.fleet.domain}"'';
       description = "Public base URL for Miniflux (used in feed links and API responses)";
     };
   };

--- a/modules/services/monitoring/monitoring.nix
+++ b/modules/services/monitoring/monitoring.nix
@@ -8,6 +8,7 @@
 
 let
   cfg = config.cg.service.monitoring;
+  fleet = config.cg.fleet;
 
   # ZFS health metrics script for textfile collector
   # Outputs Prometheus metrics for ZFS pool health
@@ -174,6 +175,9 @@ let
   '';
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../../nixos/fleet.nix ];
+
   options.cg.service.monitoring = {
     enable = lib.mkEnableOption "Monitoring stack";
 
@@ -243,7 +247,8 @@ in
 
         baseUrl = lib.mkOption {
           type = lib.types.str;
-          default = "https://ntfy.gyarmathy.co";
+          default = "https://ntfy.${fleet.domain}";
+          defaultText = lib.literalExpression ''"https://ntfy.''${config.cg.fleet.domain}"'';
           description = "Base URL of the ntfy server the bridge publishes to";
         };
 
@@ -512,17 +517,28 @@ in
                 }
               ];
             }
-            {
-              job_name = "cloudflared";
-              static_configs = [
-                {
-                  targets = [ cfg.cloudflaredTarget ];
-                  labels = {
-                    instance = "homelab01";
-                  };
-                }
-              ];
-            }
+          ]
+          # `null to disable` per the option's description. It used to emit the
+          # job regardless, which produced `targets = [ null ]` and a type
+          # error rather than the documented no-op; nothing sets it to null
+          # today, and now nothing has to.
+          ++ lib.optional (cfg.cloudflaredTarget != null) {
+            job_name = "cloudflared";
+            static_configs = [
+              {
+                targets = [ cfg.cloudflaredTarget ];
+                labels = {
+                  # cloudflared is scraped from wherever the tunnel runs,
+                  # which is not necessarily this host - so the instance label
+                  # comes from the target rather than from
+                  # `networking.hostName`, which would mislabel every series
+                  # the peer scrapes.
+                  instance = lib.head (lib.splitString ":" cfg.cloudflaredTarget);
+                };
+              }
+            ];
+          }
+          ++ [
             {
               job_name = "blackbox-http";
               metrics_path = "/probe";
@@ -876,8 +892,8 @@ in
             server = {
               http_port = 3000;
               http_addr = "127.0.0.1";
-              domain = "grafana.gyarmathy.co";
-              root_url = "https://grafana.gyarmathy.co";
+              domain = "grafana.${fleet.domain}";
+              root_url = "https://grafana.${fleet.domain}";
             };
 
             "auth.anonymous".enabled = false;

--- a/modules/services/nas-storage.nix
+++ b/modules/services/nas-storage.nix
@@ -18,6 +18,9 @@ let
   cfg = config.cg.service.nas-storage;
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../nixos/fleet.nix ];
+
   options.cg.service.nas-storage = {
     enable = lib.mkEnableOption "NAS storage with ZFS and NFS";
 
@@ -38,13 +41,14 @@ in
 
       allowedNetwork = lib.mkOption {
         type = lib.types.str;
-        default = "10.20.2.0/24";
+        default = config.cg.fleet.lan.cidr;
+        defaultText = lib.literalExpression "config.cg.fleet.lan.cidr";
         example = "10.20.2.85/32";
         description = ''
           Host or network allowed to mount the export. Prefer the narrowest
-          value that works — ideally the single NFS client's IP (e.g.
-          "10.20.2.85/32") rather than a whole subnet, since the export grants
-          read-write access to all media.
+          value that works — ideally the single NFS client's address as a /32
+          rather than a whole subnet, since the export grants read-write
+          access to all media.
         '';
       };
 

--- a/modules/services/ntfy.nix
+++ b/modules/services/ntfy.nix
@@ -23,7 +23,7 @@
 #     `monitoring/ntfy/webhook-password`, e.g.:
 #       openssl rand -hex 24   # once per secret
 #     then re-run the deploy so the bridges pick them up.
-#  3. In the ntfy app add server https://ntfy.gyarmathy.co, log in with
+#  3. In the ntfy app add server https://ntfy.<domain>, log in with
 #     the user from step 1, and subscribe to the `alerts` topic.
 #
 # The auth database lives in /var/lib/ntfy-sh/user.db. It is not in the
@@ -39,6 +39,9 @@ let
   cfg = config.cg.service.ntfy;
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../nixos/fleet.nix ];
+
   options.cg.service.ntfy = {
     enable = lib.mkEnableOption "ntfy self-hosted push notification server";
 
@@ -69,7 +72,7 @@ in
       settings = {
         # What clients see in messages' links and what iOS-style instant
         # delivery would key off; must match the public URL.
-        base-url = "https://${cfg.subdomain}.gyarmathy.co";
+        base-url = "https://${cfg.subdomain}.${config.cg.fleet.domain}";
         listen-http = "127.0.0.1:${toString cfg.port}";
 
         # We sit behind Caddy, which already terminates TLS and applies its

--- a/modules/services/reverse-proxy.nix
+++ b/modules/services/reverse-proxy.nix
@@ -17,7 +17,7 @@
 # - Certs auto-renew before expiry
 #
 # To switch to wildcard later, change the virtualHosts to use:
-#   "*.gyarmathy.co" = { ... }
+#   "*.${domain}" = { ... }
 # and add a single tls block with the dns challenge
 #
 # ════════════════════════════════════════════════════════════════════════════
@@ -43,7 +43,8 @@
 }:
 let
   cfg = config.cg.service.reverse-proxy;
-  domain = "gyarmathy.co";
+  fleet = config.cg.fleet;
+  inherit (fleet) domain;
 
   # Build Caddy with Cloudflare DNS plugin
   # This is required for DNS-01 challenge
@@ -152,7 +153,7 @@ let
 
           ${lib.optionalString localOnly ''
             # Restrict to local network only
-            @denied not remote_ip 10.20.2.0/24 10.89.0.0/24 192.168.0.0/16 127.0.0.1
+            @denied not remote_ip ${fleet.lan.cidr} 10.89.0.0/24 192.168.0.0/16 127.0.0.1
             respond @denied "Access denied" 403
           ''}
 
@@ -170,6 +171,9 @@ let
     };
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../nixos/fleet.nix ];
+
   options.cg.service.reverse-proxy = {
     enable = lib.mkEnableOption "Caddy reverse proxy with automatic TLS";
 

--- a/modules/services/vikunja.nix
+++ b/modules/services/vikunja.nix
@@ -45,6 +45,9 @@ let
   cfg = config.cg.service.vikunja;
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../nixos/fleet.nix ];
+
   options.cg.service.vikunja = {
     enable = lib.mkEnableOption "Vikunja task manager";
 
@@ -56,7 +59,8 @@ in
 
     frontendHostname = lib.mkOption {
       type = lib.types.str;
-      default = "tasks.gyarmathy.co";
+      default = "tasks.${config.cg.fleet.domain}";
+      defaultText = lib.literalExpression ''"tasks.''${config.cg.fleet.domain}"'';
       description = "Public hostname for Vikunja (used in links and CORS headers)";
     };
   };

--- a/modules/services/wallabag.nix
+++ b/modules/services/wallabag.nix
@@ -51,6 +51,9 @@ let
   cfg = config.cg.service.wallabag;
 in
 {
+  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
+  imports = [ ../nixos/fleet.nix ];
+
   options.cg.service.wallabag = {
     enable = lib.mkEnableOption "Wallabag read-it-later service";
 
@@ -62,7 +65,8 @@ in
 
     baseUrl = lib.mkOption {
       type = lib.types.str;
-      default = "https://read.gyarmathy.co";
+      default = "https://read.${config.cg.fleet.domain}";
+      defaultText = lib.literalExpression ''"https://read.''${config.cg.fleet.domain}"'';
       description = "Public base URL for Wallabag (must match SYMFONY__ENV__DOMAIN_NAME)";
     };
   };


### PR DESCRIPTION
Item 1 of [`docs/plans/structural-cleanup.md`](https://github.com/corygyarmathy/dotfiles/blob/master/docs/plans/structural-cleanup.md).

Host addresses, the domain and which machine owns which fleet-wide duty were each written down in several files with nothing to notice when the copies diverged. `fleet/default.nix` now holds them once, and everything else reads them.

## The shape

`fleet/default.nix` is plain data — the domain, the LAN (CIDR and gateway), every host (`kind`, `system`, and an `address` for the two that have a reservation), and a two-entry `roles` map. No `lib`, no `config`, no options, so the flake can read it before there is a module system to ask.

It is surfaced twice, deliberately:

- The **flake** reads the file directly. `nixosConfigurations` is `mapAttrs mkHost fleet.hosts`, and `hosts/<name>/` receive the fleet as a specialArg.
- **Modules** read `config.cg.fleet`, declared in `modules/nixos/fleet.nix` with the file as its **default**, so every module-system evaluation gets a fleet — including the behaviour tests, which instantiate modules directly and never go through `mkHost`. A definition set by `mkHost` would have looked equivalent and would have broken every check the moment a module read it.

The option is **not `readOnly`**. That counts its own default among its definitions, so `readOnly` plus a default rejects *any* override and would leave every check permanently stuck with the production fleet. `types.raw` keeps the part that was actually wanted: two definitions conflict rather than merging into one union of two fleets.

## Three things the plan did not anticipate

**`nixosConfigurations` had to be generated from the fleet.** The `Done when` forbids a literal host name in a `.nix` file, and `mkHost { hostname = "homelab01"; … }` is one. `extraModules` went with it — the nixos-hardware modules a machine needs are a property of that machine, so each `hosts/<name>/default.nix` imports its own. Adding a host is now an entry in `fleet/` and a directory beside it. The build matrix in `ci.yml` still names hosts explicitly, deliberately: a host that stops being built is exactly what the gate is for.

**A module that reads the fleet imports the declaration itself.** Putting the data in the default gets a fleet into every evaluation, but only where the option is *declared*, and the checks import single module files rather than `modules/nixos`. So the sixteen modules that read `config.cg.fleet` each carry `imports = [ ../nixos/fleet.nix ]`. Importing one path from several modules costs nothing — the module system keys on it — and it is what kept `checks/lib.nix` from having to learn anything about the fleet.

**The override is exercised, not just left possible.** `checks/reverse-proxy.nix` now sets `cg.fleet` to a fleet that is not this one (`example.test`, a `10.0.0.0/24` LAN, no hosts) and asserts against `internal.example.test`. That is the reason the option is not `readOnly` stated as a passing test rather than as a comment, and it took the last of the domain literals out of `checks/`.

## Behaviour

Marked `minor` in the plan's table rather than `no`. Two lines of generated configuration change, neither of which a running host can tell apart:

- Root's SSH config for backups was `Host 10.20.2.*`. It is now the fleet's own addresses, one at a time — a glob offers the backup key to whatever else answers on the LAN.
- The `cloudflared` scrape job is emitted only when `cloudflaredTarget` is set, which is what the option's `null to disable` always claimed; it used to emit `targets = [ null ]` and fail the type check. Its `instance` label is now taken from the target rather than hardcoded, so the peer scraping the tunnel host no longer labels the series with its own name.

## Verified inert, rather than assumed

For homelab01 and homelab02, every entry in the generated `/etc` was compared against the same host built from `43102b0`, and every systemd unit within it. **One entry differs on each host: `ssh/ssh_config`**, the deliberate change above. Caddy's config file, Prometheus' scrape config, AdGuard's settings, the NFS export and all four restic units are byte-identical.

Five other derivations move — `system-path`, `dbus-1`, `user-units`, and the `nixos-upgrade`, `nixos-deploy-metrics`, `digital-garden-build`, `dbus-broker` and `polkit` units. Those are not this change: comparing `43102b0` against its own parent, a documentation-only commit, moves exactly the same set. They carry `system.configurationRevision`, directly or through `nixos-version` in the system path, so any commit moves them. Worth chasing down rather than waving at — "some unrelated things also changed" is how a real difference gets missed.

## Checks run

- All ten checks pass, including the three VM tests that instantiate a module which now reads the fleet.
- `nix fmt -- --ci` clean; all three hosts evaluate.
- `devShells`, `packages` and `apps` — the three outputs the `lint` job evaluates by hand — still evaluate. `garden-preview` resolves to the same store path, which is the check that the gateway lookup replacing `nixosConfigurations.homelab01` picks the same host.
- The `Done when` was checked by script rather than by eye. Four occurrences remain, all of them the host name inside an SSH public key's own comment field (`… coryg@xps15`). That is key material, not a transcribed fleet fact: editing it would change the key.

## Deliberately not in scope

Documentation (`README.md`, `docs/runbooks/fleet-map.md`, `AGENTS.md`, an ADR for the fleet layer) is item 7's single pass, taken once the shape settles. Item 6's rule — a module's default should be correct for a machine outside this fleet — is untouched; `adguard-home` now *requires* `roles.gateway` and `roles.storage` to name real hosts, which item 6's problem list has been updated to say.
