### PR TITLE
refactor: let services publish themselves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
           - digital-garden-sync-health
           - grafana
           - monitoring
+          - publish
           - reverse-proxy
           - upgrade-verify
     steps:

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -216,6 +216,10 @@ in
   };
   grafana = testLib.mkTest ./grafana.nix;
   monitoring = testLib.mkTest ./monitoring.nix;
+
+  # Not a VM: what it asserts is a shape in the generated configuration, and
+  # the file says why that shape is worth a check of its own.
+  publish = import ./publish.nix { inherit pkgs self inputs; };
   reverse-proxy = testLib.mkTest ./reverse-proxy.nix;
   upgrade-verify = testLib.mkTest ./upgrade-verify.nix;
 }

--- a/checks/monitoring.nix
+++ b/checks/monitoring.nix
@@ -167,306 +167,314 @@
       virtualisation.memorySize = 2048;
     };
 
-  testScript = ''
-    import json
-    import shlex
-    import time
-    from datetime import datetime, timedelta, timezone
+  # A function of `nodes`, so the webhook port below is read from the module
+  # rather than written down again here. It was a literal, and moving the
+  # bridge's default off 8000 broke this test rather than the thing the test
+  # is about - the copy kept asserting against a port nothing listened on, and
+  # failed as an unauthenticated POST that was not rejected. Reading the
+  # option is both shorter and the only version that stays true.
+  testScript =
+    { nodes, ... }:
+    ''
+      import json
+      import shlex
+      import time
+      from datetime import datetime, timedelta, timezone
 
-    def query(expr):
-        out = machine.succeed(
-            "curl -sf --get --data-urlencode 'query={}' "
-            "http://localhost:9090/api/v1/query".format(expr)
-        )
-        return json.loads(out)["data"]["result"]
+      def query(expr):
+          out = machine.succeed(
+              "curl -sf --get --data-urlencode 'query={}' "
+              "http://localhost:9090/api/v1/query".format(expr)
+          )
+          return json.loads(out)["data"]["result"]
 
-    machine.wait_for_unit("prometheus.service")
-    machine.wait_for_open_port(9090)
-    machine.wait_until_succeeds("curl -sf http://localhost:9090/-/ready", timeout=120)
+      machine.wait_for_unit("prometheus.service")
+      machine.wait_for_open_port(9090)
+      machine.wait_until_succeeds("curl -sf http://localhost:9090/-/ready", timeout=120)
 
-    with subtest("the rule file is loaded by the server, not merely valid on disk"):
-        rules = json.loads(machine.succeed("curl -sf http://localhost:9090/api/v1/rules"))
-        assert rules["status"] == "success", rules
-        groups = rules["data"]["groups"]
-        assert groups, "Prometheus started with no rule groups loaded"
+      with subtest("the rule file is loaded by the server, not merely valid on disk"):
+          rules = json.loads(machine.succeed("curl -sf http://localhost:9090/api/v1/rules"))
+          assert rules["status"] == "success", rules
+          groups = rules["data"]["groups"]
+          assert groups, "Prometheus started with no rule groups loaded"
 
-        names = {r["name"] for g in groups for r in g["rules"]}
-        # One representative from each family the deployment pipeline depends
-        # on. If alert-rules.yml is reorganised these names may legitimately
-        # change - but they should change deliberately, not silently.
-        for expected in ["NixosDeployFailed", "NixosDeployStale", "NixosVerifyFailed"]:
-            assert expected in names, f"{expected} missing from loaded rules: {sorted(names)}"
+          names = {r["name"] for g in groups for r in g["rules"]}
+          # One representative from each family the deployment pipeline depends
+          # on. If alert-rules.yml is reorganised these names may legitimately
+          # change - but they should change deliberately, not silently.
+          for expected in ["NixosDeployFailed", "NixosDeployStale", "NixosVerifyFailed"]:
+              assert expected in names, f"{expected} missing from loaded rules: {sorted(names)}"
 
-    with subtest("a target is actually scraped"):
-        machine.wait_for_unit("prometheus-node-exporter.service")
-        machine.wait_for_open_port(9100)
+      with subtest("a target is actually scraped"):
+          machine.wait_for_unit("prometheus-node-exporter.service")
+          machine.wait_for_open_port(9100)
 
-        # scrape_interval is 1m and Prometheus jitters each target's first
-        # scrape across that window, so this can genuinely take a minute.
-        def node_up(_):
-            result = query('up{job="node"}')
-            return bool(result) and result[0]["value"][1] == "1"
+          # scrape_interval is 1m and Prometheus jitters each target's first
+          # scrape across that window, so this can genuinely take a minute.
+          def node_up(_):
+              result = query('up{job="node"}')
+              return bool(result) and result[0]["value"][1] == "1"
 
-        retry(node_up, timeout=timedelta(seconds=180))
+          retry(node_up, timeout=timedelta(seconds=180))
 
-    with subtest("deployment metrics reach Prometheus"):
-        # NOT wait_for_unit: nixos-deploy-metrics is a Type=oneshot without
-        # RemainAfterExit, so it reads `inactive` the moment it succeeds and
-        # waiting for it to be active waits forever. Starting it explicitly is
-        # also the deterministic choice - it already ran at multi-user.target,
-        # and this removes the race with node_exporter's first read.
-        #
-        # (The same shape is the trap item 3 documents for criticalUnits:
-        # `is-active` is only meaningful for a oneshot that sets
-        # RemainAfterExit. This unit is not probed there, but it is the same
-        # mistake waiting to be made.)
-        machine.succeed("systemctl start nixos-deploy-metrics.service")
+      with subtest("deployment metrics reach Prometheus"):
+          # NOT wait_for_unit: nixos-deploy-metrics is a Type=oneshot without
+          # RemainAfterExit, so it reads `inactive` the moment it succeeds and
+          # waiting for it to be active waits forever. Starting it explicitly is
+          # also the deterministic choice - it already ran at multi-user.target,
+          # and this removes the race with node_exporter's first read.
+          #
+          # (The same shape is the trap item 3 documents for criticalUnits:
+          # `is-active` is only meaningful for a oneshot that sets
+          # RemainAfterExit. This unit is not probed there, but it is the same
+          # mistake waiting to be made.)
+          machine.succeed("systemctl start nixos-deploy-metrics.service")
 
-        # First that the file is written where the collector is looking, so a
-        # failure here points at deploy-metrics rather than at the scrape.
-        machine.succeed("test -s /var/lib/prometheus-node-exporter/nixos_deploy.prom")
+          # First that the file is written where the collector is looking, so a
+          # failure here points at deploy-metrics rather than at the scrape.
+          machine.succeed("test -s /var/lib/prometheus-node-exporter/nixos_deploy.prom")
 
-        # Then that node_exporter's textfile collector is switched on and
-        # pointed at that directory - the wiring deploy-metrics.nix has to
-        # override a mkDefault to get.
-        #
-        # Written to a file rather than piped into grep: the test driver runs
-        # commands under `pipefail`, and `grep -q` exits at the first match,
-        # which hands curl an EPIPE and fails the whole pipeline for a match
-        # that was actually found. The symptom is a passing condition that
-        # times out, so it is worth not writing it the obvious way.
-        machine.wait_until_succeeds(
-            "curl -sf -o /tmp/node-metrics http://localhost:9100/metrics "
-            "&& grep -q nixos_deploy_revision_info /tmp/node-metrics",
-            timeout=60,
-        )
+          # Then that node_exporter's textfile collector is switched on and
+          # pointed at that directory - the wiring deploy-metrics.nix has to
+          # override a mkDefault to get.
+          #
+          # Written to a file rather than piped into grep: the test driver runs
+          # commands under `pipefail`, and `grep -q` exits at the first match,
+          # which hands curl an EPIPE and fails the whole pipeline for a match
+          # that was actually found. The symptom is a passing condition that
+          # times out, so it is worth not writing it the obvious way.
+          machine.wait_until_succeeds(
+              "curl -sf -o /tmp/node-metrics http://localhost:9100/metrics "
+              "&& grep -q nixos_deploy_revision_info /tmp/node-metrics",
+              timeout=60,
+          )
 
-        # And finally that it survives the scrape, which is the only step that
-        # proves the whole ADR 0001 telemetry chain is connected.
-        def revision_exported(_):
-            return bool(query("nixos_deploy_revision_info"))
+          # And finally that it survives the scrape, which is the only step that
+          # proves the whole ADR 0001 telemetry chain is connected.
+          def revision_exported(_):
+              return bool(query("nixos_deploy_revision_info"))
 
-        retry(revision_exported, timeout=timedelta(seconds=180))
+          retry(revision_exported, timeout=timedelta(seconds=180))
 
-    with subtest("a failed unit's journal tail reaches the textfile collector"):
-        # The canary exits 1 after printing its marker; `start` therefore
-        # reports failure and must not fail the test itself.
-        machine.succeed("systemctl start journal-tail-canary.service || true")
+      with subtest("a failed unit's journal tail reaches the textfile collector"):
+          # The canary exits 1 after printing its marker; `start` therefore
+          # reports failure and must not fail the test itself.
+          machine.succeed("systemctl start journal-tail-canary.service || true")
 
-        # Deterministic capture: run the exporter now rather than waiting for
-        # the timer. First the file it writes...
-        machine.succeed("systemctl start journal-tail-exporter.service")
-        machine.succeed(
-            "grep -q JOURNAL-TAIL-CANARY /var/lib/prometheus-node-exporter/journal_tail.prom"
-        )
+          # Deterministic capture: run the exporter now rather than waiting for
+          # the timer. First the file it writes...
+          machine.succeed("systemctl start journal-tail-exporter.service")
+          machine.succeed(
+              "grep -q JOURNAL-TAIL-CANARY /var/lib/prometheus-node-exporter/journal_tail.prom"
+          )
 
-        # ...then that node_exporter serves it - the wiring step
-        # journal-tail.nix has to override a mkDefault to get.
-        machine.wait_until_succeeds(
-            "curl -sf -o /tmp/node-metrics http://localhost:9100/metrics "
-            "&& grep -q systemd_unit_journal_tail_info /tmp/node-metrics",
-            timeout=60,
-        )
+          # ...then that node_exporter serves it - the wiring step
+          # journal-tail.nix has to override a mkDefault to get.
+          machine.wait_until_succeeds(
+              "curl -sf -o /tmp/node-metrics http://localhost:9100/metrics "
+              "&& grep -q systemd_unit_journal_tail_info /tmp/node-metrics",
+              timeout=60,
+          )
 
-        # Prometheus-side presence is not asserted here: the file-to-scraper
-        # chain is generic and already proven by the deployment metrics
-        # subtest above, while firing SystemdUnitFailed end-to-end would mean
-        # waiting out its 5m hold-down for one annotation string. The join
-        # and templates are pinned exactly by the alert-rules-unit check.
-        #
-        # Clear the failed state so the canary can never leak into the
-        # push-lane assertions below as a real SystemdUnitFailed.
-        machine.succeed("systemctl reset-failed journal-tail-canary.service")
+          # Prometheus-side presence is not asserted here: the file-to-scraper
+          # chain is generic and already proven by the deployment metrics
+          # subtest above, while firing SystemdUnitFailed end-to-end would mean
+          # waiting out its 5m hold-down for one annotation string. The join
+          # and templates are pinned exactly by the alert-rules-unit check.
+          #
+          # Clear the failed state so the canary can never leak into the
+          # push-lane assertions below as a real SystemdUnitFailed.
+          machine.succeed("systemctl reset-failed journal-tail-canary.service")
 
-    with subtest("the staged timestamp tracks the generation, not the last rebuild"):
-        # Read off the file rather than out of Prometheus: this is about what
-        # the script computes, and putting a scrape in the middle would add a
-        # minute of waiting and a race to every assertion below.
-        def staged_ts():
-            machine.succeed("systemctl start nixos-deploy-metrics.service")
-            return int(machine.succeed(
-                "awk '/^nixos_deploy_staged_timestamp_seconds/ {print $NF}' "
-                "/var/lib/prometheus-node-exporter/nixos_deploy.prom"
-            ).strip())
+      with subtest("the staged timestamp tracks the generation, not the last rebuild"):
+          # Read off the file rather than out of Prometheus: this is about what
+          # the script computes, and putting a scrape in the middle would add a
+          # minute of waiting and a race to every assertion below.
+          def staged_ts():
+              machine.succeed("systemctl start nixos-deploy-metrics.service")
+              return int(machine.succeed(
+                  "awk '/^nixos_deploy_staged_timestamp_seconds/ {print $NF}' "
+                  "/var/lib/prometheus-node-exporter/nixos_deploy.prom"
+              ).strip())
 
-        def profile_mtime():
-            return int(machine.succeed("stat -c %Y /nix/var/nix/profiles/system").strip())
+          def profile_mtime():
+              return int(machine.succeed("stat -c %Y /nix/var/nix/profiles/system").strip())
 
-        # The VM boots straight from the store, so the profile starts with no
-        # generations at all. Seed it with what is running, as a host has.
-        running = machine.succeed("readlink -f /run/current-system").strip()
-        machine.succeed("nix-env -p /nix/var/nix/profiles/system --set {}".format(running))
-        first, first_mtime = staged_ts(), profile_mtime()
+          # The VM boots straight from the store, so the profile starts with no
+          # generations at all. Seed it with what is running, as a host has.
+          running = machine.succeed("readlink -f /run/current-system").strip()
+          machine.succeed("nix-env -p /nix/var/nix/profiles/system --set {}".format(running))
+          first, first_mtime = staged_ts(), profile_mtime()
 
-        # Whole-second mtimes, so a timestamp that moves has to move visibly.
-        machine.succeed("sleep 2")
+          # Whole-second mtimes, so a timestamp that moves has to move visibly.
+          machine.succeed("sleep 2")
 
-        # What a nightly rebuild does on a host nothing has changed: the same
-        # store path set again. nix keeps the generation it already has and
-        # re-points the profile symlink at it anyway.
-        machine.succeed("nix-env -p /nix/var/nix/profiles/system --set {}".format(running))
-        second, second_mtime = staged_ts(), profile_mtime()
+          # What a nightly rebuild does on a host nothing has changed: the same
+          # store path set again. nix keeps the generation it already has and
+          # re-points the profile symlink at it anyway.
+          machine.succeed("nix-env -p /nix/var/nix/profiles/system --set {}".format(running))
+          second, second_mtime = staged_ts(), profile_mtime()
 
-        # The control. Without it the assertion below would also pass on a day
-        # when nix stopped re-pointing an unchanged profile - green because the
-        # condition under test had gone away, which is the failure a regression
-        # test is least able to survive.
-        assert second_mtime > first_mtime, (
-            "the profile symlink was not re-pointed ({} == {}), so this no longer "
-            "reproduces what a no-change rebuild does and proves nothing"
-            .format(first_mtime, second_mtime)
-        )
+          # The control. Without it the assertion below would also pass on a day
+          # when nix stopped re-pointing an unchanged profile - green because the
+          # condition under test had gone away, which is the failure a regression
+          # test is least able to survive.
+          assert second_mtime > first_mtime, (
+              "the profile symlink was not re-pointed ({} == {}), so this no longer "
+              "reproduces what a no-change rebuild does and proves nothing"
+              .format(first_mtime, second_mtime)
+          )
 
-        # The claim: re-staging the generation that is already staged is not a
-        # staging event. Reading the profile symlink's own mtime said it was,
-        # which reset NixosRebootPending's 26h window nightly and fired
-        # NixosVerifyStale against a generation verified two days earlier.
-        assert second == first, (
-            "staged timestamp moved ({} -> {}) for a generation that was already "
-            "staged; it is reporting rebuilds rather than generations"
-            .format(first, second)
-        )
+          # The claim: re-staging the generation that is already staged is not a
+          # staging event. Reading the profile symlink's own mtime said it was,
+          # which reset NixosRebootPending's 26h window nightly and fired
+          # NixosVerifyStale against a generation verified two days earlier.
+          assert second == first, (
+              "staged timestamp moved ({} -> {}) for a generation that was already "
+              "staged; it is reporting rebuilds rather than generations"
+              .format(first, second)
+          )
 
-    with subtest("alertmanager routes, inhibits and pushes"):
-        machine.wait_for_unit("alertmanager.service")
-        machine.wait_for_unit("alertmanager-ntfy.service")
-        machine.wait_for_unit("ntfy-sh.service")
-        machine.wait_until_succeeds("curl -sf http://localhost:9093/-/ready", timeout=60)
-        machine.wait_until_succeeds("curl -sf http://localhost:2586/v1/health", timeout=60)
+      with subtest("alertmanager routes, inhibits and pushes"):
+          machine.wait_for_unit("alertmanager.service")
+          machine.wait_for_unit("alertmanager-ntfy.service")
+          machine.wait_for_unit("ntfy-sh.service")
+          machine.wait_until_succeeds("curl -sf http://localhost:9093/-/ready", timeout=60)
+          machine.wait_until_succeeds("curl -sf http://localhost:2586/v1/health", timeout=60)
 
-        # The 2026-08-25 Grafana page died here: Alertmanager could not read
-        # its own webhook password because the secret was declared without an
-        # owner and landed root:root 0400. The private fixtures reproduce
-        # those production permissions, so this is the assertion that turns a
-        # silent delivery failure into a red test.
-        machine.succeed("runuser -u alertmanager -- test -r /run/stub-secrets/monitoring/ntfy/webhook-password")
+          # The 2026-08-25 Grafana page died here: Alertmanager could not read
+          # its own webhook password because the secret was declared without an
+          # owner and landed root:root 0400. The private fixtures reproduce
+          # those production permissions, so this is the assertion that turns a
+          # silent delivery failure into a red test.
+          machine.succeed("runuser -u alertmanager -- test -r /run/stub-secrets/monitoring/ntfy/webhook-password")
 
-        # alertmanager-ntfy ignores unknown config keys, so a wrong key in the
-        # auth file (http.basic instead of http.auth) disables /hook auth with
-        # nothing but a startup warning to show for it.
-        bridge_log = machine.succeed("journalctl -u alertmanager-ntfy -b --no-pager")
-        assert "Basic auth is disabled" not in bridge_log, (
-            "the bridge started without incoming authentication; "
-            "the auth template's keys do not match what alertmanager-ntfy reads"
-        )
+          # alertmanager-ntfy ignores unknown config keys, so a wrong key in the
+          # auth file (http.basic instead of http.auth) disables /hook auth with
+          # nothing but a startup warning to show for it.
+          bridge_log = machine.succeed("journalctl -u alertmanager-ntfy -b --no-pager")
+          assert "Basic auth is disabled" not in bridge_log, (
+              "the bridge started without incoming authentication; "
+              "the auth template's keys do not match what alertmanager-ntfy reads"
+          )
 
-        # And behaviourally, from the outside: no credentials, no entry.
-        unauth = machine.succeed(
-            "curl -s -o /dev/null -w '%{http_code}' -XPOST -H 'Content-Type: application/json' "
-            "-d '{\"alerts\":[]}' http://127.0.0.1:8000/hook || true"
-        ).strip()
-        assert unauth == "401", f"unauthenticated webhook post was not rejected: {unauth}"
+          # And behaviourally, from the outside: no credentials, no entry.
+          unauth = machine.succeed(
+              "curl -s -o /dev/null -w '%{http_code}' -XPOST -H 'Content-Type: application/json' "
+              "-d '{\"alerts\":[]}' http://127.0.0.1:${toString nodes.machine.cg.service.monitoring.alertmanager.ntfy.port}/hook || true"
+          ).strip()
+          assert unauth == "401", f"unauthenticated webhook post was not rejected: {unauth}"
 
-        def post_alerts(alerts):
-            body = json.dumps(
-                [
-                    {
-                        "labels": dict(a["labels"]),
-                        "annotations": {
-                            "summary": "{} summary".format(a["labels"]["alertname"]),
-                            "description": "{} description".format(a["labels"]["alertname"]),
-                        },
-                        "startsAt": datetime.now(timezone.utc).isoformat(),
-                        "endsAt": (datetime.now(timezone.utc) + timedelta(hours=4)).isoformat(),
-                    }
-                    for a in alerts
-                ]
-            )
-            machine.succeed(
-                "curl -sf -XPOST -H 'Content-Type: application/json' "
-                "http://localhost:9093/api/v2/alerts -d {}".format(shlex.quote(body))
-            )
+          def post_alerts(alerts):
+              body = json.dumps(
+                  [
+                      {
+                          "labels": dict(a["labels"]),
+                          "annotations": {
+                              "summary": "{} summary".format(a["labels"]["alertname"]),
+                              "description": "{} description".format(a["labels"]["alertname"]),
+                          },
+                          "startsAt": datetime.now(timezone.utc).isoformat(),
+                          "endsAt": (datetime.now(timezone.utc) + timedelta(hours=4)).isoformat(),
+                      }
+                      for a in alerts
+                  ]
+              )
+              machine.succeed(
+                  "curl -sf -XPOST -H 'Content-Type: application/json' "
+                  "http://localhost:9093/api/v2/alerts -d {}".format(shlex.quote(body))
+              )
 
-        _poll_failures = [0]
+          _poll_failures = [0]
 
-        def messages():
-            # Public subscribe API: NDJSON stream that ends immediately when
-            # poll=1. Only message events carry notifications. Paced slower
-            # than one request per default replenish interval so the loop
-            # stays inside ntfy's visitor allowance no matter what.
-            time.sleep(6)
-            code = machine.succeed(
-                "curl -s -o /tmp/poll-body -w '%{http_code}' "
-                "'http://localhost:2586/alerts/json?poll=1'"
-            ).strip()
-            if not code.startswith("2"):
-                _poll_failures[0] += 1
-                if _poll_failures[0] <= 2:
-                    machine.log(
-                        "POLL-ERROR status={} body={}".format(
-                            code,
-                            machine.succeed("cat /tmp/poll-body || true")[:300].replace("\n", " | "),
-                        )
-                    )
-                return []
-            body = machine.succeed("cat /tmp/poll-body")
-            return [
-                json.loads(line)
-                for line in body.splitlines()
-                if line.strip() and json.loads(line).get("event") == "message"
-            ]
+          def messages():
+              # Public subscribe API: NDJSON stream that ends immediately when
+              # poll=1. Only message events carry notifications. Paced slower
+              # than one request per default replenish interval so the loop
+              # stays inside ntfy's visitor allowance no matter what.
+              time.sleep(6)
+              code = machine.succeed(
+                  "curl -s -o /tmp/poll-body -w '%{http_code}' "
+                  "'http://localhost:2586/alerts/json?poll=1'"
+              ).strip()
+              if not code.startswith("2"):
+                  _poll_failures[0] += 1
+                  if _poll_failures[0] <= 2:
+                      machine.log(
+                          "POLL-ERROR status={} body={}".format(
+                              code,
+                              machine.succeed("cat /tmp/poll-body || true")[:300].replace("\n", " | "),
+                          )
+                      )
+                  return []
+              body = machine.succeed("cat /tmp/poll-body")
+              return [
+                  json.loads(line)
+                  for line in body.splitlines()
+                  if line.strip() and json.loads(line).get("event") == "message"
+              ]
 
-        def titles(msgs):
-            return {m.get("title", "") for m in msgs}
+          def titles(msgs):
+              return {m.get("title", "") for m in msgs}
 
-        # Two hosts' worth of synthetic alerts:
-        #
-        #  deadhost - TargetDown plus HighMemoryUsage for an instance nothing
-        #             can reach. The inhibition rule must let the root cause
-        #             through and swallow the symptom; if HighMemoryUsage ever
-        #             shows up below, inhibition is broken in exactly the way
-        #             that turns one outage into a full inbox.
-        #  vm       - TestCritical and TestWarning exercise the severity
-        #             lanes end to end, including the priority each arrives
-        #             with. TestInfo has no matching route and must stay off
-        #             push entirely (email only).
-        post_alerts(
-            [
-                {"labels": {"alertname": "TargetDown", "severity": "critical", "instance": "deadhost:9100", "job": "node"}},
-                {"labels": {"alertname": "HighMemoryUsage", "severity": "warning", "instance": "deadhost:9100"}},
-                {"labels": {"alertname": "TestCritical", "severity": "critical", "instance": "vm:9100"}},
-                {"labels": {"alertname": "TestWarning", "severity": "warning", "instance": "vm:9100"}},
-                {"labels": {"alertname": "TestInfo", "severity": "info", "instance": "vm:9100"}},
-            ]
-        )
+          # Two hosts' worth of synthetic alerts:
+          #
+          #  deadhost - TargetDown plus HighMemoryUsage for an instance nothing
+          #             can reach. The inhibition rule must let the root cause
+          #             through and swallow the symptom; if HighMemoryUsage ever
+          #             shows up below, inhibition is broken in exactly the way
+          #             that turns one outage into a full inbox.
+          #  vm       - TestCritical and TestWarning exercise the severity
+          #             lanes end to end, including the priority each arrives
+          #             with. TestInfo has no matching route and must stay off
+          #             push entirely (email only).
+          post_alerts(
+              [
+                  {"labels": {"alertname": "TargetDown", "severity": "critical", "instance": "deadhost:9100", "job": "node"}},
+                  {"labels": {"alertname": "HighMemoryUsage", "severity": "warning", "instance": "deadhost:9100"}},
+                  {"labels": {"alertname": "TestCritical", "severity": "critical", "instance": "vm:9100"}},
+                  {"labels": {"alertname": "TestWarning", "severity": "warning", "instance": "vm:9100"}},
+                  {"labels": {"alertname": "TestInfo", "severity": "info", "instance": "vm:9100"}},
+              ]
+          )
 
-        # Critical lane: group_wait is 30s, so this also proves the bridge and
-        # ntfy are actually wired together.
-        def critical_arrived(_):
-            return any("TargetDown" in t or "TestCritical" in t for t in titles(messages()))
+          # Critical lane: group_wait is 30s, so this also proves the bridge and
+          # ntfy are actually wired together.
+          def critical_arrived(_):
+              return any("TargetDown" in t or "TestCritical" in t for t in titles(messages()))
 
-        retry(critical_arrived, timeout=timedelta(seconds=120))
+          retry(critical_arrived, timeout=timedelta(seconds=120))
 
-        # Warning lane: its group_wait is shortened to 5s in this machine
-        # (see the warningGroupWait override above), so it arrives almost
-        # immediately. The retry window starts after the critical lane's
-        # assertions, so a minute is generous for the remaining grace period
-        # plus polling slack.
-        def warning_arrived(_):
-            return any("TestWarning" in t for t in titles(messages()))
+          # Warning lane: its group_wait is shortened to 5s in this machine
+          # (see the warningGroupWait override above), so it arrives almost
+          # immediately. The retry window starts after the critical lane's
+          # assertions, so a minute is generous for the remaining grace period
+          # plus polling slack.
+          def warning_arrived(_):
+              return any("TestWarning" in t for t in titles(messages()))
 
-        retry(warning_arrived, timeout=timedelta(seconds=60))
+          retry(warning_arrived, timeout=timedelta(seconds=60))
 
-        msgs = messages()
-        crit = [m for m in msgs if "TestCritical" in m.get("title", "")]
-        warn = [m for m in msgs if "TestWarning" in m.get("title", "")]
-        down = [m for m in msgs if "TargetDown" in m.get("title", "")]
-        inhibited = [m for m in msgs if "HighMemoryUsage" in m.get("title", "")]
-        info = [m for m in msgs if "TestInfo" in m.get("title", "")]
+          msgs = messages()
+          crit = [m for m in msgs if "TestCritical" in m.get("title", "")]
+          warn = [m for m in msgs if "TestWarning" in m.get("title", "")]
+          down = [m for m in msgs if "TargetDown" in m.get("title", "")]
+          inhibited = [m for m in msgs if "HighMemoryUsage" in m.get("title", "")]
+          info = [m for m in msgs if "TestInfo" in m.get("title", "")]
 
-        assert crit and down and warn, "expected all three routed lanes to arrive: {}".format(sorted(titles(msgs)))
-        assert not inhibited, "inhibition failed: HighMemoryUsage notified despite TargetDown firing"
-        assert not info, "info-severity alert reached push; it should be email-only"
+          assert crit and down and warn, "expected all three routed lanes to arrive: {}".format(sorted(titles(msgs)))
+          assert not inhibited, "inhibition failed: HighMemoryUsage notified despite TargetDown firing"
+          assert not info, "info-severity alert reached push; it should be email-only"
 
-        # ntfy priorities: 5 urgent (buzz), 2 low (silent), 3 default.
-        assert crit[0]["priority"] == 5, "critical did not arrive urgent: {}".format(crit[0])
-        assert warn[0]["priority"] == 2, "warning did not arrive silent: {}".format(warn[0])
-        assert down[0]["priority"] == 5, "root-cause alert did not arrive urgent: {}".format(down[0])
+          # ntfy priorities: 5 urgent (buzz), 2 low (silent), 3 default.
+          assert crit[0]["priority"] == 5, "critical did not arrive urgent: {}".format(crit[0])
+          assert warn[0]["priority"] == 2, "warning did not arrive silent: {}".format(warn[0])
+          assert down[0]["priority"] == 5, "root-cause alert did not arrive urgent: {}".format(down[0])
 
-        # Resolved notifications follow their alert's route with
-        # send_resolved enabled on the webhook, so resolutions land on push as
-        # ordinary-priority all-clears - asserted structurally by amtool rather
-        # than here, because Alertmanager batches resolutions on group_interval
-        # and waiting that out does not fit this harness.
-  '';
+          # Resolved notifications follow their alert's route with
+          # send_resolved enabled on the webhook, so resolutions land on push as
+          # ordinary-priority all-clears - asserted structurally by amtool rather
+          # than here, because Alertmanager batches resolutions on group_interval
+          # and waiting that out does not fit this harness.
+    '';
 }

--- a/checks/publish.nix
+++ b/checks/publish.nix
@@ -1,0 +1,211 @@
+# A service's port reaches all three consumers, and nothing is published
+# without being watched.
+#
+# `cg.publish` exists because the same port used to be written down in the
+# module that runs a service and again in the host's proxy block, with nothing
+# to notice when the two disagreed - and because the probe lists, a third
+# copy, had already drifted six entries apart with seven proxied hostnames
+# probed from nowhere. Neither failure is visible in a build: both produce a
+# configuration that evaluates, realises and deploys, and then quietly answers
+# nothing or watches nothing.
+#
+# So this pins the two properties that replace the transcription:
+#
+#   1. One port, three consumers. A module changing its own port option moves
+#      the Caddy vhost, the tunnel ingress and the blackbox probe with it.
+#      Asserted against a stand-in service module rather than a real one, so
+#      the test says what the registry does rather than what sonarr's default
+#      happens to be.
+#
+#   2. The fleet's own publications are complete. Every vhost the two hosts
+#      serve is probed, and every hostname in the tunnel is a vhost on the
+#      host that carries it. This is the assertion that would have caught the
+#      original drift, so it runs against the real hosts, not a fixture.
+#
+# Evaluation only, no VM: everything here is a question about generated
+# configuration, and checks/reverse-proxy.nix already boots Caddy against a
+# `cg.publish` registry to prove the vhosts it generates actually serve.
+{
+  pkgs,
+  self,
+  inputs,
+}:
+let
+  inherit (pkgs) lib;
+
+  # ==========================================================================
+  # 1. One port, three consumers
+  # ==========================================================================
+
+  # Stands in for a service module: it owns a port option and publishes
+  # itself, which is the whole of what a real one does here.
+  fakeService =
+    { config, ... }:
+    {
+      imports = [ ../modules/nixos/publish.nix ];
+
+      options.cg.service.widget.port = lib.mkOption {
+        type = lib.types.port;
+        default = 1234;
+      };
+
+      config.cg.publish.widget = {
+        subdomain = "widget";
+        port = config.cg.service.widget.port;
+      };
+    };
+
+  fixture = inputs.nixpkgs.lib.nixosSystem {
+    system = "x86_64-linux";
+    modules = [
+      inputs.sops-nix.nixosModules.sops
+      ../modules/services/reverse-proxy.nix
+      ../modules/services/cloudflare-tunnel.nix
+      ../modules/services/monitoring/monitoring.nix
+      fakeService
+      (
+        { config, ... }:
+        {
+          # A fleet that is not this one, for the reason checks/
+          # reverse-proxy.nix gives: the assertions below are about the
+          # registry, not about gyarmathy.co.
+          cg.fleet = {
+            domain = "example.test";
+            lan.cidr = "10.0.0.0/24";
+            hosts = { };
+            roles = { };
+          };
+
+          # The port a real module would carry in its own option. Nothing
+          # below repeats the number; the point is that changing it here
+          # changes all three consumers.
+          cg.service.widget.port = 9999;
+
+          cg.publish = {
+            widget.localOnly = false;
+
+            # LAN-only: a vhost and a probe, but no ingress.
+            inside = {
+              port = 4444;
+              localOnly = true;
+            };
+
+            # Published but deliberately unwatched, which is the only way to
+            # be published and unprobed.
+            quiet = {
+              port = 5555;
+              probe = false;
+            };
+          };
+
+          cg.service = {
+            reverse-proxy = {
+              enable = true;
+              email = "test@example.invalid";
+              cloudflareTokenFile = "/dev/null";
+            };
+            cloudflare-tunnel.enable = true;
+            monitoring = {
+              enable = true;
+              prometheus.enable = true;
+            };
+          };
+        }
+      )
+    ];
+  };
+
+  fixtureCfg = fixture.config;
+
+  ingressOf =
+    cfg:
+    lib.filter (rule: rule ? hostname)
+      (builtins.fromJSON cfg.sops.templates."cloudflared-config.yml".content).ingress;
+
+  fixtureIngress = ingressOf fixtureCfg;
+  fixtureProbes = map (p: p.url) fixtureCfg.cg.service.monitoring.httpProbes;
+  fixtureVhosts = fixtureCfg.services.caddy.virtualHosts;
+
+  has = needle: haystack: lib.hasInfix needle haystack;
+
+  fixtureFailures =
+    lib.optional (
+      !(has "reverse_proxy localhost:9999" fixtureVhosts."widget.example.test".extraConfig)
+    ) "the proxy did not follow the module's port to 9999"
+    ++ lib.optional (
+      !(lib.any (r: r.service == "http://localhost:9999") fixtureIngress)
+    ) "the tunnel ingress did not follow the module's port to 9999"
+    ++ lib.optional (
+      !(lib.elem "https://widget.example.test" fixtureProbes)
+    ) "the published service was not probed"
+    ++ lib.optional (!(fixtureVhosts ? "inside.example.test")) "a LAN-only service did not get a vhost"
+    ++ lib.optional (lib.any (
+      r: r.hostname == "inside.example.test"
+    ) fixtureIngress) "a LAN-only service reached the tunnel ingress"
+    ++ lib.optional (
+      !(lib.elem "https://inside.example.test" fixtureProbes)
+    ) "a LAN-only service was not probed"
+    ++ lib.optional (
+      !(fixtureVhosts ? "quiet.example.test")
+    ) "probe = false removed the vhost as well as the probe"
+    ++ lib.optional (lib.elem "https://quiet.example.test" fixtureProbes) "probe = false was ignored";
+
+  # ==========================================================================
+  # 2. The fleet's own publications are complete
+  # ==========================================================================
+
+  hostFailures =
+    name:
+    let
+      cfg = self.nixosConfigurations.${name}.config;
+      domain = cfg.cg.fleet.domain;
+
+      vhosts = lib.attrNames cfg.services.caddy.virtualHosts;
+      probed = map (p: p.url) cfg.cg.service.monitoring.httpProbes;
+
+      # Published without `probe = false`, so it must be watched. Written from
+      # the registry rather than from the vhost list so the message can name
+      # the entry a reader would go and edit.
+      shouldProbe = lib.filterAttrs (_: svc: svc.probe) cfg.cg.publish;
+
+      unprobed = lib.filterAttrs (
+        _: svc: !(lib.elem "https://${svc.subdomain}.${domain}${svc.probePath}" probed)
+      ) shouldProbe;
+
+      ingress = if cfg.cg.service.cloudflare-tunnel.enable then ingressOf cfg else [ ];
+      unserved = lib.filter (rule: !(lib.elem rule.hostname vhosts)) ingress;
+    in
+    map (entry: "${name}: cg.publish.${entry} is published but not probed") (lib.attrNames unprobed)
+    ++ map (
+      rule: "${name}: ${rule.hostname} is in the tunnel but this host's Caddy does not serve it"
+    ) unserved;
+
+  failures =
+    fixtureFailures
+    ++ lib.concatMap hostFailures [
+      "homelab01"
+      "homelab02"
+    ];
+in
+pkgs.runCommand "check-publish"
+  {
+    passAsFile = [ "failures" ];
+    failures = lib.concatStringsSep "\n" failures;
+    # Reported so a passing run says what it covered rather than only that it
+    # passed; a count that quietly falls to zero is the way this check would
+    # stop meaning anything.
+    counts = ''
+      fixture: ${toString (lib.length fixtureProbes)} probes, ${toString (lib.length fixtureIngress)} ingress rules
+      homelab01: ${toString (lib.length (lib.attrNames self.nixosConfigurations.homelab01.config.cg.publish))} published
+      homelab02: ${toString (lib.length (lib.attrNames self.nixosConfigurations.homelab02.config.cg.publish))} published
+    '';
+  }
+  ''
+    if [ -s "$failuresPath" ]; then
+      echo "cg.publish invariants violated:" >&2
+      cat "$failuresPath" >&2
+      exit 1
+    fi
+    printf '%s\n' "$counts"
+    touch $out
+  ''

--- a/checks/reverse-proxy.nix
+++ b/checks/reverse-proxy.nix
@@ -66,6 +66,7 @@
     {
       imports = [
         ../modules/services/reverse-proxy.nix
+        ../modules/nixos/publish.nix
         (import ./stub-secrets.nix {
           secrets."cloudflare/api-token" = token;
           templates."caddy-cloudflare-env" = "CF_API_TOKEN=${token}\n";
@@ -88,31 +89,33 @@
       cg.service.reverse-proxy = {
         enable = true;
         email = "test@example.invalid";
-        # Exactly how the hosts wire it (hosts/homelab01/default.nix:218), so
-        # the test breaks if that indirection changes.
+        # Exactly how the hosts wire it, so the test breaks if that
+        # indirection changes.
         cloudflareTokenFile = config.sops.templates."caddy-cloudflare-env".path;
+      };
 
-        services = {
-          # The common case: a LAN-only service. mkProxyHost's allowlist
-          # includes 127.0.0.1, so a request from inside the VM is permitted.
-          internal = {
-            subdomain = "internal";
-            port = backendPort;
-            localOnly = true;
-            extraConfig = "tls internal";
-          };
+      # What Caddy serves comes from `cg.publish`, contributed to on a real
+      # host by the modules that run the services. Written by hand here for
+      # the same reason `cg.fleet` is overridden above: this test is about the
+      # proxy, not about which services this fleet happens to run.
+      cg.publish = {
+        # The common case: a LAN-only service. mkProxyHost's allowlist
+        # includes 127.0.0.1, so a request from inside the VM is permitted.
+        internal = {
+          port = backendPort;
+          localOnly = true;
+          extraConfig = "tls internal";
+        };
 
-          # An internet-facing service, which takes the other branch of
-          # mkProxyHost entirely: security headers and the rate_limit
-          # directive - the latter being the one thing here that depends on
-          # the Caddy build actually carrying the caddy-ratelimit plugin.
-          public = {
-            subdomain = "public";
-            port = backendPort;
-            localOnly = false;
-            rateLimitProfile = "media";
-            extraConfig = "tls internal";
-          };
+        # An internet-facing service, which takes the other branch of
+        # mkProxyHost entirely: security headers and the rate_limit
+        # directive - the latter being the one thing here that depends on
+        # the Caddy build actually carrying the caddy-ratelimit plugin.
+        public = {
+          port = backendPort;
+          localOnly = false;
+          rateLimitProfile = "media";
+          extraConfig = "tls internal";
         };
       };
 

--- a/docs/plans/structural-cleanup.md
+++ b/docs/plans/structural-cleanup.md
@@ -1,8 +1,8 @@
 # Plan: structural cleanup
 
-Status: drafted 2026-08-28. Items 0 and 1 landed the same day; nothing else started.
+Status: drafted 2026-08-28. Items 0 and 1 landed the same day, item 2 on 2026-08-29; nothing else started.
 
-This is a refactoring plan, not a feature plan. Almost none of it changes what the fleet does; most of it changes where a fact is written down and who is allowed to read it. Two items are exceptions and are marked as such — the secrets re-key (item 4) and closing the service ports (item 5) both change behaviour on running machines. Item 1 is marked `minor`: it changed two lines of generated configuration, neither of which a running host can tell apart, and both are listed under what it landed.
+This is a refactoring plan, not a feature plan. Almost none of it changes what the fleet does; most of it changes where a fact is written down and who is allowed to read it. Two items are exceptions and are marked as such — the secrets re-key (item 4) and closing the service ports (item 5) both change behaviour on running machines. Items 1 and 2 are marked `minor`: each changed a handful of lines of generated configuration, and each lists them under what it landed. Item 2's are the probe list it exists to fix.
 
 The pipeline, the checks harness and the documentation are in good shape and are not the subject here. What has not kept up is the boundary between a host and a module: hosts transcribe facts that modules already know, modules hardcode facts about specific hosts, and the same value is written down in three places with nothing to notice when the copies diverge. Every item below is an instance of that one problem.
 
@@ -10,7 +10,7 @@ The pipeline, the checks harness and the documentation are in good shape and are
 | --- | --------------------------------- | ------ | ----------------- | ---------- | --------------------- |
 | 0   | Gate hygiene and budget           | small  | no                | —          | **done** 2026-08-28   |
 | 1   | A fleet source of truth           | medium | minor             | —          | **done** 2026-08-28   |
-| 2   | Services publish themselves       | large  | no                | 1          | not started           |
+| 2   | Services publish themselves       | large  | minor             | 1          | **done** 2026-08-29   |
 | 3   | Hosts become profiles + toggles   | medium | no                | 2          | not started           |
 | 4   | Per-host secret scoping           | large  | **yes**           | 1          | not started           |
 | 5   | Caddy as the real boundary        | medium | **yes**           | 1, 2       | not started           |
@@ -225,6 +225,39 @@ No port number appears in a host file, `httpProbes` is not written by hand anywh
 This is the item most likely to sprawl, because `cg.publish` is a small piece of framework and framework attracts features. Keep the submodule to the fields the three consumers actually read today. `proxyExtraConfig` and `rateLimitProfile` already exist on the proxy and should move across unchanged rather than being redesigned in passing.
 
 The probe derivation will _add_ seven probes to a running Prometheus, and new probes on services nobody was watching may well fire. That is the point, but do it on a day when investigating an alert is welcome.
+
+### What landed
+
+`modules/nixos/publish.nix` declares `cg.publish`, an `attrsOf submodule` with nine fields, every one of them read by one of the three consumers. Twenty-two service modules contribute an entry each; `reverse-proxy.nix` builds its vhosts from the registry, `cloudflare-tunnel.nix` its ingress from the `localOnly = false` subset, and `monitoring.nix` its `httpProbes` from all of it. Both hosts' `services` blocks, both probe lists and the `lib.mapAttrs` that wired the proxy into the tunnel are gone — 331 lines out of the two host files against 65 added, most of the latter being the block naming which services face the internet.
+
+**Four things the approach did not anticipate.**
+
+_`localOnly` moved off the modules entirely, including ntfy's._ `ntfy.nix` was already publishing itself into the proxy, and it set `localOnly = false` there. Leaving that would have meant the answer to "what does this host expose" was one block in the host file plus however many modules had opinions. It is now the host's block alone, and the field defaults to `true`, so a service nobody decided about stays off the internet.
+
+_Two web UIs cannot both be `prometheus`._ Every host runs a Prometheus and an Alertmanager, so a module that publishes them unconditionally puts the same hostname on two proxies — where DNS picks one and the other holds a certificate for a name it never serves. They are published where Grafana is, since Grafana is what links to them and runs on one host. Reach the peer's at `<host>:9090` over ssh, as before.
+
+_The probe URL is the `instance` label._ Building it as `https://${subdomain}.${domain}${probePath}` with `probePath` defaulting to `/` appended a trailing slash to all seventeen existing probes and renamed every series they produce — silently cutting the dashboards and alert history off from their own past. The default is `""`, and `probePath` is documented as being about that rather than about tidiness.
+
+_Two more transcribed ports were in scope after all._ `scrapeTargets` and `smartctlTargets` were `map (host: "${host}:9100") servers` in both host files — the same duplication one level down, since `9100` and `9633` are set by `monitoring.nix` itself. They now default to every `server` in `cg.fleet` at the port that module gives its own exporters, and neither host writes them. That is what makes the `Done when` true rather than nearly true.
+
+**One thing changed on purpose**, and it is the item's whole point: each host now probes what its own Caddy serves. `cg.publish` is per-host and a host cannot see what its peer publishes, so the union of the two lists covers the fleet exactly once, where the hand-written lists covered thirteen hostnames twice and seven not at all. The redundancy is gone with them: a host that is down takes its own probes with it, and is reported by the node and target-down alerts instead of by its peer's probe.
+
+`checks/publish.nix` pins both halves. Against a stand-in service module it asserts that a port set once reaches the vhost, the ingress and the probe, that `localOnly` keeps a service out of the tunnel but not out of Caddy, and that `probe = false` removes the probe but not the vhost. Against the real hosts it asserts that every published entry is probed and that every tunnel hostname is served by the host carrying it — the assertion that would have caught the original drift. It fails as intended: dropping two entries from the probe derivation names `cg.publish.bazarr` and `cg.publish.suwayomi`.
+
+### Verified, 2026-08-29
+
+**Inert, not assumed.** For homelab01 and homelab02, every entry in the generated `/etc` was compared against the same host built from `b950130`, and every systemd unit within it. **`/etc/caddy/caddy_config` is byte-identical on both hosts** — the same store path, from a registry assembled a completely different way, which is the strongest available statement that no service moved.
+
+Two units differ beyond the five that always do:
+
+- `cloudflared-route-dns.service` on homelab01, by ordering alone. The same ten hostnames are registered; the registry is keyed by module name rather than by subdomain, so `invite` now comes last instead of second. `cloudflared tunnel route dns` is idempotent and each call is `|| true`.
+- `prometheus.service` on both, which is the intended change. Every retained probe URL is byte-identical; homelab01 gains `alertmanager`, `bazarr`, `grimmory`, `invite`, `ntfy` and `prometheus` and loses `downloads` and `adguard2` to homelab02, which gains `shelfmark` and `suwayomi` and loses the eleven the gateway fronts. The node and smartctl target lists are unchanged, which is the check on the `scrapeTargets` default.
+
+The five that always move — `system-path`, `dbus-1`, `user-units`, and the `nixos-upgrade`, `nixos-deploy-metrics`, `digital-garden-build`, `dbus-broker` and `polkit` units — are the same set item 1 identified, and move for the same reason: they carry `system.configurationRevision`.
+
+All eleven checks pass, including the reverse-proxy VM test now driven from a `cg.publish` registry rather than the deleted `services` option. `nix fmt -- --ci` is clean, all three hosts build, and `devShells`, `packages` and `apps` still evaluate.
+
+The `Done when` was checked by script. One port literal remains in a host file: `monitoring.alertmanager.ntfy.port = 8015` on homelab02, which is not a transcription of anything — it is a genuine host-specific bind choice, off the module's default because gluetun's control server holds 8000 on that machine. Moving it into the module would change homelab01's bridge port for no reason.
 
 ---
 

--- a/docs/plans/structural-cleanup.md
+++ b/docs/plans/structural-cleanup.md
@@ -238,9 +238,13 @@ _Two web UIs cannot both be `prometheus`._ Every host runs a Prometheus and an A
 
 _The probe URL is the `instance` label._ Building it as `https://${subdomain}.${domain}${probePath}` with `probePath` defaulting to `/` appended a trailing slash to all seventeen existing probes and renamed every series they produce — silently cutting the dashboards and alert history off from their own past. The default is `""`, and `probePath` is documented as being about that rather than about tidiness.
 
-_Two more transcribed ports were in scope after all._ `scrapeTargets` and `smartctlTargets` were `map (host: "${host}:9100") servers` in both host files — the same duplication one level down, since `9100` and `9633` are set by `monitoring.nix` itself. They now default to every `server` in `cg.fleet` at the port that module gives its own exporters, and neither host writes them. That is what makes the `Done when` true rather than nearly true.
+_Three more transcribed ports were in scope after all._ `scrapeTargets` and `smartctlTargets` were `map (host: "${host}:9100") servers` in both host files — the same duplication one level down, since `9100` and `9633` are set by `monitoring.nix` itself. They now default to every `server` in `cg.fleet` at the port that module gives its own exporters, and neither host writes them.
+
+The third was the alertmanager-ntfy bridge's `port = 8015` on homelab02, which is the only one of these that changes a running host. It was not a copy of anything — it was a host dodging the module's default, because 8000 is gluetun's control server wherever the media stack runs and the bridge lost that bind race on homelab02 every start. Repairing it per-host left the collision sitting in the default, one host away from happening again, so 8015 is now the default and homelab02 says nothing. The bridge on homelab01 moves 8000 → 8015 with it. Both ends of that port are read from the same option, so the move is self-consistent: the generated diff is Alertmanager's webhook URL and the bridge's listen address, and nothing else. With it gone, no host file contains a port number at all.
 
 **One thing changed on purpose**, and it is the item's whole point: each host now probes what its own Caddy serves. `cg.publish` is per-host and a host cannot see what its peer publishes, so the union of the two lists covers the fleet exactly once, where the hand-written lists covered thirteen hostnames twice and seven not at all. The redundancy is gone with them: a host that is down takes its own probes with it, and is reported by the node and target-down alerts instead of by its peer's probe.
+
+_The one literal that mattered was in a check._ `checks/monitoring.nix` asserted against `http://127.0.0.1:8000/hook`, transcribed from the module. Moving the bridge's default broke that test — and broke it *as* "unauthenticated webhook post was not rejected", a message about authentication that had nothing to do with the cause. Its `testScript` is now a function of `nodes` and reads the port from the option, which is the same lesson as the rest of this item arriving from the direction of a test.
 
 `checks/publish.nix` pins both halves. Against a stand-in service module it asserts that a port set once reaches the vhost, the ingress and the probe, that `localOnly` keeps a service out of the tunnel but not out of Caddy, and that `probe = false` removes the probe but not the vhost. Against the real hosts it asserts that every published entry is probed and that every tunnel hostname is served by the host carrying it — the assertion that would have caught the original drift. It fails as intended: dropping two entries from the probe derivation names `cg.publish.bazarr` and `cg.publish.suwayomi`.
 
@@ -248,16 +252,19 @@ _Two more transcribed ports were in scope after all._ `scrapeTargets` and `smart
 
 **Inert, not assumed.** For homelab01 and homelab02, every entry in the generated `/etc` was compared against the same host built from `b950130`, and every systemd unit within it. **`/etc/caddy/caddy_config` is byte-identical on both hosts** — the same store path, from a registry assembled a completely different way, which is the strongest available statement that no service moved.
 
-Two units differ beyond the five that always do:
+Four units differ beyond the five that always do:
 
 - `cloudflared-route-dns.service` on homelab01, by ordering alone. The same ten hostnames are registered; the registry is keyed by module name rather than by subdomain, so `invite` now comes last instead of second. `cloudflared tunnel route dns` is idempotent and each call is `|| true`.
+- `alertmanager.service` and `alertmanager-ntfy.service` on homelab01, by the bridge port alone: `http://127.0.0.1:8000/hook` becomes `:8015` in Alertmanager's webhook config, and the bridge's `http.addr` follows. Nothing else in either file moves. homelab02 is unaffected — it was already on 8015.
 - `prometheus.service` on both, which is the intended change. Every retained probe URL is byte-identical; homelab01 gains `alertmanager`, `bazarr`, `grimmory`, `invite`, `ntfy` and `prometheus` and loses `downloads` and `adguard2` to homelab02, which gains `shelfmark` and `suwayomi` and loses the eleven the gateway fronts. The node and smartctl target lists are unchanged, which is the check on the `scrapeTargets` default.
 
 The five that always move — `system-path`, `dbus-1`, `user-units`, and the `nixos-upgrade`, `nixos-deploy-metrics`, `digital-garden-build`, `dbus-broker` and `polkit` units — are the same set item 1 identified, and move for the same reason: they carry `system.configurationRevision`.
 
 All eleven checks pass, including the reverse-proxy VM test now driven from a `cg.publish` registry rather than the deleted `services` option. `nix fmt -- --ci` is clean, all three hosts build, and `devShells`, `packages` and `apps` still evaluate.
 
-The `Done when` was checked by script. One port literal remains in a host file: `monitoring.alertmanager.ntfy.port = 8015` on homelab02, which is not a transcription of anything — it is a genuine host-specific bind choice, off the module's default because gluetun's control server holds 8000 on that machine. Moving it into the module would change homelab01's bridge port for no reason.
+**`publish` is in the `ci.yml` matrix**, which it was not on the first pass — the flake had eleven checks and the matrix ten, so `lint`'s "Every flake check is in the matrix" audit would have failed the PR. That is item 0's audit doing exactly the job it was added for, on the first check added after it landed. Both directions were re-confirmed locally: with the entry the audit reports eleven, without it, it names `publish` and exits 1. Its own shard rather than a group, since it evaluates two whole hosts; item 0's grouping note is about the cheap static checks and only applies once shard count becomes the cost.
+
+The `Done when` was checked by script, and holds without exception: no port number appears in any host file.
 
 ---
 

--- a/hosts/homelab01/default.nix
+++ b/hosts/homelab01/default.nix
@@ -192,7 +192,6 @@ in
     # see modules/services/digital-garden/publish-filter.py.
     digital-garden = {
       enable = true;
-      port = 8086;
       baseUrl = "garden.${domain}";
       siteTitle = "Cory Gyarmathy";
       footerLinks = {
@@ -212,144 +211,15 @@ in
     # -------------------------------------------------------------------------
     # Reverse Proxy (Caddy)
     # -------------------------------------------------------------------------
+    # What it serves is not written here. Each service module contributes its
+    # own entry to `cg.publish` (modules/nixos/publish.nix) and Caddy is built
+    # from that, so a port lives in exactly one place. The one decision left
+    # to this host is which of them answer from outside the LAN, and that is
+    # the `cg.publish` block further down.
     reverse-proxy = {
       enable = true;
       email = "cory@${domain}";
       cloudflareTokenFile = config.sops.templates."caddy-cloudflare-env".path;
-
-      services = {
-        # Media - User Facing
-        jellyfin = {
-          subdomain = "jellyfin";
-          port = 8096;
-          localOnly = false;
-          rateLimitProfile = "media"; # Higher limits for media streaming
-        };
-        requests = {
-          subdomain = "requests";
-          port = 5055;
-          localOnly = false;
-          rateLimitProfile = "media"; # Users browse content frequently
-        };
-        invite = {
-          subdomain = "invite";
-          port = 5690;
-          localOnly = false;
-        };
-
-        # Media - Admin
-        sonarr = {
-          subdomain = "sonarr";
-          port = 8989;
-          localOnly = true;
-        };
-        radarr = {
-          subdomain = "radarr";
-          port = 7878;
-          localOnly = true;
-        };
-        prowlarr = {
-          subdomain = "prowlarr";
-          port = 9696;
-          localOnly = true;
-        };
-        bazarr = {
-          subdomain = "bazarr";
-          port = 6767;
-          localOnly = true;
-        };
-        autobrr = {
-          subdomain = "autobrr";
-          port = 7474;
-          localOnly = true;
-        };
-
-        # Management
-        cleanuparr = {
-          subdomain = "cleanuparr";
-          port = 11011;
-          localOnly = true;
-        };
-
-        # Infrastructure (this host's AdGuard)
-        adguard = {
-          subdomain = "adguard";
-          port = 3080;
-          localOnly = true;
-        };
-        grafana = {
-          subdomain = "grafana";
-          port = 3000;
-          localOnly = true;
-        };
-
-        # Monitoring internals. LAN-only like the other admin UIs - remote
-        # access stays ssh-tunnelled. The Alertmanager UI is where silences
-        # live and Prometheus' graph view backs every alert expression, so
-        # both are one click from Grafana instead of an ssh port-forward.
-        prometheus-ui = {
-          subdomain = "prometheus";
-          port = 9090;
-          localOnly = true;
-        };
-        alertmanager-ui = {
-          subdomain = "alertmanager";
-          port = 9093;
-          localOnly = true;
-        };
-
-        # RSS
-        rss = {
-          subdomain = "rss";
-          port = 8082;
-          localOnly = false;
-        };
-        read = {
-          subdomain = "read";
-          port = 8083;
-          localOnly = false;
-        };
-
-        # Digital garden - static, public, no backend to protect
-        garden = {
-          subdomain = "garden";
-          port = 8086;
-          localOnly = false;
-        };
-
-        # Maintainerr - media library maintenance
-        maintainerr = {
-          subdomain = "maintainerr";
-          port = 6246;
-          localOnly = true;
-          rateLimitProfile = "none"; # Scans entire Jellyfin library
-        };
-
-        # Reading
-        kavita = {
-          subdomain = "kavita";
-          port = 5000;
-          localOnly = false; # readers need external access
-          rateLimitProfile = "media";
-        };
-        audiobookshelf = {
-          subdomain = "audiobookshelf";
-          port = 13378;
-          localOnly = false; # listeners need external access for mobile apps
-          rateLimitProfile = "media";
-        };
-        # Runs on the storage host, where the library is on local disk rather
-        # than the NFS mount -- see the header of
-        # modules/services/media-stack/grimmory.nix. Proxied from here because
-        # this host owns the Cloudflare tunnel.
-        grimmory = {
-          subdomain = "grimmory";
-          port = 6060;
-          upstream = storage.address;
-          localOnly = false; # readers need external access
-          rateLimitProfile = "media";
-        };
-      };
     };
 
     monitoring = {
@@ -369,83 +239,12 @@ in
 
       grafana.enable = true;
       zfs.enable = false;
-      scrapeTargets = map (host: "${host}:9100") servers;
-      smartctlTargets = map (host: "${host}:9633") servers;
       cloudflaredTarget = "${gateway}:20241";
 
-      httpProbes = [
-        {
-          name = "jellyfin";
-          url = "https://jellyfin.${domain}";
-        }
-        {
-          name = "requests";
-          url = "https://requests.${domain}";
-        }
-        {
-          name = "sonarr";
-          url = "https://sonarr.${domain}";
-        }
-        {
-          name = "radarr";
-          url = "https://radarr.${domain}";
-        }
-        {
-          name = "prowlarr";
-          url = "https://prowlarr.${domain}";
-        }
-        {
-          name = "downloads";
-          url = "https://downloads.${domain}";
-        }
-        {
-          name = "grafana";
-          url = "https://grafana.${domain}";
-        }
-        {
-          name = "adguard-01";
-          url = "https://adguard.${domain}";
-        }
-        {
-          name = "adguard-02";
-          url = "https://adguard2.${domain}";
-        }
-        {
-          name = "autobrr";
-          url = "https://autobrr.${domain}";
-        }
-        {
-          name = "miniflux";
-          url = "https://rss.${domain}";
-        }
-        {
-          name = "wallabag";
-          url = "https://read.${domain}";
-        }
-        {
-          # /health rather than the bare root the other entries use: this is
-          # the readiness endpoint cleanuparr's podman healthcheck used to hit,
-          # so probing it keeps exactly the signal that healthcheck gave.
-          name = "cleanuparr";
-          url = "https://cleanuparr.${domain}/health";
-        }
-        {
-          name = "maintainerr";
-          url = "https://maintainerr.${domain}";
-        }
-        {
-          name = "kavita";
-          url = "https://kavita.${domain}";
-        }
-        {
-          name = "audiobookshelf";
-          url = "https://audiobookshelf.${domain}";
-        }
-        {
-          name = "garden";
-          url = "https://garden.${domain}";
-        }
-      ];
+      # httpProbes is not set: it defaults to every service this host
+      # publishes. The two hosts used to hand-maintain overlapping lists that
+      # had drifted apart by six entries, with seven proxied hostnames probed
+      # from nowhere.
     };
 
     # -------------------------------------------------------------------------
@@ -462,7 +261,6 @@ in
     adguard-home = {
       enable = true;
       role = "primary";
-      webPort = 3080;
       bindAddresses = [
         "127.0.0.1"
         fleet.hosts.${hostName}.address
@@ -567,18 +365,11 @@ in
     # -------------------------------------------------------------------------
     # Cloudflare Tunnel
     # -------------------------------------------------------------------------
-    cloudflare-tunnel = {
-      enable = true;
-
-      # Map reverse-proxy services to cloudflare-tunnel format
-      # Only pass the fields that cloudflare-tunnel understands
-      services = lib.mapAttrs (name: svc: {
-        subdomain = svc.subdomain;
-        port = svc.port;
-        upstream = svc.upstream;
-        localOnly = svc.localOnly;
-      }) config.cg.service.reverse-proxy.services;
-    };
+    # Ingress is every `cg.publish` entry with `localOnly = false`, read
+    # directly by the module. The hand-written mapAttrs that used to sit here
+    # was module-to-module wiring in a host file: the one place least able to
+    # notice when the two sides stopped agreeing.
+    cloudflare-tunnel.enable = true;
 
     # -------------------------------------------------------------------------
     # Commercial Detection (Comskip)
@@ -616,6 +407,46 @@ in
         # Performance
         threads = 4; # Parallel processing threads
       };
+    };
+  };
+
+  # ============================================================================
+  # What this host puts on the internet
+  # ============================================================================
+  # Everything else about a publication - its hostname, its port, its
+  # rate-limit profile - comes from the module that runs the service
+  # (modules/nixos/publish.nix). Reachability does not: whether strangers can
+  # reach a service is a decision about this fleet, not a property of the
+  # software, so it is the one field a host writes.
+  #
+  # `localOnly` defaults to true, so this list is the complete answer to "what
+  # is exposed", and forgetting to add something here fails closed. Anything
+  # named below is also in the Cloudflare tunnel's ingress, which is what
+  # actually carries the traffic.
+  cg.publish = {
+    jellyfin.localOnly = false;
+    seerr.localOnly = false; # requests.
+    wizarr.localOnly = false; # invite; the link is handed to new users.
+    miniflux.localOnly = false; # rss.
+    wallabag.localOnly = false; # read.
+    digital-garden.localOnly = false; # garden; static and public by design.
+    kavita.localOnly = false; # readers need it away from the LAN
+    audiobookshelf.localOnly = false; # mobile apps stream from outside
+    ntfy.localOnly = false; # push to phones on mobile data is the whole point
+
+    # Grimmory is the one service this host proxies without running: it lives
+    # on the storage host, where the library is on local disk rather than the
+    # NFS mount (see the header of modules/services/media-stack/grimmory.nix),
+    # and it is published from here because this host owns the tunnel.
+    #
+    # So the entry is written here rather than by the module - but the port is
+    # still read from the module's own option, and the address from the fleet,
+    # so neither is transcribed.
+    grimmory = {
+      port = config.cg.service.grimmory.port;
+      upstream = storage.address;
+      localOnly = false; # readers need external access
+      rateLimitProfile = "media";
     };
   };
 

--- a/hosts/homelab02/default.nix
+++ b/hosts/homelab02/default.nix
@@ -185,14 +185,12 @@ in
         # only the local alertmanager-ntfy bridge, so either host can still
         # deliver on its own if the other is down.
         #
-        # Off 8000 because gluetun's control server is published there
-        # (qbittorrent.nix) - with the shared default the bridge lost the bind
-        # race on every start, and the 2026-08-26 upgrade that introduced it
-        # was marked failed by its own activation.
-        ntfy = {
-          enable = true;
-          port = 8015;
-        };
+        # The bridge's port is the module's default, which is off 8000 for
+        # this host's sake: gluetun's control server is published there
+        # (qbittorrent.nix), and with the old shared default the bridge lost
+        # the bind race on every start - the 2026-08-26 upgrade that
+        # introduced it was marked failed by its own activation.
+        ntfy.enable = true;
         email = {
           to = "cory@${domain}";
           from = "alerts@${domain}";

--- a/hosts/homelab02/default.nix
+++ b/hosts/homelab02/default.nix
@@ -202,66 +202,13 @@ in
       };
       grafana.enable = false;
       zfs.enable = true;
-      scrapeTargets = map (host: "${host}:9100") servers;
-      smartctlTargets = map (host: "${host}:9633") servers;
       cloudflaredTarget = "${gateway}:20241";
 
       vpn.enable = true;
 
-      httpProbes = [
-        {
-          name = "jellyfin";
-          url = "https://jellyfin.${domain}";
-        }
-        {
-          name = "requests";
-          url = "https://requests.${domain}";
-        }
-        {
-          name = "sonarr";
-          url = "https://sonarr.${domain}";
-        }
-        {
-          name = "radarr";
-          url = "https://radarr.${domain}";
-        }
-        {
-          name = "prowlarr";
-          url = "https://prowlarr.${domain}";
-        }
-        {
-          name = "downloads";
-          url = "https://downloads.${domain}";
-        }
-        {
-          name = "grafana";
-          url = "https://grafana.${domain}";
-        }
-        {
-          name = "adguard-01";
-          url = "https://adguard.${domain}";
-        }
-        {
-          name = "adguard-02";
-          url = "https://adguard2.${domain}";
-        }
-        {
-          name = "autobrr";
-          url = "https://autobrr.${domain}";
-        }
-        {
-          name = "miniflux";
-          url = "https://rss.${domain}";
-        }
-        {
-          name = "wallabag";
-          url = "https://read.${domain}";
-        }
-        {
-          name = "filebrowser";
-          url = "https://filebrowser.${domain}";
-        }
-      ];
+      # httpProbes is not set: it defaults to every service this host
+      # publishes. This host and its peer used to hand-maintain overlapping
+      # lists that had drifted apart by six entries.
     };
 
     orphan-cleanup = {
@@ -301,62 +248,19 @@ in
     # -------------------------------------------------------------------------
     # Reverse Proxy (Caddy)
     # -------------------------------------------------------------------------
+    # What it serves is not written here. Each service module contributes its
+    # own entry to `cg.publish` (modules/nixos/publish.nix) and Caddy is built
+    # from that, so a port lives in exactly one place.
+    #
+    # Nothing this host publishes is internet-facing, so it has no `cg.publish`
+    # block of its own: `localOnly` defaults to true. The tunnel lives on the
+    # gateway, and grimmory - the one service here that answers from outside -
+    # is published from there.
     reverse-proxy = {
       enable = true;
       email = "cory@${domain}";
       cloudflareTokenFile = config.sops.templates."caddy-cloudflare-env".path;
 
-      services = {
-        # Download client
-        downloads = {
-          subdomain = "downloads";
-          port = 8080; # qBittorrent
-          localOnly = true;
-          proxyExtraConfig = ''
-            # qBittorrent auth fix - strip headers that trigger CSRF protection
-            header_up -Origin
-            header_up -Referer
-            # Increase timeouts for large torrent lists
-            transport http {
-              response_header_timeout 30s
-            }
-          '';
-        };
-
-        # This host's AdGuard instance
-        adguard2 = {
-          subdomain = "adguard2";
-          port = 3080;
-          localOnly = true;
-        };
-
-        # FileBrowser
-        filebrowser = {
-          subdomain = "filebrowser";
-          port = 8085;
-          rateLimitProfile = "media";
-          localOnly = true;
-        };
-
-        # Shelfmark. Published by the gluetun container on this host, so from
-        # Caddy's point of view it is just another local port.
-        shelfmark = {
-          subdomain = "shelfmark";
-          port = 8084;
-          localOnly = true; # acquisition tooling
-        };
-
-        # Suwayomi. Not behind gluetun, so this is an ordinary local port.
-        suwayomi = {
-          subdomain = "suwayomi";
-          port = 4567;
-          localOnly = true;
-          rateLimitProfile = "media"; # it is a reader as well as a downloader
-        };
-
-        # Future NAS-related services would go here
-        # e.g., syncthing, nextcloud, etc.
-      };
     };
 
     # -------------------------------------------------------------------------
@@ -365,7 +269,6 @@ in
     adguard-home = {
       enable = true;
       role = "secondary";
-      webPort = 3080;
       bindAddresses = [
         "127.0.0.1"
         fleet.hosts.${hostName}.address

--- a/modules/nixos/publish.nix
+++ b/modules/nixos/publish.nix
@@ -1,0 +1,162 @@
+# How a service asks to be published.
+#
+# A port used to be written down twice: once in the module that runs the
+# service, and again as a literal in the host's reverse-proxy block. Changing
+# the module's port produced no error - it produced a proxy pointing at
+# nothing. The probe lists were a third copy, hand-maintained per host, and
+# had already drifted: seven proxied hostnames were probed from nowhere, two
+# of them published to the internet.
+#
+# So the direction is inverted. The module that runs a service is the only
+# thing that knows its port, so it is the thing that declares how it should be
+# published:
+#
+#   cg.publish.sonarr = {
+#     subdomain = "sonarr";
+#     port = cfg.port;        # the module's own option, never a copy
+#     rateLimitProfile = "admin";
+#   };
+#
+# and the three consumers read this registry instead of a hand-written list:
+#
+# - modules/services/reverse-proxy.nix builds a Caddy vhost per entry.
+# - modules/services/cloudflare-tunnel.nix builds its ingress from the
+#   entries with `localOnly = false`.
+# - modules/services/monitoring/monitoring.nix derives `httpProbes` from all
+#   of them, which is what closes the drift: a service that is published and
+#   not probed is no longer expressible.
+#
+# WHAT DOES NOT BELONG HERE. `localOnly` is the exception that proves the
+# rule. Whether a service answers from outside the LAN is a policy choice
+# about this fleet, not a property of the software, so modules leave it alone
+# and each host states its own set in one block. It defaults to `true`:
+# forgetting to decide keeps a service off the internet.
+#
+# KEEP THIS SMALL. It is a piece of framework, and framework attracts
+# features. Every option below is read by one of the three consumers named
+# above; nothing here exists to be general.
+#
+# This declaration is imported by the modules that contribute to it as well as
+# by the ones that read it, for the reason modules/nixos/fleet.nix gives: a
+# check that instantiates a single service module has to get the option along
+# with it. Importing the same path from several modules is free.
+{ lib, ... }:
+{
+  options.cg.publish = lib.mkOption {
+    default = { };
+    description = ''
+      Services this host publishes, keyed by the module that runs them. The
+      reverse proxy, the Cloudflare tunnel and the blackbox probes are all
+      derived from this; see `modules/nixos/publish.nix` for what belongs in
+      an entry.
+    '';
+    type = lib.types.attrsOf (
+      lib.types.submodule (
+        { name, ... }:
+        {
+          options = {
+            subdomain = lib.mkOption {
+              type = lib.types.str;
+              default = name;
+              defaultText = lib.literalExpression "the attribute name";
+              description = ''
+                Hostname this service answers to, without the domain. Defaults
+                to the attribute name, which is the module's name -- several
+                services are known to users by something else (`requests` for
+                seerr, `read` for wallabag), and those say so.
+              '';
+            };
+
+            port = lib.mkOption {
+              type = lib.types.port;
+              description = ''
+                Port the service listens on. Always the module's own port
+                option, never a copy of its value: a copy is what this
+                registry exists to remove.
+              '';
+            };
+
+            upstream = lib.mkOption {
+              type = lib.types.str;
+              default = "localhost";
+              example = "10.20.2.130";
+              description = ''
+                Host the service actually runs on. Defaults to this machine.
+                Set it to another node's address to proxy a service hosted
+                there -- the traffic crosses the LAN in the clear, so this is
+                for links inside the trusted network only. Take the address
+                from `config.cg.fleet`, not from a literal.
+              '';
+            };
+
+            localOnly = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = ''
+                Restrict this service to the local network. `false` also puts
+                it into the Cloudflare tunnel's ingress, which is what makes
+                it reachable from the internet.
+
+                A host decides this, not the module that publishes the
+                service. The default is the safe direction on purpose.
+              '';
+            };
+
+            rateLimitProfile = lib.mkOption {
+              type = lib.types.enum [
+                "media"
+                "admin"
+                "none"
+              ];
+              default = "admin";
+              description = ''
+                Rate limiting profile the proxy applies to internet-facing
+                requests. A property of the traffic the service sees, so the
+                module that runs it chooses.
+              '';
+            };
+
+            probe = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = ''
+                Whether blackbox_exporter probes this service. Leave it on
+                unless the service has no useful GET, and say why when
+                turning it off.
+              '';
+            };
+
+            probePath = lib.mkOption {
+              type = lib.types.str;
+              default = "";
+              example = "/health";
+              description = ''
+                Path the probe requests, appended to the URL. Only worth
+                setting when the service has a readiness endpoint that says
+                more than its front page does.
+
+                Empty rather than `/` for the default, which is not cosmetic:
+                the probe URL becomes the `instance` label on every series
+                blackbox_exporter produces, so a trailing slash would rename
+                the lot and cut every existing dashboard and alert off from
+                its own history.
+              '';
+            };
+
+            extraConfig = lib.mkOption {
+              type = lib.types.lines;
+              default = "";
+              description = "Additional Caddy configuration for this vhost";
+            };
+
+            proxyExtraConfig = lib.mkOption {
+              type = lib.types.lines;
+              default = "";
+              description = "Additional Caddy config inside the reverse_proxy block";
+            };
+          };
+        }
+      )
+    );
+  };
+}

--- a/modules/services/adguard-home.nix
+++ b/modules/services/adguard-home.nix
@@ -173,8 +173,12 @@ let
 
 in
 {
-  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
-  imports = [ ../nixos/fleet.nix ];
+  # Reads config.cg.fleet and contributes to config.cg.publish, so it declares
+  # both - see modules/nixos/fleet.nix and modules/nixos/publish.nix.
+  imports = [
+    ../nixos/fleet.nix
+    ../nixos/publish.nix
+  ];
 
   options.cg.service.adguard-home = {
     enable = lib.mkEnableOption "AdGuard Home DNS server";
@@ -244,6 +248,14 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # The web UI. Both instances run this module, so the hostname is the one
+    # part a host has to choose for itself - the secondary answers to
+    # `adguard2`, which is the name in the storage host's rewrite list above.
+    cg.publish.adguard-home = {
+      subdomain = if cfg.role == "primary" then "adguard" else "adguard2";
+      port = cfg.webPort;
+    };
+
     # Configure secrets
     sops.secrets."adguard/admin-password" = {
       sopsFile = ../../secrets/homelab.yaml;

--- a/modules/services/cloudflare-tunnel.nix
+++ b/modules/services/cloudflare-tunnel.nix
@@ -5,6 +5,11 @@
 # - Automatic DNS management via tunnel routing
 # - Protection against DDoS and direct IP exposure
 #
+# WHAT IT EXPOSES:
+# Every entry in `cg.publish` with `localOnly = false` - the same registry the
+# reverse proxy reads, so the two cannot disagree about a port or a hostname.
+# See modules/nixos/publish.nix.
+#
 # Architecture:
 # - cloudflared daemon runs on the fleet's gateway host
 # - Registers DNS routes in Cloudflare
@@ -25,10 +30,14 @@
 let
   cfg = config.cg.service.cloudflare-tunnel;
 
+  # Everything this host publishes that is not LAN-only. `cg.publish` is the
+  # same registry the reverse proxy builds its vhosts from (see
+  # modules/nixos/publish.nix), so the tunnel and Caddy cannot disagree about
+  # a port; the filter is the whole of what makes a service public.
+  publicServices = lib.filterAttrs (_: svc: !svc.localOnly) config.cg.publish;
+
   # Build the list of public hostnames at eval time
-  publicHostnames = map (svc: "${svc.subdomain}.${cfg.domain}") (
-    lib.attrValues (lib.filterAttrs (_: svc: !svc.localOnly) cfg.services)
-  );
+  publicHostnames = map (svc: "${svc.subdomain}.${cfg.domain}") (lib.attrValues publicServices);
 
   routeScript = pkgs.writeShellScript "cloudflared-route-dns" ''
     TUNNEL_ID=$(cat ${config.sops.secrets."cloudflare/tunnel-id".path})
@@ -41,8 +50,12 @@ let
   '';
 in
 {
-  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
-  imports = [ ../nixos/fleet.nix ];
+  # Reads config.cg.fleet and config.cg.publish, so it declares both - see
+  # modules/nixos/fleet.nix and modules/nixos/publish.nix.
+  imports = [
+    ../nixos/fleet.nix
+    ../nixos/publish.nix
+  ];
 
   options.cg.service.cloudflare-tunnel = {
     enable = lib.mkEnableOption "Cloudflare Tunnel for zero-trust access";
@@ -54,39 +67,6 @@ in
       description = "Domain name for services";
     };
 
-    services = lib.mkOption {
-      type = lib.types.attrsOf (
-        lib.types.submodule {
-          options = {
-            subdomain = lib.mkOption {
-              type = lib.types.str;
-              description = "Subdomain for this service";
-            };
-            port = lib.mkOption {
-              type = lib.types.port;
-              description = "Port the service listens on";
-            };
-            upstream = lib.mkOption {
-              type = lib.types.str;
-              default = "localhost";
-              example = "homelab02";
-              description = ''
-                Host the service runs on. Defaults to this machine -- cloudflared
-                bypasses Caddy and connects to the origin directly, so a service
-                living on another node needs its hostname here too.
-              '';
-            };
-            localOnly = lib.mkOption {
-              type = lib.types.bool;
-              default = false;
-              description = "If true, exclude from tunnel (local network only)";
-            };
-          };
-        }
-      );
-      default = { };
-      description = "Services to expose through the tunnel";
-    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -125,15 +105,18 @@ in
 
           # Ingress rules - routes traffic based on hostname
           ingress =
-            # Public services only (where localOnly = false)
-            (lib.mapAttrsToList (name: svc: {
+            # Public services only (where localOnly = false). cloudflared
+            # bypasses Caddy and connects to the origin directly, so a service
+            # living on another node reaches the tunnel through the same
+            # `upstream` the proxy uses.
+            (lib.mapAttrsToList (_name: svc: {
               hostname = "${svc.subdomain}.${cfg.domain}";
               service = "http://${svc.upstream}:${toString svc.port}";
               originRequest = {
                 httpHostHeader = "${svc.subdomain}.${cfg.domain}";
                 noTLSVerify = true;
               };
-            }) (lib.filterAttrs (_: svc: !svc.localOnly) cfg.services))
+            }) publicServices)
 
             # Required catch-all rule
             ++ [

--- a/modules/services/digital-garden/digital-garden.nix
+++ b/modules/services/digital-garden/digital-garden.nix
@@ -13,8 +13,8 @@
 #   filters it down to published notes, then runs the site generator over the
 #   filtered tree.
 # - Serving is plain HTTP on 127.0.0.1:<port>, which lets this slot into
-#   cg.service.reverse-proxy.services (TLS + LAN) and
-#   cg.service.cloudflare-tunnel.services (public) with no special casing.
+#   cg.publish (TLS and LAN through Caddy, the internet through the tunnel)
+#   with no special casing.
 #
 # Where the vault comes from is `source`:
 # - "git" clones the notes repo, so publishing waits on whatever commits it.
@@ -287,7 +287,10 @@ let
 in
 {
   # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
-  imports = [ ../../nixos/fleet.nix ];
+  imports = [
+    ../../nixos/fleet.nix
+    ../../nixos/publish.nix
+  ];
 
   options.cg.service.digital-garden = {
     enable = lib.mkEnableOption "Digital garden (published subset of the Obsidian vault)";
@@ -442,6 +445,11 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    cg.publish.digital-garden = {
+      subdomain = "garden";
+      port = cfg.port;
+    };
+
     sops.secrets = lib.mkMerge [
       (lib.mkIf (cfg.source == "git") {
         "digital-garden/deploy-key" = {

--- a/modules/services/filebrowser.nix
+++ b/modules/services/filebrowser.nix
@@ -34,6 +34,10 @@ let
   stack = config.cg.service.media-stack;
 in
 {
+  # Contributes to config.cg.publish, so it declares it - see
+  # modules/nixos/publish.nix.
+  imports = [ ../nixos/publish.nix ];
+
   options.cg.service.filebrowser = {
     enable = lib.mkEnableOption "File Browser web file manager";
 
@@ -45,6 +49,11 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    cg.publish.filebrowser = {
+      port = cfg.port;
+      rateLimitProfile = "media"; # a directory listing is many thumbnails
+    };
+
     # Require media-stack infrastructure
     assertions = [
       {

--- a/modules/services/media-stack/audiobookshelf.nix
+++ b/modules/services/media-stack/audiobookshelf.nix
@@ -32,6 +32,10 @@ let
   stack = config.cg.service.media-stack;
 in
 {
+  # Contributes to config.cg.publish, so it declares it - see
+  # modules/nixos/publish.nix.
+  imports = [ ../../nixos/publish.nix ];
+
   options.cg.service.audiobookshelf = {
     enable = lib.mkEnableOption "Audiobookshelf audiobook and podcast server";
 
@@ -43,6 +47,11 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    cg.publish.audiobookshelf = {
+      port = cfg.port;
+      rateLimitProfile = "media"; # streams audio, chapter by chapter
+    };
+
     # Require media-stack infrastructure
     assertions = [
       {

--- a/modules/services/media-stack/autobrr.nix
+++ b/modules/services/media-stack/autobrr.nix
@@ -30,6 +30,10 @@ let
   stack = config.cg.service.media-stack;
 in
 {
+  # Contributes to config.cg.publish, so it declares it - see
+  # modules/nixos/publish.nix.
+  imports = [ ../../nixos/publish.nix ];
+
   options.cg.service.autobrr = {
     enable = lib.mkEnableOption "Autobrr torrent automation";
 
@@ -41,6 +45,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # Published under its own name at the module's own port; whether it
+    # answers from outside the LAN is the host's call.
+    cg.publish.autobrr.port = cfg.port;
+
     # Require media-stack infrastructure
     assertions = [
       {

--- a/modules/services/media-stack/bazarr.nix
+++ b/modules/services/media-stack/bazarr.nix
@@ -23,6 +23,10 @@ let
   stack = config.cg.service.media-stack;
 in
 {
+  # Contributes to config.cg.publish, so it declares it - see
+  # modules/nixos/publish.nix.
+  imports = [ ../../nixos/publish.nix ];
+
   options.cg.service.bazarr = {
     enable = lib.mkEnableOption "Bazarr subtitle management";
 
@@ -34,6 +38,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # Published under its own name at the module's own port; whether it
+    # answers from outside the LAN is the host's call.
+    cg.publish.bazarr.port = cfg.port;
+
     # Require media-stack infrastructure
     assertions = [
       {

--- a/modules/services/media-stack/cleanuparr.nix
+++ b/modules/services/media-stack/cleanuparr.nix
@@ -85,6 +85,10 @@ let
   stack = config.cg.service.media-stack;
 in
 {
+  # Contributes to config.cg.publish, so it declares it - see
+  # modules/nixos/publish.nix.
+  imports = [ ../../nixos/publish.nix ];
+
   options.cg.service.cleanuparr = {
     enable = lib.mkEnableOption "Cleanuparr stalled download cleanup";
 
@@ -103,6 +107,14 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    cg.publish.cleanuparr = {
+      port = cfg.port;
+      # The readiness endpoint the podman healthcheck used to hit, so probing
+      # it keeps exactly the signal that healthcheck gave. The front page
+      # answers 200 whether or not the app is working.
+      probePath = "/health";
+    };
+
     # Require media-stack infrastructure
     assertions = [
       {

--- a/modules/services/media-stack/jellyfin.nix
+++ b/modules/services/media-stack/jellyfin.nix
@@ -35,8 +35,12 @@ let
   stack = config.cg.service.media-stack;
 in
 {
-  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
-  imports = [ ../../nixos/fleet.nix ];
+  # Reads config.cg.fleet and contributes to config.cg.publish, so it declares
+  # both - see modules/nixos/fleet.nix and modules/nixos/publish.nix.
+  imports = [
+    ../../nixos/fleet.nix
+    ../../nixos/publish.nix
+  ];
 
   options.cg.service.jellyfin = {
     enable = lib.mkEnableOption "Jellyfin media server";
@@ -46,6 +50,16 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    cg.publish.jellyfin = {
+      # 8096 is a literal because there is nothing to read it from: the
+      # upstream NixOS module has no port option, and Jellyfin's own default
+      # is what `openFirewall` below opens. One place is still one place.
+      port = 8096;
+      # Streaming: a client pulls segments continuously, and the admin
+      # profile's 300-per-10-minutes cuts a film off partway.
+      rateLimitProfile = "media";
+    };
+
     # Require media-stack infrastructure
     assertions = [
       {

--- a/modules/services/media-stack/kavita.nix
+++ b/modules/services/media-stack/kavita.nix
@@ -28,6 +28,10 @@ let
   stack = config.cg.service.media-stack;
 in
 {
+  # Contributes to config.cg.publish, so it declares it - see
+  # modules/nixos/publish.nix.
+  imports = [ ../../nixos/publish.nix ];
+
   options.cg.service.kavita = {
     enable = lib.mkEnableOption "Kavita reading server";
 
@@ -39,6 +43,11 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    cg.publish.kavita = {
+      port = cfg.port;
+      rateLimitProfile = "media"; # a reader: many small requests per page turn
+    };
+
     # Require media-stack infrastructure
     assertions = [
       {

--- a/modules/services/media-stack/maintainerr.nix
+++ b/modules/services/media-stack/maintainerr.nix
@@ -78,6 +78,10 @@ let
   stack = config.cg.service.media-stack;
 in
 {
+  # Contributes to config.cg.publish, so it declares it - see
+  # modules/nixos/publish.nix.
+  imports = [ ../../nixos/publish.nix ];
+
   options.cg.service.maintainerr = {
     enable = lib.mkEnableOption "Maintainerr media library maintenance";
 
@@ -96,6 +100,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    cg.publish.maintainerr = {
+      port = cfg.port;
+      # A collection scan walks the whole Jellyfin library through this UI,
+      # which the admin profile's 300-per-10-minutes cuts off partway.
+      rateLimitProfile = "none";
+    };
+
     # Require media-stack infrastructure
     assertions = [
       {

--- a/modules/services/media-stack/prowlarr.nix
+++ b/modules/services/media-stack/prowlarr.nix
@@ -24,6 +24,10 @@ let
   stack = config.cg.service.media-stack;
 in
 {
+  # Contributes to config.cg.publish, so it declares it - see
+  # modules/nixos/publish.nix.
+  imports = [ ../../nixos/publish.nix ];
+
   options.cg.service.prowlarr = {
     enable = lib.mkEnableOption "Prowlarr indexer manager";
 
@@ -35,6 +39,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # Published under its own name at the module's own port; whether it
+    # answers from outside the LAN is the host's call.
+    cg.publish.prowlarr.port = cfg.port;
+
     # Require media-stack infrastructure
     assertions = [
       {

--- a/modules/services/media-stack/qbittorrent.nix
+++ b/modules/services/media-stack/qbittorrent.nix
@@ -38,7 +38,10 @@ let
 in
 {
   # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
-  imports = [ ../../nixos/fleet.nix ];
+  imports = [
+    ../../nixos/fleet.nix
+    ../../nixos/publish.nix
+  ];
 
   options.cg.service.qbittorrent = {
     enable = lib.mkEnableOption "qBittorrent torrent client";
@@ -67,6 +70,23 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # The WebUI's CSRF protection rejects a proxied request that still
+    # carries Origin or Referer, so the proxy config travels with the
+    # module rather than being remembered by whichever host runs it.
+    cg.publish.qbittorrent = {
+      subdomain = "downloads";
+      port = cfg.port;
+      proxyExtraConfig = ''
+        # qBittorrent auth fix - strip headers that trigger CSRF protection
+        header_up -Origin
+        header_up -Referer
+        # Increase timeouts for large torrent lists
+        transport http {
+          response_header_timeout 30s
+        }
+      '';
+    };
+
     # Require media-stack infrastructure
     assertions = [
       {

--- a/modules/services/media-stack/radarr.nix
+++ b/modules/services/media-stack/radarr.nix
@@ -27,6 +27,10 @@ let
   stack = config.cg.service.media-stack;
 in
 {
+  # Contributes to config.cg.publish, so it declares it - see
+  # modules/nixos/publish.nix.
+  imports = [ ../../nixos/publish.nix ];
+
   options.cg.service.radarr = {
     enable = lib.mkEnableOption "Radarr movie management";
 
@@ -38,6 +42,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # Published under its own name at the module's own port; whether it
+    # answers from outside the LAN is the host's call.
+    cg.publish.radarr.port = cfg.port;
+
     # Require media-stack infrastructure
     assertions = [
       {

--- a/modules/services/media-stack/seerr.nix
+++ b/modules/services/media-stack/seerr.nix
@@ -25,6 +25,10 @@ let
   stack = config.cg.service.media-stack;
 in
 {
+  # Contributes to config.cg.publish, so it declares it - see
+  # modules/nixos/publish.nix.
+  imports = [ ../../nixos/publish.nix ];
+
   options.cg.service.seerr = {
     enable = lib.mkEnableOption "Seerr request management";
 
@@ -36,6 +40,15 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # `requests` rather than `seerr`: this is the front door people are
+    # given, and it is named for what they do with it.
+    cg.publish.seerr = {
+      subdomain = "requests";
+      port = cfg.port;
+      # Users browse and search constantly; the admin profile throttles them.
+      rateLimitProfile = "media";
+    };
+
     # Require media-stack infrastructure
     assertions = [
       {

--- a/modules/services/media-stack/shelfmark.nix
+++ b/modules/services/media-stack/shelfmark.nix
@@ -68,6 +68,10 @@ let
   qbt = config.cg.service.qbittorrent;
 in
 {
+  # Contributes to config.cg.publish, so it declares it - see
+  # modules/nixos/publish.nix.
+  imports = [ ../../nixos/publish.nix ];
+
   options.cg.service.shelfmark = {
     enable = lib.mkEnableOption "Shelfmark book search and request hub";
 
@@ -104,6 +108,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # Published by the gluetun container on this host, so from Caddy's point
+    # of view it is an ordinary local port.
+    cg.publish.shelfmark.port = cfg.port;
+
     assertions = [
       {
         assertion = stack.enable;

--- a/modules/services/media-stack/sonarr.nix
+++ b/modules/services/media-stack/sonarr.nix
@@ -27,6 +27,10 @@ let
   stack = config.cg.service.media-stack;
 in
 {
+  # Contributes to config.cg.publish, so it declares it - see
+  # modules/nixos/publish.nix.
+  imports = [ ../../nixos/publish.nix ];
+
   options.cg.service.sonarr = {
     enable = lib.mkEnableOption "Sonarr TV show management";
 
@@ -38,6 +42,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # Published under its own name at the module's own port; whether it
+    # answers from outside the LAN is the host's call.
+    cg.publish.sonarr.port = cfg.port;
+
     # Require media-stack infrastructure
     assertions = [
       {

--- a/modules/services/media-stack/suwayomi.nix
+++ b/modules/services/media-stack/suwayomi.nix
@@ -50,6 +50,10 @@ let
   stack = config.cg.service.media-stack;
 in
 {
+  # Contributes to config.cg.publish, so it declares it - see
+  # modules/nixos/publish.nix.
+  imports = [ ../../nixos/publish.nix ];
+
   options.cg.service.suwayomi = {
     enable = lib.mkEnableOption "Suwayomi manga server";
 
@@ -71,6 +75,11 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    cg.publish.suwayomi = {
+      port = cfg.port;
+      rateLimitProfile = "media"; # it is a reader as well as a downloader
+    };
+
     assertions = [
       {
         assertion = stack.enable;

--- a/modules/services/media-stack/wizarr.nix
+++ b/modules/services/media-stack/wizarr.nix
@@ -22,6 +22,10 @@ let
   stack = config.cg.service.media-stack;
 in
 {
+  # Contributes to config.cg.publish, so it declares it - see
+  # modules/nixos/publish.nix.
+  imports = [ ../../nixos/publish.nix ];
+
   options.cg.service.wizarr = {
     enable = lib.mkEnableOption "Wizarr user invitation system";
 
@@ -33,6 +37,12 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # `invite` is the link handed to a new user, so it is the hostname.
+    cg.publish.wizarr = {
+      subdomain = "invite";
+      port = cfg.port;
+    };
+
     # Require media-stack infrastructure
     assertions = [
       {

--- a/modules/services/miniflux.nix
+++ b/modules/services/miniflux.nix
@@ -44,7 +44,10 @@ let
 in
 {
   # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
-  imports = [ ../nixos/fleet.nix ];
+  imports = [
+    ../nixos/fleet.nix
+    ../nixos/publish.nix
+  ];
 
   options.cg.service.miniflux = {
     enable = lib.mkEnableOption "Miniflux RSS reader";
@@ -64,6 +67,11 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    cg.publish.miniflux = {
+      subdomain = "rss";
+      port = cfg.port;
+    };
+
     sops = {
       secrets = {
         # Admin credentials EnvironmentFile: ADMIN_USERNAME and ADMIN_PASSWORD

--- a/modules/services/monitoring/monitoring.nix
+++ b/modules/services/monitoring/monitoring.nix
@@ -237,20 +237,28 @@ in
         enable = lib.mkEnableOption "ntfy push routing for Alertmanager";
 
         # Loopback port the local bridge listens on, and the one port
-        # Alertmanager delivers to. Configurable because 8000 is already taken
-        # by convention wherever the media stack runs: gluetun's HTTP control
-        # server is published there (qbittorrent.nix), and gluetun coexists
-        # with this bridge precisely on storage hosts. When the bridge landed
-        # on homelab02 with the shared literal below it lost that race on
-        # every start, crash-looped all night, and the switch that activated
-        # it reported failed units. Anything loopback and free will do;
-        # there is nothing to match on either side.
+        # Alertmanager delivers to. Both sides are read from here, so the
+        # number matters only in that nothing else on the host may hold it.
+        #
+        # It is 8015 rather than the 8000 this defaulted to, because 8000 is
+        # taken by convention wherever the media stack runs: gluetun's HTTP
+        # control server is published there (qbittorrent.nix), and gluetun
+        # coexists with this bridge precisely on storage hosts. The bridge
+        # landed on homelab02 against that, lost the bind race on every
+        # start, crash-looped all night, and the switch that activated it
+        # reported failed units. That was repaired by having homelab02 name
+        # a different port - which left the collision in the default, one
+        # host away from happening again. A default that does not collide
+        # with anything this fleet runs costs nothing and needs no host to
+        # remember.
         port = lib.mkOption {
           type = lib.types.port;
-          default = 8000;
+          default = 8015;
           description = ''
-            Loopback port for the local alertmanager-ntfy bridge. Move off
-            8000 on any host whose gluetun control server is published there.
+            Loopback port for the local alertmanager-ntfy bridge. Anything
+            loopback and free will do; there is nothing to match on either
+            side. Avoid 8000, which gluetun's control server is published on
+            wherever the media stack runs.
           '';
         };
 

--- a/modules/services/monitoring/monitoring.nix
+++ b/modules/services/monitoring/monitoring.nix
@@ -10,6 +10,10 @@ let
   cfg = config.cg.service.monitoring;
   fleet = config.cg.fleet;
 
+  # The fleet's always-on machines: what gets scraped. Sorted, because
+  # `attrNames` is, which keeps the generated scrape config stable.
+  servers = lib.attrNames (lib.filterAttrs (_: host: host.kind == "server") fleet.hosts);
+
   # ZFS health metrics script for textfile collector
   # Outputs Prometheus metrics for ZFS pool health
   zfsHealthScript = pkgs.writeShellScript "zfs-health-exporter" ''
@@ -175,8 +179,13 @@ let
   '';
 in
 {
-  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
-  imports = [ ../../nixos/fleet.nix ];
+  # Reads config.cg.fleet and config.cg.publish, and publishes its own three
+  # web UIs into the latter - see modules/nixos/fleet.nix and
+  # modules/nixos/publish.nix.
+  imports = [
+    ../../nixos/fleet.nix
+    ../../nixos/publish.nix
+  ];
 
   options.cg.service.monitoring = {
     enable = lib.mkEnableOption "Monitoring stack";
@@ -328,27 +337,47 @@ in
     };
 
     # Targets for Prometheus to scrape
+    #
+    # Both default to every machine the fleet calls a `server` - the ones with
+    # a reserved address, expected to be up - at the port this module gives
+    # its own exporters. Neither the host list nor the port is written down
+    # twice: the hosts came from `cg.fleet` and the port from the exporter
+    # that answers on it, so moving either moves the scrape with it.
     scrapeTargets = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [ ];
-      example = [
-        "homelab01:9100"
-        "homelab02:9100"
-      ];
+      default = map (host: "${host}:${toString config.services.prometheus.exporters.node.port}") servers;
+      defaultText = lib.literalExpression "every `server` in `config.cg.fleet`, at the node_exporter port";
       description = "List of node_exporter targets to scrape";
     };
 
     smartctlTargets = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [ ];
-      example = [
-        "homelab01:9633"
-        "homelab02:9633"
-      ];
+      default = map (
+        host: "${host}:${toString config.services.prometheus.exporters.smartctl.port}"
+      ) servers;
+      defaultText = lib.literalExpression "every `server` in `config.cg.fleet`, at the smartctl_exporter port";
       description = "List of smartctl_exporter targets to scrape";
     };
 
     # HTTP endpoints to probe
+    #
+    # Derived from `cg.publish`, and that is the point: the two hosts used to
+    # hand-maintain overlapping lists, and by the time this was written seven
+    # proxied hostnames were probed from nowhere - two of them published to
+    # the internet. A service that is published and not probed is no longer
+    # expressible, because nothing writes this list any more.
+    #
+    # Each host probes what its own Caddy serves. `cg.publish` is per-host, so
+    # a host cannot see what its peer publishes, and the union of the two
+    # covers the fleet exactly once. The dual coverage the hand-written lists
+    # happened to give is gone with them; a host that is down takes its own
+    # probes with it and is reported by the node and target-down alerts
+    # instead.
+    #
+    # The value is the option's *default* rather than a fixed computation, for
+    # the reason modules/nixos/fleet.nix gives about `cg.fleet`: checks/
+    # instantiates this module directly and needs to point a probe at a target
+    # that exists inside a sandboxed VM. No host sets it.
     httpProbes = lib.mkOption {
       type = lib.types.listOf (
         lib.types.submodule {
@@ -364,7 +393,14 @@ in
           };
         }
       );
-      default = [ ];
+      default = lib.mapAttrsToList (name: svc: {
+        inherit name;
+        url = "https://${svc.subdomain}.${fleet.domain}${svc.probePath}";
+      }) (lib.filterAttrs (_: svc: svc.probe) config.cg.publish);
+      defaultText = lib.literalExpression ''
+        every `config.cg.publish` entry with `probe = true`, as
+        `https://''${subdomain}.''${config.cg.fleet.domain}''${probePath}`
+      '';
       description = "HTTP endpoints to probe with blackbox_exporter";
     };
 
@@ -472,6 +508,22 @@ in
       # Prometheus server + blackbox exporter
       # ============================================================
       (lib.mkIf cfg.prometheus.enable {
+        # A hostname for the graph view, but only where Grafana is. Every
+        # host in the fleet runs a Prometheus, and a subdomain names one
+        # machine - so publishing from each of them would put the same
+        # hostname on two proxies, where DNS decides which one answers and
+        # the other holds a certificate for a name it never serves. Grafana
+        # runs on one host, and it is the thing that links here, so its
+        # presence is the sensible place to hang the name. Reach the others
+        # at `<host>:9090` over ssh.
+        #
+        # The port comes from the upstream option rather than a literal, which
+        # is the whole point of the registry: nothing here can drift from what
+        # Prometheus is actually listening on.
+        cg.publish = lib.mkIf cfg.grafana.enable {
+          prometheus.port = config.services.prometheus.port;
+        };
+
         services.prometheus.exporters.blackbox = {
           enable = true;
           configFile = pkgs.writeText "blackbox.yml" ''
@@ -582,6 +634,14 @@ in
       # Alertmanager
       # ============================================================
       (lib.mkIf cfg.alertmanager.enable {
+        # Where silences live, so it is worth a hostname - on the one host
+        # that gets one, for the reason given against the Prometheus UI
+        # above. Both hosts run an Alertmanager; they are clustered, so a
+        # silence set through this one reaches the peer anyway.
+        cg.publish = lib.mkIf cfg.grafana.enable {
+          alertmanager.port = config.services.prometheus.alertmanager.port;
+        };
+
         # Ensure alertmanager user exists before sops-nix runs
         users.users.alertmanager = {
           isSystemUser = true;
@@ -858,6 +918,10 @@ in
       # Grafana
       # ============================================================
       (lib.mkIf cfg.grafana.enable {
+        # Grafana binds 127.0.0.1 (see the server settings below), so the
+        # proxy is the only way in.
+        cg.publish.grafana.port = config.services.grafana.settings.server.http_port;
+
         # Ensure grafana user exists before sops-nix runs
         users.users.grafana = {
           isSystemUser = true;

--- a/modules/services/ntfy.nix
+++ b/modules/services/ntfy.nix
@@ -39,8 +39,12 @@ let
   cfg = config.cg.service.ntfy;
 in
 {
-  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
-  imports = [ ../nixos/fleet.nix ];
+  # Reads config.cg.fleet and contributes to config.cg.publish, so it declares
+  # both - see modules/nixos/fleet.nix and modules/nixos/publish.nix.
+  imports = [
+    ../nixos/fleet.nix
+    ../nixos/publish.nix
+  ];
 
   options.cg.service.ntfy = {
     enable = lib.mkEnableOption "ntfy self-hosted push notification server";
@@ -91,12 +95,12 @@ in
       };
     };
 
-    # Published for phones on mobile data; authentication is ntfy's own job,
-    # not the proxy's.
-    cg.service.reverse-proxy.services.ntfy = {
+    # Meant to be reached from phones on mobile data; authentication is ntfy's
+    # own job, not the proxy's. The host still decides `localOnly`, as it does
+    # for everything else.
+    cg.publish.ntfy = {
       subdomain = cfg.subdomain;
       port = cfg.port;
-      localOnly = false;
       rateLimitProfile = "none"; # alert storms must not be rate-limited
     };
 

--- a/modules/services/reverse-proxy.nix
+++ b/modules/services/reverse-proxy.nix
@@ -6,6 +6,11 @@
 # - DNS-01 challenge via Cloudflare (works for internal-only services)
 # - Individual certificates per service (as requested for learning)
 #
+# WHAT IT PROXIES:
+# One vhost per entry in `cg.publish`, which the modules that run the services
+# contribute to themselves - this module keeps no list of its own. See
+# modules/nixos/publish.nix.
+#
 # Prerequisites:
 # - Domain DNS managed by Cloudflare
 # - Cloudflare API token with Zone:DNS:Edit permissions
@@ -118,20 +123,20 @@ let
 
   # Helper to create a reverse proxy virtual host with TLS
   # Each service gets its own cert via DNS-01 challenge
+  #
+  # Takes a `cg.publish` entry whole, so every field it reads has already been
+  # given a type and a default by modules/nixos/publish.nix rather than here.
   mkProxyHost =
     {
       subdomain,
       port,
-      # Optional: host the service actually runs on. Defaults to this machine;
-      # set it to proxy a service hosted on another homelab node.
-      upstream ? "localhost",
-      # Optional: restrict to local network only
-      localOnly ? false,
-      # Optional: rate limiting profile ("media", "admin", "none")
-      rateLimitProfile ? "admin",
-      # Optional: extra Caddy config
-      extraConfig ? "",
-      proxyExtraConfig ? "",
+      upstream,
+      localOnly,
+      rateLimitProfile,
+      extraConfig,
+      proxyExtraConfig,
+      # `probe` and `probePath` are the monitoring consumer's business.
+      ...
     }:
     {
       "${subdomain}.${domain}" = {
@@ -171,8 +176,12 @@ let
     };
 in
 {
-  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
-  imports = [ ../nixos/fleet.nix ];
+  # Reads config.cg.fleet and config.cg.publish, so it declares both - see
+  # modules/nixos/fleet.nix and modules/nixos/publish.nix.
+  imports = [
+    ../nixos/fleet.nix
+    ../nixos/publish.nix
+  ];
 
   options.cg.service.reverse-proxy = {
     enable = lib.mkEnableOption "Caddy reverse proxy with automatic TLS";
@@ -187,65 +196,6 @@ in
       type = lib.types.path;
       description = "Path to file containing Cloudflare API token";
       example = "/run/secrets/cloudflare-api-token";
-    };
-
-    # Service definitions - add new services here
-    # Format: { subdomain, port, localOnly (optional), extraConfig (optional) }
-    #
-    # NOTE: Services marked localOnly = true will only be accessible from
-    # the local network, even if exposed via Cloudflare tunnel later
-    services = lib.mkOption {
-      type = lib.types.attrsOf (
-        lib.types.submodule {
-          options = {
-            subdomain = lib.mkOption {
-              type = lib.types.str;
-              description = "Subdomain for this service";
-            };
-            port = lib.mkOption {
-              type = lib.types.port;
-              description = "Port the service listens on";
-            };
-            upstream = lib.mkOption {
-              type = lib.types.str;
-              default = "localhost";
-              example = "homelab02";
-              description = ''
-                Host the service runs on. Defaults to this machine. Set it to
-                another node's hostname or IP to proxy a service hosted there --
-                the traffic crosses the LAN in the clear, so only use it for
-                links inside the trusted network.
-              '';
-            };
-            localOnly = lib.mkOption {
-              type = lib.types.bool;
-              default = true;
-              description = "Restrict access to local network";
-            };
-            rateLimitProfile = lib.mkOption {
-              type = lib.types.enum [
-                "media"
-                "admin"
-                "none"
-              ];
-              default = "admin";
-              description = "Rate limiting profile to apply";
-            };
-            extraConfig = lib.mkOption {
-              type = lib.types.lines;
-              default = "";
-              description = "Additional Caddy configuration";
-            };
-            proxyExtraConfig = lib.mkOption {
-              type = lib.types.lines;
-              default = "";
-              description = "Additional Caddy config inside the reverse_proxy block";
-            };
-          };
-        }
-      );
-      default = { };
-      description = "Services to proxy on this host";
     };
 
     openFirewall = lib.mkOption {
@@ -305,8 +255,13 @@ in
         }
       '';
 
-      # Convert services attrset to virtualHosts format
-      virtualHosts = lib.foldl' (acc: svc: acc // (mkProxyHost svc)) { } (lib.attrValues cfg.services);
+      # One vhost per published service. The registry is contributed to by
+      # the modules that run the services (see modules/nixos/publish.nix), so
+      # a port change in one of them moves the proxy with it instead of
+      # leaving it pointed at nothing.
+      virtualHosts = lib.foldl' (acc: svc: acc // (mkProxyHost svc)) { } (
+        lib.attrValues config.cg.publish
+      );
     };
 
     # Firewall

--- a/modules/services/wallabag.nix
+++ b/modules/services/wallabag.nix
@@ -52,7 +52,10 @@ let
 in
 {
   # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
-  imports = [ ../nixos/fleet.nix ];
+  imports = [
+    ../nixos/fleet.nix
+    ../nixos/publish.nix
+  ];
 
   options.cg.service.wallabag = {
     enable = lib.mkEnableOption "Wallabag read-it-later service";
@@ -72,6 +75,11 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    cg.publish.wallabag = {
+      subdomain = "read";
+      port = cfg.port;
+    };
+
     sops = {
       # Database password — group-owned by postgres so wallabag-db-setup can
       # read it while running as the postgres OS user (peer auth on local socket).


### PR DESCRIPTION
Item 2 of [`docs/plans/structural-cleanup.md`](https://github.com/corygyarmathy/dotfiles/blob/master/docs/plans/structural-cleanup.md).

Every service port was written down twice — once in the module that runs the service, once again as a literal in the host's `reverse-proxy.services` block. Changing the module's port produced no error; it produced a proxy pointing at nothing. The probe lists were a third copy, hand-maintained per host, and had already drifted: seven proxied hostnames were probed from nowhere, two of them published to the internet.

## The shape

`modules/nixos/publish.nix` declares `cg.publish`, a registry any module may contribute to. The module that runs a service is the only thing that knows its port, so it is the thing that says how it should be published:

```nix
cg.publish.sonarr.port = cfg.port;   # the module's own option, never a copy
```

Twenty-two service modules now declare their own entry, and the three consumers read the registry instead of a hand-written list:

- `reverse-proxy.nix` builds one Caddy vhost per entry.
- `cloudflare-tunnel.nix` builds its ingress from the `localOnly = false` subset. The `lib.mapAttrs` that used to wire one module into the other from inside a host file is deleted, not moved.
- `monitoring.nix` derives `httpProbes` from all of them. That is what closes the drift by construction: a service that is published and not probed is no longer expressible.

Both hosts' `services` blocks, both probe lists and that `mapAttrs` are gone — 331 lines out of the two host files against 65 added, most of the latter being the block naming which services face the internet.

## Four things the plan did not anticipate

**`localOnly` moved off the modules entirely, ntfy's included.** `ntfy.nix` was already publishing itself into the proxy, and it set `localOnly = false` there. Leaving that would have meant the answer to "what does this host expose" was one block in the host file plus however many modules had opinions. It is now the host's block alone, and the field defaults to `true`, so a service nobody decided about stays off the internet.

**Two web UIs cannot both be `prometheus`.** Every host runs a Prometheus and an Alertmanager, so a module that publishes them unconditionally puts the same hostname on two proxies — where DNS picks one and the other holds a certificate for a name it never serves. They are published where Grafana is, since Grafana is what links to them and runs on one host. The peer's are reached at `<host>:9090` over ssh, as before.

**The probe URL is the `instance` label.** Building it as `https://${subdomain}.${domain}${probePath}` with `probePath` defaulting to `/` appended a trailing slash to all seventeen existing probes and renamed every series they produce — silently cutting the dashboards and alert history off from their own past. The default is `""`, and the option is documented as being about that rather than about tidiness.

**Three more transcribed ports were in scope after all.** `scrapeTargets` and `smartctlTargets` were `map (host: "${host}:9100") servers` in both host files — the same duplication one level down, since `9100` and `9633` are set by `monitoring.nix` itself. They now default to every `server` in `cg.fleet` at the port that module gives its own exporters.

The third is the only one that changes a running host. The alertmanager-ntfy bridge defaulted to `8000` and homelab02 dodged it, because gluetun's control server is published there wherever the media stack runs — the bridge lost that bind race on every start and the upgrade that introduced it was marked failed by its own activation. Repairing that per-host left the collision sitting in the default, one host away from happening again. `8015` is the default now, homelab02 says nothing, and homelab01's bridge moves with it. With that gone, no host file contains a port number at all.

## Behaviour

Marked `minor` in the plan's table rather than `no`. Three things change on a running fleet, and the first is the point of the item:

- **Each host now probes what its own Caddy serves.** `cg.publish` is per-host and a host cannot see what its peer publishes, so the union of the two lists covers the fleet exactly once — where the hand-written lists covered thirteen hostnames twice and seven not at all. Nine probes are added across the fleet (`alertmanager`, `bazarr`, `grimmory`, `invite`, `ntfy` and `prometheus` on homelab01; `shelfmark` and `suwayomi` on homelab02), and the redundancy is gone with the duplication: a host that is down takes its own probes with it, and is reported by the node and target-down alerts instead of by its peer's probe.
- The alertmanager-ntfy bridge on homelab01 moves from `127.0.0.1:8000` to `:8015`. Both ends of that port are read from the same option, so the move is self-consistent.
- `cloudflared-route-dns` registers the same ten hostnames in a different order. The registry is keyed by module name rather than by subdomain, so `invite` comes last instead of second; `cloudflared tunnel route dns` is idempotent and each call is `|| true`.

**Worth timing.** New probes on services nobody was watching may well fire. That is the point, but it is worth landing on a day when investigating an alert is welcome.

## Verified inert, rather than assumed

For homelab01 and homelab02, every entry in the generated `/etc` was compared against the same host built from `b950130`, and every systemd unit within it. **`/etc/caddy/caddy_config` is byte-identical on both hosts** — the same store path, from a registry assembled a completely different way, which is the strongest available statement that no service moved.

Four units differ beyond the five that always do:

- `prometheus.service` on both, which is the intended change. Every retained probe URL is byte-identical; the additions and removals are exactly the list above. The node and smartctl target lists are unchanged, which is the check on the `scrapeTargets` default.
- `alertmanager.service` and `alertmanager-ntfy.service` on homelab01, by the bridge port alone: `http://127.0.0.1:8000/hook` becomes `:8015` in Alertmanager's webhook config and the bridge's `http.addr` follows. Nothing else in either file moves, and homelab02 is unaffected — it was already on 8015.
- `cloudflared-route-dns.service` on homelab01, by ordering alone, as above.

The five that always move — `system-path`, `dbus-1`, `user-units`, and the `nixos-upgrade`, `nixos-deploy-metrics`, `digital-garden-build`, `dbus-broker` and `polkit` units — are the same set item 1 identified, and move for the same reason: they carry `system.configurationRevision`.

## The new check

`checks/publish.nix` pins both halves, by evaluation rather than in a VM — `checks/reverse-proxy.nix` already boots Caddy against a `cg.publish` registry to prove the vhosts it generates actually serve.

Against a stand-in service module it asserts that a port set once reaches the vhost, the ingress and the probe; that `localOnly` keeps a service out of the tunnel but not out of Caddy; and that `probe = false` removes the probe but not the vhost. Against the real hosts it asserts that every published entry is probed and that every tunnel hostname is served by the host carrying it — the assertion that would have caught the original drift.

It was tested against a deliberate break, the way the other checks are: dropping two entries from the probe derivation makes it name `cg.publish.bazarr` and `cg.publish.suwayomi` and exit 1.

## Checks run

- All eleven checks pass, including the reverse-proxy VM test now driven from a `cg.publish` registry rather than the deleted `services` option.
- `nix fmt -- --ci` clean; all three hosts build; `devShells`, `packages` and `apps` — the three outputs the `lint` job evaluates by hand — still evaluate.
- **`publish` is in the `ci.yml` matrix**, which it was not on the first pass. The flake had eleven checks and the matrix ten, so `lint`'s "Every flake check is in the matrix" audit would have failed this PR — item 0's audit doing exactly the job it was added for, on the first check added after it landed. Confirmed in both directions locally. It gets its own shard rather than joining the cheap static ones, since it evaluates two whole hosts.
- `checks/monitoring.nix` had the bridge port written down as a literal, so moving the default broke it — as `unauthenticated webhook post was not rejected`, a message about authentication that says nothing about the cause. Its `testScript` is now a function of `nodes` and reads the option, which is the same lesson as the rest of this branch arriving from the direction of a test.
- The `Done when` was checked by script and holds without exception: no port number appears in any host file, `httpProbes` is written by hand nowhere, and all seven previously-unprobed hostnames are now probed.

## Deliberately not in scope

`adguard-home.nix`'s `gatewaySubdomains` / `storageSubdomains` lists are a fourth transcription of the same facts, and they are left alone: they are cross-host by nature — the gateway's DNS has to name the storage host's subdomains — and a per-host registry cannot supply them. Documentation is item 7's single pass. Item 3 is now unblocked.
