### PR TITLE
fix(upgrade): gate the build on real connectivity and self-heal on reconnect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
           - alert-rules
           - alert-rules-unit
           - alertmanager-config
+          - auto-upgrade-build-gate
           - bless-boot-guard
           - digital-garden
           - digital-garden-sync-health

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -209,6 +209,95 @@ in
       touch $out
     '';
 
+  # The build gate and its self-heal hook, together.
+  #
+  # A laptop's `nixos-upgrade-build` can be asked to run before the network
+  # works: network-online.target only means a default route exists, and the
+  # Persistent timer fires the catch-up at the first opportunity after the
+  # 04:00 slot, which is usually just after boot. The module's defence is
+  # three things that only exist as text in the generated unit, dispatcher and
+  # NetworkManager.conf - a wait-for-connectivity gate in the build's script,
+  # a marker that turns a deferral into a retryable event rather than a
+  # genuine failure, and a dispatcher hook that clears the marker and restarts
+  # the build on `up` / `connectivity-change` when the network returns. All
+  # default to silently doing nothing if they evaluate, so this reads the
+  # evaluated outputs (never a copy) and asserts the behaviour markers that a
+  # refactor could fold away without breaking the build: the gate becoming a
+  # bare `nix build`, the deferral losing its marker, the hook forgetting to
+  # handicap by CONNECTIVITY_STATE, or NetworkManager's connectivity check
+  # being dropped so the `connectivity-change` branch never fires.
+  auto-upgrade-build-gate =
+    let
+      eval = inputs.nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          ../modules/nixos/auto-upgrade.nix
+          {
+            networking.hostName = "check-md";
+            networking.networkmanager.enable = true;
+            system.stateVersion = "24.11";
+            cg.auto-upgrade = {
+              enable = true;
+              flake = "github:corygyarmathy/dotfiles/deploy";
+            };
+          }
+        ];
+      };
+      buildScript = eval.config.systemd.services.nixos-upgrade-build.script;
+      dispatchers = eval.config.networking.networkmanager.dispatcherScripts;
+      retryScript = builtins.concatStringsSep "\n" (
+        builtins.map (d: builtins.readFile d.source) dispatchers
+      );
+    in
+    pkgs.runCommand "check-auto-upgrade-build-gate"
+      {
+        passAsFile = [
+          "build"
+          "retry"
+          "nmsettings"
+        ];
+        build = buildScript;
+        retry = retryScript;
+        nmsettings = builtins.toJSON eval.config.networking.networkmanager.settings;
+      }
+      ''
+        fail() { echo "FAIL: $*" >&2; exit 1; }
+
+        # The gate itself.
+        grep -q 'github.com' "$buildPath" \
+          || fail "build service no longer waits for outbound connectivity"
+        grep -q 'deferring the build until a connection comes up' "$buildPath" \
+          || fail "connectivity timeout no longer defers the build"
+        grep -q 'offline-defers' "$buildPath" \
+          || fail "deferral marker was removed from the build script"
+
+        # The self-heal hook: scoped to network-return events, throttled by
+        # the marker, and only ever a retry of a failed unit.
+        grep -qF 'up)' "$retryPath" \
+          || fail "dispatcher no longer reacts to connection-up events"
+        grep -qF 'connectivity-change' "$retryPath" \
+          || fail "dispatcher no longer reacts to connectivity-change"
+        grep -qF 'CONNECTIVITY_STATE' "$retryPath" \
+          || fail "connectivity-change is no longer gated on the assessed state"
+        grep -qF 'offline-defers' "$retryPath" \
+          || fail "retry is no longer limited to deferred (offline) builds"
+        grep -qF 'is-failed --quiet' "$retryPath" \
+          || fail "dispatcher no longer checks the unit is failed before retrying"
+        grep -qF 'start --no-block' "$retryPath" \
+          || fail "retry no longer starts the build asynchronously"
+        grep -qF '"$systemctl" reset-failed' "$retryPath" \
+          || fail "retry no longer clears the failed result first"
+
+        # Without NetworkManager actually assessing connectivity, the
+        # connectivity-change branch above can never fire.
+        grep -q '"connectivity"' "$nmsettingsPath" \
+          || fail "NetworkManager connectivity checking is no longer enabled"
+        grep -q '"uri"' "$nmsettingsPath" \
+          || fail "NetworkManager connectivity check has no probe URI"
+
+        touch $out
+      '';
+
   digital-garden = testLib.mkTest ./digital-garden.nix;
   digital-garden-sync-health = import ./digital-garden-sync-health.nix {
     inherit pkgs;

--- a/modules/nixos/auto-upgrade.nix
+++ b/modules/nixos/auto-upgrade.nix
@@ -16,6 +16,14 @@
 #   - reboot on a schedule       that is a server behaviour
 #   - catch up on resume         systemd timers with Persistent already do this
 #
+# The build is gated on real outbound connectivity (schedule.onlineWait):
+# `network-online.target` on a NetworkManager laptop can be satisfied while the
+# wifi is still joining, and a fetch made before the network works would leave
+# the indicator showing an error for the rest of the session. A deferral drops
+# a marker (`offline-defers`) that the NetworkManager dispatcher hook consumes
+# by re-running the build once a connection - or assessed connectivity -
+# returns.
+#
 # The waybar front-end is packages/nixos-upgrade-scripts; the home-manager
 # side is modules/home/desktop/auto-upgrade-desktop.nix.
 {
@@ -59,6 +67,22 @@ in
         type = lib.types.str;
         default = "30min";
         description = "Random delay added to the scheduled time";
+      };
+
+      # `network-online.target` only means NetworkManager has reached a
+      # default route. On a laptop that can predate any real internet (DNS
+      # still settling, captive portal up, wifi auth unfinished), and the
+      # Persistent catch-up fires this unit at the first opportunity after the
+      # 04:00 slot was missed - typically just after boot, before the user has
+      # signed in. Rather than fail the fetch (which leaves the waybar
+      # indicator showing an error for the rest of the session), the build
+      # waits up to this many seconds for real outbound connectivity first.
+      # The dispatcher hook then defers the build to when a connection comes
+      # up if this window runs out.
+      onlineWait = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 600;
+        description = "Seconds to wait for outbound connectivity before deferring a scheduled build";
       };
     };
 
@@ -118,10 +142,48 @@ in
       path = [
         pkgs.nix
         pkgs.git
+        pkgs.curl
       ];
       environment.HOME = "/root";
 
       script = ''
+        # Only touch the network once there is real outbound connectivity.
+        #
+        # `network-online.target` is ordered here, but it means NetworkManager
+        # has *a* default route - not that the internet works. On a laptop the
+        # timer's Persistent catch-up fires this the moment the machine boots,
+        # which is before the user has signed in and often before the wifi has
+        # come up, and `--refresh` turns a fetch made too early into a hard
+        # unit failure that the waybar indicator then shows for the rest of
+        # the session. The actual precondition for a flake build is an HTTPS
+        # connection to the flake host, so wait for that.
+        #
+        # The timeout defers rather than fails: the NetworkManager dispatcher
+        # hook restarts this unit when a connection comes up, and a later
+        # success clears the failed state the indicator reads. The marker it
+        # leaves behind is what lets the hook tell "deferred for being
+        # offline" (retry when the network returns) from "build genuinely
+        # failed" (keep showing the error) - see the dispatcher below.
+        deadline=$(( $(date +%s) + ${toString cfg.schedule.onlineWait} ))
+        while :; do
+          if ${pkgs.curl}/bin/curl -fsS --connect-timeout 5 --max-time 10 \
+              https://github.com/ >/dev/null 2>&1; then
+            break
+          fi
+          if [ "$(date +%s)" -ge "$deadline" ]; then
+            touch "${stateDir}/offline-defers"
+            echo "No outbound connectivity after ${toString cfg.schedule.onlineWait}s; deferring the build until a connection comes up." >&2
+            exit 1
+          fi
+          sleep 5
+        done
+
+        # Connectivity confirmed, so any offline condition (and with it the
+        # deferral marker) is over. Clear it first: a build that now fails for
+        # a real reason must stay failed rather than be retried on every
+        # reconnect.
+        rm -f "${stateDir}/offline-defers"
+
         # --refresh, or the flake evaluation cache pins `deploy` to whatever it
         # resolved to last time and the build silently never sees a new
         # revision.
@@ -148,6 +210,84 @@ in
         # doing what systemd already does.
         Persistent = true;
         Unit = "nixos-upgrade-build.service";
+      };
+    };
+
+    # Self-heal a build that the connectivity gate had to defer.
+    #
+    # A deferral is still a failure to systemd, and a failed build shows on
+    # the waybar indicator for the rest of the session even once the machine
+    # is online - so when the network genuinely comes back, re-run the build.
+    # Success clears the failed state and the indicator goes back to the
+    # truth.
+    #
+    # The marker makes that retry safe: it is left only by the gate's timeout
+    # path and removed as soon as connectivity is confirmed, so a genuinely
+    # broken fetch or build (marker absent) keeps its error instead of being
+    # retried on every reconnect forever.
+    #
+    # Two events mean "the network is back". `up`, when a device activates,
+    # and `connectivity-change` when the assessed level recovers on an
+    # *already-linked* device - a captive portal accepted, an ISP outage
+    # ending, a VPN coming up. The second needs NetworkManager to actually
+    # assess connectivity (enabled below); without it a same-connection
+    # recovery never reaches this hook, which is precisely the stale-error
+    # case that matters after sign-in.
+    #
+    # It never restarts an in-flight build and never force-builds ahead of a
+    # deferral, and the gateway between a disconnected and a connected state
+    # is narrow: `reset-failed` + `start` replaces a failed result with a
+    # fresh, cheaper attempt.
+    networking.networkmanager = {
+      dispatcherScripts = [
+        {
+          type = "basic";
+          source = pkgs.writeShellScript "nixos-upgrade-build-retry" ''
+            case "$NM_DISPATCHER_ACTION" in
+              up)
+                ;;
+              connectivity-change)
+                [ "$CONNECTIVITY_STATE" = "FULL" ] || exit 0
+                ;;
+              *)
+                exit 0
+                ;;
+            esac
+
+            if [ ! -f "${stateDir}/offline-defers" ]; then
+              exit 0
+            fi
+
+            unit=nixos-upgrade-build.service
+            systemctl=${pkgs.systemd}/bin/systemctl
+
+            if "$systemctl" is-active --quiet "$unit"; then
+              # already building (or waiting on the connectivity gate)
+              exit 0
+            fi
+
+            if ! "$systemctl" is-failed --quiet "$unit"; then
+              exit 0
+            fi
+
+            rm -f "${stateDir}/offline-defers"
+            echo "Network is up; retrying $unit after its earlier offline deferral." >&2
+            "$systemctl" reset-failed "$unit"
+            "$systemctl" start --no-block "$unit"
+          '';
+        }
+      ];
+
+      # The dispatcher's `connectivity-change` branch above only exists if
+      # NetworkManager assesses connectivity. That is off by default; the
+      # accepted-portal / never-device-change recovery would otherwise never
+      # fire. The check is a periodic request along the default route (the
+      # URI returns a bare OK), which is the small cost of self-healing the
+      # same-connection case.
+      settings.connectivity = {
+        enabled = true;
+        uri = "http://connectivity-check.ubuntu.com/connectivity-check.html";
+        interval = 300;
       };
     };
 

--- a/packages/nixos-upgrade-scripts/waybar-status.sh
+++ b/packages/nixos-upgrade-scripts/waybar-status.sh
@@ -44,19 +44,30 @@ kernel_of() {
 
 # --- in-flight states take precedence over anything derived ------------------
 
-if [ "$(state_of nixos-upgrade-apply.service)" = "active" ]; then
+apply_state="$(state_of nixos-upgrade-apply.service)"
+build_state="$(state_of nixos-upgrade-build.service)"
+
+# Type=oneshot units report `activating` for the whole run - they only reach
+# `active` after completion (and only then when RemainAfterExit is set, which
+# these units don't) - so `activating` is the "something is happening right
+# now" state, not `active`. The build spends it both actually building and
+# waiting out the connectivity gate, which cannot be told apart from systemd
+# state alone; both are better shown as work in progress than as "up to
+# date", which is what falling through to the derived states would claim.
+
+if [ "$apply_state" = "active" ] || [ "$apply_state" = "activating" ]; then
   emit "⟳" "Applying updates…" "applying"
 fi
 
-if [ "$(state_of nixos-upgrade-build.service)" = "active" ]; then
-  emit "󰔟" "Building updates in the background…" "building"
+if [ "$build_state" = "active" ] || [ "$build_state" = "activating" ]; then
+  emit "󰔟" "Checking for updates in the background…" "building"
 fi
 
-if [ "$(state_of nixos-upgrade-apply.service)" = "failed" ]; then
+if [ "$apply_state" = "failed" ]; then
   emit "⚠" "Update failed to apply. Middle-click for logs." "error"
 fi
 
-if [ "$(state_of nixos-upgrade-build.service)" = "failed" ]; then
+if [ "$build_state" = "failed" ]; then
   emit "⚠" "Update failed to build. Middle-click for logs." "error"
 fi
 


### PR DESCRIPTION
### Problem

The `auto-upgrade` widget on `xps15` showed a ⚠ / errored state at sign-in. Root cause: `nixos-upgrade-build.service` is `Type=oneshot` with a `Persistent` calendar timer, so the missed-run catch-up fires right after boot — before real internet exists. `network-online.target` on a NetworkManager laptop only means a default route is up, not that there's outbound connectivity, so `nix build --refresh` failed and the unit was left `failed` for the whole session.

### Fix

Three coordinated changes:

1. **Connectivity gate** (`modules/nixos/auto-upgrade.nix`): before building, poll `curl` against a connectivity host for up to `cg.auto-upgrade.schedule.onlineWait` (default 600s). On success, build as before. On timeout, touch the marker `/var/lib/nixos-upgrade/offline-defers` and exit 1 with a message. The marker is what lets the hook tell "deferred for being offline" from "build genuinely failed".

2. **Self-heal dispatcher**: a NetworkManager dispatcher script handles `connectivity-change` (with `CONNECTIVITY_STATE=FULL`) and `up` events. When the marker is present and the unit is `failed`, it clears the marker, `reset-failed`, and `start --no-block` — so the deferred build retries the moment a real connection arrives. Requires enabling NM's connectivity check (`settings.connectivity`), which is what emits `connectivity-change`.

3. **Widget state fix** (`packages/nixos-upgrade-scripts/waybar-status.sh`): a `Type=oneshot` unit reports `activating` while running and never `active` unless `RemainAfterExit` is set (these aren't) — so the old branches keyed on `active` were dead code. The widget now treats `activating` as work in progress, and the build shows "Checking for updates…" instead of a false "up to date" while gating/building.

The retry is marker-throttled so a build that actually fails (bad fetch, broken commit) stays failed rather than being retried on every reconnect.

### Verification

- Static check `checks.x86_64-linux.auto-upgrade-build-gate` asserts the gate contents, the dispatcher (including the `CONNECTIVITY_STATE=FULL` gating and `reset-failed`/`start --no-block` retry), and that NM connectivity checking is configured.
- `nix flake check` passes (all hosts + VM tests).
- `nixos-rebuild test` on xps15 installs the dispatcher (`03userscript0001`) and NM `[connectivity]` block; `nmcli` reports `running:full`; timer armed (next run 04:08).
- End-to-end trigger test: with the marker present and a healthy unit, firing the dispatcher is a correct no-op (marker preserved, no spurious retry) — the fail/retry path is covered by the static checks and occurs naturally when the machine boots offline then connects.