### PR TITLE
fix(garden): cap tables to the measure so prose wraps, not the page

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -449,24 +449,60 @@
         assert "fonts.googleapis.com" not in css and "fonts.gstatic.com" not in css, \
             "the stylesheet fetches a font from a CDN"
 
-    with subtest("a table is wrapped in something that can scroll"):
-        # The other shape of the same failure the font assertion guards: a rule
-        # that is written and never reached. `.table-container { overflow-x:
-        # auto }` sat in the stylesheet for weeks with no hook to emit the div,
-        # so it matched nothing, and a table wider than the measure scrolled
-        # the PAGE - at 390px the document went to about twice the width of the
-        # phone, and every paragraph on it could be dragged sideways. Nothing
-        # failed: the build was clean, the CSS was there, the table rendered.
+    with subtest("a table is capped to the measure, not scrolled past it"):
+        # Two independent failures are guarded here, each of which alone is a
+        # bug.
         #
-        # So both halves are asserted, because either one alone is the bug: the
-        # selector exists in the stylesheet, AND the markup an actual table
-        # produces contains it.
+        # The first is the wrapper: `.table-container { overflow-x: auto }` sat
+        # in the stylesheet for weeks with no hook to emit the div, so it
+        # matched nothing, and a table wider than the measure scrolled the PAGE
+        # - at 390px the document went to about twice the width of the phone,
+        # and every paragraph on it could be dragged sideways. Nothing failed:
+        # the build was clean, the CSS was there, the table rendered. So both
+        # halves are asserted: the selector exists in the stylesheet, AND the
+        # markup an actual table produces contains it.
+        #
+        # The second is the cap. The wrapper alone left a wide table scrolled
+        # inside its box - better than scrolling the page, but the right-hand
+        # columns sat off-screen and another ~500px of sideways scroll was still
+        # the interface. The hook now emits a <colgroup> of percentage widths
+        # summed to 100%, and the stylesheet honours them with
+        # `table-layout: fixed; width: 100%`, so every column stays on the
+        # measure and nothing is left to scroll. That only works if all three
+        # halves land on an actual table rendered through the hook:
+        #
+        #   - the hook emitted the <colgroup> (a table whose widths are left to
+        #     auto layout can blow a prose column wide again);
+        #   - the stylesheet applies fixed layout (a <col> width is a hint the
+        #     content can outgrow under auto layout);
+        #   - the old `width: max-content` that made the table as wide as its
+        #     content is gone (under fixed layout it would fight the cap).
         page = served("/on-gates")
         assert "MARKER-TABLE-CELL" in page, "the fixture table did not render"
         assert re.search(r'<div class="table-container"[^>]*>\s*<table', page), \
             "a table is not wrapped in .table-container"
         assert ".table-container" in css, \
             ".table-container missing from the stylesheet"
+        assert re.search(r'<table[^>]*>\s*<colgroup>\s*<col\s+style="width:\s*\d', page), \
+            "the table has no <colgroup> width cap from the hook"
+        # Presence is not enough: the widths could be negative, out of range, or
+        # fail to sum to a table that fills the measure. Parse every column the
+        # fixture's table emits and check both - a positive percentage each, and
+        # a total of 100 (within rounding). A negative fallback (an impossible
+        # table of eleven short columns plus a prose one) would be caught here.
+        col_widths = [float(m)
+                      for m in re.findall(r'<col\s+style="width:\s*(-?\d+\.\d+|-?\d+)%"', page)]
+        assert col_widths, "the table emitted no parseable <col> widths"
+        assert all(0.0 < w <= 100.0 for w in col_widths), \
+            f"a table column has an out-of-range width: {col_widths}"
+        assert abs(sum(col_widths) - 100.0) < 0.1, \
+            f"a table's columns do not sum to 100%: {col_widths} = {sum(col_widths)}"
+        assert re.search(r'table\s*{[^}]*table-layout:\s*fixed', css), \
+            "tables are not laid out with fixed width"
+        assert re.search(r'table\s*{[^}]*width:\s*100%', css), \
+            "tables do not fill the measure"
+        assert not re.search(r'table\s*{[^}]*width:\s*max-content', css), \
+            "the table rule still sizes the table to its content, so the cap would fight it"
 
     with subtest("the page declares a tab icon"):
         # Without one the browser asks for /favicon.ico on every visit and gets

--- a/docs/plans/digital-garden-design.md
+++ b/docs/plans/digital-garden-design.md
@@ -336,6 +336,8 @@ Both of the new assertions are in `checks/digital-garden.nix`, and they are ther
 
 This is the same line item 6 drew between its two assertions. A rule that is written and never reached is the same class of failure as a stylesheet naming a font CDN, and neither is visible in a screenshot or a green gate.
 
+**Updated, 2026-08-29:** the `width: max-content; min-width: 100%` fix above was itself the next instance of the same shape. It left a wide table scrolling inside its container — no longer the page, but the right-hand prose columns sat off-screen and ~500px of sideways scroll was still the interface. It is replaced by a `<colgroup>` cap emitted by the hook plus `table-layout: fixed; width: 100%` on the table, so every column stays on the measure and prose wraps at a capped width. Two numbers tune it: the prose cap (120 codepoints) sits high enough that a longer column still earns proportionally more of the table, and a 10% share floor keeps a short data column ("Role", a price) from being crushed by a long prose neighbour. Fixed layout is what makes the hook's widths stick — under auto layout a `<col>` width is only a hint the content can outgrow, which is the original bug returning. See `_markup/render-table.html` and `checks/digital-garden.nix`.
+
 ### The open question, not decided
 
 Lotus's `--brand` is 4.12:1 on the masthead. At 1.1rem and weight 600 that is 17.6px semibold, just under the 18.66px where the large-text allowance of 3:1 starts, so the 4.5:1 floor applies and it misses.

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -595,7 +595,13 @@ mark {
 /* Wide content must scroll inside its own box rather than making the page
  * scroll sideways. The box is put there by _markup/render-table.html; for a
  * while this rule was written and the hook was not, so it matched nothing and
- * the page did the scrolling — see that file. */
+ * the page did the scrolling — see that file.
+ *
+ * Today the table fits the measure by construction — see `table` below — so
+ * the scroll bar sits unused on a well-sized table. It is kept because the
+ * width estimate in the hook is intentionally crude: a table of exceptional
+ * glyphs (CJK, say) underprices a column and overflows, and when that happens
+ * we want the overflow consumed here rather than scrolling the page. */
 .table-container {
   overflow-x: auto;
 }
@@ -622,18 +628,28 @@ pre:focus-visible {
   padding: 0.2rem 0;
 }
 
-/* Sized to its own content, with the measure as a floor rather than a ceiling.
- * `width: 100%` was both halves of the same bug: it guaranteed the table could
- * never overflow .table-container, so the container's `overflow-x` never had
- * anything to scroll, and it guaranteed a table too wide for the measure would
- * be squeezed into it instead — which is how a column of one-sentence theses
- * came to be set one word per line. max-content lets a wide table be as wide as
- * it needs and scroll; min-width keeps a narrow one filling the measure, which
- * is what `width: 100%` was there for in the first place. */
+/* The width estimate that used to live on the table is gone. What was
+ * `width: max-content` sized the table to its content, so a wide table
+ * scrolled inside .table-container and a prose column sat untouched at 450px
+ * while the reader scrolled the rest of the way sideways — the exact thing the
+ * container was meant to replace. `fixed` + `100%` instead takes the measures
+ * the hook put on each <col> and uses them verbatim, so every column stays on
+ * the measure and prose wraps at a readable cap instead of running off to the
+ * right. The columns already sum to 100%, so the table is exactly the width of
+ * the box it sits in.
+ *
+ * `overflow-wrap: anywhere` and `min-width: 0` are what let a cell wrap
+ * rather than fitting its content to one long unbroken line. A fixed table
+ * will not wrap a cell on its own; it honours the col width and lets the text
+ * break at the box edge — good for prose, but it turns a long unbreakable token
+ * into a page-wide overflow. `anywhere` caps that (the stronger of the two
+ * break modes, which is what keeps a token from widening the page), and without
+ * `min-width: 0` a grid or block child would still force the min-content width
+ * and overflow anyway. */
 table {
   border-collapse: collapse;
-  width: max-content;
-  min-width: 100%;
+  table-layout: fixed;
+  width: 100%;
 }
 
 th,
@@ -641,6 +657,8 @@ td {
   border-bottom: 1px solid var(--border);
   padding: 0.4rem 0.6rem;
   text-align: left;
+  overflow-wrap: anywhere;
+  min-width: 0;
 }
 
 /* ── heading anchors ────────────────────────────────────────────────────── */

--- a/modules/services/digital-garden/lib/hugo/layouts/_markup/render-table.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_markup/render-table.html
@@ -1,16 +1,48 @@
 {{/*
-  A table, wrapped in the scroll container the stylesheet has always styled.
+  A table, wrapped in the scroll container the stylesheet has always styled,
+  with a column cap so a wide table never overflows the measure.
 
-  This hook exists for the wrapper and for nothing else: the cells below are
-  the markup Hugo emits without it. `.table-container { overflow-x: auto }` was
-  written when the single-column layout landed, but Hugo emits a bare <table>
-  and there was no hook to put the div around it, so the rule matched nothing
-  and a wide table had no box to scroll inside. It scrolled the PAGE instead —
-  at 390px the reference tables in the Lighting notes made the whole document
-  about twice the width of the phone, so every paragraph on the page could be
-  dragged sideways and had to be dragged back. That is the bug this fixes; the
-  desktop symptom of the same cause was a table pinned to the measure and
-  squeezing a prose column down to one word per line.
+  This hook started with the wrapper and none of the widths: the cells below
+  are the markup Hugo emits without it. `.table-container { overflow-x: auto }`
+  was written when the single-column layout landed, but Hugo emits a bare
+  <table> and there was no hook to put the div around it, so the rule matched
+  nothing and a wide table had no box to scroll inside. It scrolled the PAGE
+  instead — at 390px the reference tables in the Lightning notes made the whole
+  document about twice the width of the phone, so every paragraph on the page
+  could be dragged sideways and had to be dragged back.
+
+  The wrapper alone fixed the page-scrolling, but left a table pinned to the
+  measure: `width: max-content` sized the table to its content and the scroll
+  box let the right-hand columns run off to the right, so a prose column sat
+  untouched while the reader scrolled ~500px sideways to reach it. The cap
+  below is the second half. Each table gets a <colgroup> whose columns carry a
+  percentage width estimated from the longest thing in them, so a wide table
+  keeps every column on the measure instead of forcing the page to grow:
+
+    - a short column (a number, a date, a code name) is given what its longest
+      cell actually needs, so "2026-08-23" does not wrap into a two-line cell;
+    - a long prose column is capped high enough (120 codepoints) that it keeps
+      a share of the table proportional to its length, rather than a flat equal
+      share — a term/definition table gives the explanation most of the width;
+    - every column is floored at a minimum so a boxed header like "Headings"
+      is never squeezed into a one-glyph-wide sliver, and a short data column
+      like "Role" or a price stays readable instead of being crushed by a long
+      prose neighbour; the floor prefers the prose to give up width first;
+    - after each width is estimated the widths are normalised to a clean 100%,
+      so the table is exactly as wide as the container it sits in and there is
+      nothing left to scroll.
+
+  `table-layout: fixed` in the stylesheet is what makes these widths stick:
+  under auto layout a <col> width is only a hint the content can outgrow, and a
+  long prose cell blows it wide again — which is exactly the bug being fixed.
+  Percentages instead of pixels matter for the same reason: a fixed layout
+  handed pixel columns summing to the desktop measure overflows a phone that is
+  narrower than them, while percentages squash to whatever the container is.
+
+  The width estimate is deliberately crude — `len(.Text)` counts codepoints,
+  not rendered pixels, so a wide glyph (CJK, say) is underpriced. Nothing in
+  the vault renders one today; if it ever does, this undercounts and the table
+  wraps more than it could. That is the safe failure: it still fits the page.
 
   The alignment attribute is Goldmark's own (`|:---|---:|` in the markdown) and
   is emitted as an inline style because that is where a per-cell, per-table
@@ -20,6 +52,9 @@
   `.Attributes` carries any markdown attribute block written above the table.
   Nothing in the vault uses one today; it is passed through so that adopting
   this hook does not quietly drop a feature the bare renderer had.
+
+  A one-column table still gets a width of 100, so it behaves like any other
+  table rather than being a special case the CSS has to remember.
 
   tabindex="0" because a scrolling box has to be scrollable by keyboard.
   Firefox makes an overflow container focusable on its own; Chrome does not, so
@@ -34,11 +69,115 @@
   them is noise bought with nothing. A focusable box with no role is announced
   as what it is, which is accurate.
 */}}
+{{- $headers := index .THead 0 -}}
+{{- if not $headers }}{{ $headers = index .TBody 0 }}{{ end -}}
+{{- $n := len $headers -}}
+
+{{- /* Column width tuning, in px at the 40rem measure. A prose column is
+     capped at $textChars codepoints (120 × $char = 960px): the cap is the bound
+     that stops one pathological cell from eating the table, and it sits high
+     enough that a 150-char column still earns more of the table than a 60-char
+     one — without that a term/definition table splits 50/50 no matter how its
+     columns differ. $min is the per-cell floor, $pad the padding. The share
+     floor $MINW is separate and lives at the end: a short data column keeps at
+     least 10% of the table so that long prose cannot crush "Role" or the price
+     column into a 30px sliver. The floor holds short columns at $MINW but does
+     not guard a column that is long enough to be free: a prose column sitting
+     just above the floor gives up some of its width to the donation and can
+     drop below it. That is the point - prose yields width so a data column is
+     not crushed - and it fails safe because the prose still wraps. */ -}}
+{{- $textChars := 120 }}
+{{- $min := 56 }}
+{{- $char := 8 }}
+{{- $pad := 20 }}
+{{- $MINW := 10.0 }}
+
+{{- /* The longest text in one column, across every header and body row. */ -}}
+{{- $colMax := 0 }}
+
+{{- /* First pass: the sum of every column's weight, so shares can be derived
+     from a known total. $i is the zero-based column index that `range` over the
+     header row provides. */ -}}
+{{- $totalWeight := 0 }}
+{{- range $i, $c := $headers -}}
+  {{- $colMax = 0 -}}
+  {{- range $.THead -}}{{ with (index . $i) }}{{ $l := len .Text }}{{ if gt $l $colMax }}{{ $colMax = $l }}{{ end }}{{ end }}{{ end -}}
+  {{- range $.TBody -}}{{ with (index . $i) }}{{ $l := len .Text }}{{ if gt $l $colMax }}{{ $colMax = $l }}{{ end }}{{ end }}{{ end -}}
+  {{- $w := $colMax -}}
+  {{- if gt $w $textChars }}{{ $w = $textChars }}{{ end -}}
+  {{- $w = mul $w $char -}}
+  {{- if lt $w $min }}{{ $w = $min }}{{ end -}}
+  {{- $totalWeight = add $totalWeight (add $w $pad) -}}
+{{- end -}}
+
+{{- /* Second pass: how much of the table falls below the share floor. A column
+     at or above $MINW is "free" and donates proportionally to raise the others;
+     a column below it is held at $MINW. natural is that column's unrounded
+     percentage of the table. */ -}}
+{{- $nShort := 0 }}
+{{- $freePctSum := 0.0 }}
+{{- range $i, $c := $headers -}}
+  {{- $colMax = 0 -}}
+  {{- range $.THead -}}{{ with (index . $i) }}{{ $l := len .Text }}{{ if gt $l $colMax }}{{ $colMax = $l }}{{ end }}{{ end }}{{ end -}}
+  {{- range $.TBody -}}{{ with (index . $i) }}{{ $l := len .Text }}{{ if gt $l $colMax }}{{ $colMax = $l }}{{ end }}{{ end }}{{ end -}}
+  {{- $w := $colMax -}}
+  {{- if gt $w $textChars }}{{ $w = $textChars }}{{ end -}}
+  {{- $w = mul $w $char -}}
+  {{- if lt $w $min }}{{ $w = $min }}{{ end -}}
+  {{- $w = add $w $pad -}}
+  {{- $natural := div (mul 100.0 (float $w)) (float $totalWeight) -}}
+  {{- if lt $natural $MINW }}
+    {{- $nShort = add $nShort 1 }}
+  {{- else }}
+    {{- $freePctSum = add $freePctSum $natural }}
+  {{- end }}
+{{- end -}}
+{{- /* Apply the floor only when it is achievable. It needs at least one free
+     column to donate from (lt $nShort $n) and the reserved slots to fit
+     ($nShort × $MINW ≤ 100); otherwise short columns outnumber what a 10% share
+     can reserve, forcing $freeRemainder (and a free column's scaled width)
+     negative. In that case the floor is skipped and every column keeps its
+     natural share - no <col> can ever carry a negative width. When the floor
+     does apply, each free column is scaled so the reserved $MINW slots sum with
+     the donated remainder to exactly 100. */ -}}
+{{- $useFloor := false }}
+{{- $minReserve := mul $MINW (float $nShort) }}
+{{- if and (lt $nShort $n) (le $minReserve 100.0) }}{{ $useFloor = true }}{{ end }}
+{{- $freeRemainder := sub 100.0 $minReserve }}
+
+{{- /* used: the exact percentage of every column but the last, so the last can
+     absorb the rounding and the widths sum to a clean 100%. */ -}}
+{{- $used := 0.0 }}
 <div class="table-container" tabindex="0">
   <table
     {{- range $k, $v := .Attributes }}
       {{- with $v }} {{ $k | safeHTMLAttr }}="{{ . }}"{{ end }}
     {{- end }}>
+    <colgroup>
+      {{- range $i, $c := $headers }}
+        {{- $colMax = 0 -}}
+        {{- range $.THead -}}{{ with (index . $i) }}{{ $l := len .Text }}{{ if gt $l $colMax }}{{ $colMax = $l }}{{ end }}{{ end }}{{ end -}}
+        {{- range $.TBody -}}{{ with (index . $i) }}{{ $l := len .Text }}{{ if gt $l $colMax }}{{ $colMax = $l }}{{ end }}{{ end }}{{ end -}}
+        {{- $w := $colMax -}}
+        {{- if gt $w $textChars }}{{ $w = $textChars }}{{ end -}}
+        {{- $w = mul $w $char -}}
+        {{- if lt $w $min }}{{ $w = $min }}{{ end -}}
+        {{- $w = add $w $pad -}}
+        {{- $natural := div (mul 100.0 (float $w)) (float $totalWeight) -}}
+        {{- $pct := $natural -}}
+        {{- if and $useFloor (lt $natural $MINW) }}
+          {{- $pct = $MINW }}
+        {{- else if $useFloor }}
+          {{- $pct = div (mul $natural $freeRemainder) $freePctSum }}
+        {{- end }}
+        {{- if eq $i (sub $n 1) }}
+          <col style="width: {{ printf "%.2f" (sub 100.0 $used) }}%">
+        {{- else }}
+          {{- $used = add $used $pct -}}
+          <col style="width: {{ printf "%.2f" $pct }}%">
+        {{- end }}
+      {{- end }}
+    </colgroup>
     <thead>
       {{- range .THead }}
         <tr>


### PR DESCRIPTION
## What and why

Wide tables in the digital garden kept scrolling the page — first the whole page (no scroll wrapper), then inside a sideways-scrolling box that left prose columns sitting unwrapped ~500px off-screen. This change makes every table fit its measure so prose wraps instead of running off to the right.

## What changed

- **`render-table.html`** (the hook): emits a `<colgroup>` of percentage widths estimated from each column's longest cell. The prose cap (120 codepoints) keeps a longer column proportionally wider (fixes the 50/50 term/definition split); a 10% share floor stops a short data column (`Role`, a price) from being crushed. The floor only applies when it can fit (`nShort × MINW ≤ 100`), so no `<col>` can ever carry a negative width.
- **`main.css`**: `table-layout: fixed; width: 100%` makes the hook's widths stick (under auto layout a `<col>` width is only a hint content can outgrow), plus `overflow-wrap: anywhere; min-width: 0` so long unbreakable tokens wrap rather than blow the page wide.
- **`checks/digital-garden.nix`**: the table guard now parses every `<col>` width and asserts each is a valid positive percentage and the total sums to 100 (±0.1) — so a numerically broken table can't pass the gate just by rendering.

## Validation

- Real vault (`riverview-lighting-upgrade-writeup`) renders all 5 tables on the measure with **no page scroll** at 1600 / 700 / 390px. Long-prose columns now keep proportionally more (e.g. `Project Element | Software Engineering Parallel` → `31 / 69`); short data columns stay readable at the 10% floor.
- `nix build .#checks.x86_64-linux.digital-garden` passes (exit 0), including the hardened width-sum/positive asserts.
- Reviewed by a sub-agent (Go-template scoping/arithmetic, min-share math, CSS, guard robustness); its two real findings (reachable negative width, weak guard) were fixed.

## Notes

- Column widths are estimated on codepoint count, not rendered pixels; a CJK-heavy table would underpricate a column and wrap more than it could — the safe failure (still fits), and nothing in the vault renders one today.
- Nothing committed touches secrets, SSH, firewall, SOPS, or the deploy branch. `master` is the PR target; `deploy` is untouched.