### PR TITLE
chore(nix): silence nix flake check warnings

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -177,9 +177,20 @@
                   sharedModules = [
                     sops-nix.homeManagerModules.sops
                   ]
-                  ++ lib.optional (!config.cg.stylix.enable) inputs.stylix.homeModules.stylix;
-                  # ^ If system-level stylix is NOT enabled (like on servers),
-                  # safely inject the schema so `stylix-hm.nix` doesn't crash!
+                  # No host sets cg.stylix.enable (xps15 enables the raw
+                  # `stylix.enable` instead), so this injects the schema on
+                  # every host so `stylix-hm.nix` doesn't crash.
+                  ++ lib.optional (!config.cg.stylix.enable) {
+                    imports = [
+                      inputs.stylix.homeModules.stylix
+                    ];
+                    # With `home-manager.useGlobalPkgs` the Home Manager
+                    # `nixpkgs.*` options are inert and setting them is a
+                    # warning (soon an error). Stylix injects them through its
+                    # overlays, so switch those off here - matching what
+                    # Stylix's own `useGlobalPkgs` integration does.
+                    stylix.overlays.enable = false;
+                  };
                 };
               }
             )
@@ -258,6 +269,9 @@
           garden-preview = {
             type = "app";
             program = nixpkgs.lib.getExe preview;
+            meta = {
+              description = "Local preview that renders and serves the digital garden exactly as the server does";
+            };
           };
         }
       );

--- a/hosts/xps15/default.nix
+++ b/hosts/xps15/default.nix
@@ -155,10 +155,7 @@
   services.blueman.enable = false;
 
   # Logitech wireless devices
-  hardware.logitech.wireless = {
-    enable = true;
-    enableGraphical = true;
-  };
+  programs.solaar.enable = true;
 
   # ============================================================================
   # Audio

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -18,7 +18,7 @@
     # https://github.com/NixOS/nixpkgs/issues/514113
     openldap = prev.openldap.overrideAttrs (
       old:
-      final.lib.optionalAttrs final.stdenv.is32bit {
+      final.lib.optionalAttrs final.stdenv.hostPlatform.is32bit {
         doCheck = false;
       }
     );


### PR DESCRIPTION
## Summary

Fixes the four warnings shown by `nix flake check` on `master`:

1. `stdenv.is32bit` deprecation — `overlays/default.nix` uses `stdenv.hostPlatform.is32bit` instead.
2. Home Manager `nixpkgs.*` options while `home-manager.useGlobalPkgs` is enabled (homelab01/02): Stylix's home module injects `nixpkgs.overlays`, which HM warns about (soon an error) under `useGlobalPkgs`. Disabling `stylix.overlays.enable` on the injected HM module mirrors what Stylix's own `useGlobalPkgs` integration already does; the overlays were no-ops on the servers anyway.
3. `hardware.logitech.wireless.enableGraphical` rename — xps15 now uses `programs.solaar.enable = true` (which preserves the old `hardware.logitech.wireless.enable` via `mkDefault` and installs solaar).
4. `garden-preview` app missing `meta` — added `meta.description`.

No behavior changes intended. Each change is minimal and follows the existing module patterns.

## Verification

- `nix flake check` — all 12 checks pass (includes NixOS VM behavior tests). Only remaining message is the pre-existing informational "aarch64-linux omitted".
- `nix fmt -- --ci` on the changed files — 0 changes.

## Notes

- `flake.lock` untouched.
- No deployment/services/security behavior changed.