### PR TITLE
fix(garden): let the browser measure a table's columns

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -456,9 +456,9 @@
         assert "fonts.googleapis.com" not in css and "fonts.gstatic.com" not in css, \
             "the stylesheet fetches a font from a CDN"
 
-    with subtest("a table is capped to the measure, not scrolled past it"):
-        # Two independent failures are guarded here, each of which alone is a
-        # bug.
+    with subtest("a table wraps to the page, and scrolls only when it cannot"):
+        # Three independent failures are guarded here, each of which alone is a
+        # bug, and two of which have actually shipped.
         #
         # The first is the wrapper: `.table-container { overflow-x: auto }` sat
         # in the stylesheet for weeks with no hook to emit the div, so it
@@ -469,47 +469,57 @@
         # halves are asserted: the selector exists in the stylesheet, AND the
         # markup an actual table produces contains it.
         #
-        # The second is the cap. The wrapper alone left a wide table scrolled
-        # inside its box - better than scrolling the page, but the right-hand
-        # columns sat off-screen and another ~500px of sideways scroll was still
-        # the interface. The hook now emits a <colgroup> of percentage widths
-        # summed to 100%, and the stylesheet honours them with
-        # `table-layout: fixed; width: 100%`, so every column stays on the
-        # measure and nothing is left to scroll. That only works if all three
-        # halves land on an actual table rendered through the hook:
+        # The second and third are the two ways of sizing a column by hand,
+        # both of which were tried and both of which were worse than letting
+        # the browser measure it:
         #
-        #   - the hook emitted the <colgroup> (a table whose widths are left to
-        #     auto layout can blow a prose column wide again);
-        #   - the stylesheet applies fixed layout (a <col> width is a hint the
-        #     content can outgrow under auto layout);
-        #   - the old `width: max-content` that made the table as wide as its
-        #     content is gone (under fixed layout it would fight the cap).
+        #   - `width: max-content` sized the table to its content, so nothing
+        #     wrapped and every table wider than the measure became one long
+        #     line inside a scroll box;
+        #   - `table-layout: fixed` over a <colgroup> of percentages estimated
+        #     from codepoint counts made those estimates binding, so on a phone
+        #     a 10% column was about two characters and "Backlinks" was set as
+        #     nine stacked letters.
+        #
+        # Automatic layout has neither failure because it measures glyphs at the
+        # width the page is being read at. It is the absence of the two overrides
+        # that makes it work, and an absence is exactly what a future edit
+        # reintroduces without noticing - so both are pinned negative.
         page = served("/on-gates")
         assert "MARKER-TABLE-CELL" in page, "the fixture table did not render"
         assert re.search(r'<div class="table-container"[^>]*>\s*<table', page), \
             "a table is not wrapped in .table-container"
         assert ".table-container" in css, \
             ".table-container missing from the stylesheet"
-        assert re.search(r'<table[^>]*>\s*<colgroup>\s*<col\s+style="width:\s*\d', page), \
-            "the table has no <colgroup> width cap from the hook"
-        # Presence is not enough: the widths could be negative, out of range, or
-        # fail to sum to a table that fills the measure. Parse every column the
-        # fixture's table emits and check both - a positive percentage each, and
-        # a total of 100 (within rounding). A negative fallback (an impossible
-        # table of eleven short columns plus a prose one) would be caught here.
-        col_widths = [float(m)
-                      for m in re.findall(r'<col\s+style="width:\s*(-?\d+\.\d+|-?\d+)%"', page)]
-        assert col_widths, "the table emitted no parseable <col> widths"
-        assert all(0.0 < w <= 100.0 for w in col_widths), \
-            f"a table column has an out-of-range width: {col_widths}"
-        assert abs(sum(col_widths) - 100.0) < 0.1, \
-            f"a table's columns do not sum to 100%: {col_widths} = {sum(col_widths)}"
-        assert re.search(r'table\s*{[^}]*table-layout:\s*fixed', css), \
-            "tables are not laid out with fixed width"
+        assert "<colgroup" not in page, \
+            "the hook is estimating column widths again; the browser measures better"
+        assert not re.search(r'table\s*{[^}]*table-layout:\s*fixed', css), \
+            "fixed layout is back, which makes an estimated width binding"
+        assert not re.search(r'table\s*{[^}]*width:\s*max-content', css), \
+            "the table rule sizes the table to its content again, so nothing wraps"
         assert re.search(r'table\s*{[^}]*width:\s*100%', css), \
             "tables do not fill the measure"
-        assert not re.search(r'table\s*{[^}]*width:\s*max-content', css), \
-            "the table rule still sizes the table to its content, so the cap would fight it"
+        # `anywhere` lets a break count towards the minimum width a cell reports,
+        # so a column can be squeezed to one character and still claim to fit -
+        # which is how the fixed layout produced its stacked letters, and it
+        # would do the same under auto layout. `break-word` reports the honest
+        # minimum. The two differ by one word and by exactly this bug.
+        assert re.search(r'\bth,\s*\n\s*td\s*{[^}]*overflow-wrap:\s*break-word', css), \
+            "cells do not wrap with break-word"
+        assert not re.search(r'\bth,\s*\n\s*td\s*{[^}]*overflow-wrap:\s*anywhere', css), \
+            "cells wrap with `anywhere`, which lets a column be sized below a word"
+        # A table that scrolls has to say so. On a phone there is no scrollbar
+        # until you touch the box, so a clipped table with no shadow on its edge
+        # reads as a broken table rather than a scrollable one. The shadow pair
+        # is `local` covers over `scroll` shadows; the `local` keyword is the
+        # whole trick, so that is what is pinned.
+        assert re.search(r'\.table-container\s*{[^}]*\blocal\b', css), \
+            "the scroll shadow on a table container is gone"
+        # And paper, which cannot scroll: the box must stop clipping there, or a
+        # wide table prints with its right-hand columns cut off.
+        assert re.search(r'@media print\s*{.*\.table-container\s*{[^}]*overflow-x:\s*visible',
+                         css, re.S), \
+            "a wide table is still clipped when printed"
 
     with subtest("the page declares a tab icon"):
         # Without one the browser asks for /favicon.ico on every visit and gets

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -597,13 +597,40 @@ mark {
  * while this rule was written and the hook was not, so it matched nothing and
  * the page did the scrolling — see that file.
  *
- * Today the table fits the measure by construction — see `table` below — so
- * the scroll bar sits unused on a well-sized table. It is kept because the
- * width estimate in the hook is intentionally crude: a table of exceptional
- * glyphs (CJK, say) underprices a column and overflows, and when that happens
- * we want the overflow consumed here rather than scrolling the page. */
+ * Most tables fit and this box never scrolls. The ones that do not fit are
+ * genuinely wider than a phone: seven columns whose headers alone ("Backlinks",
+ * "Published") want nine characters each cannot be shown at 390px, and every
+ * attempt to make them fit has been worse than scrolling them.
+ *
+ * So the scroll needs to be visible, because a table that is clipped at the
+ * screen edge with nothing to say so reads as a broken table rather than a
+ * scrollable one — and a phone draws no scrollbar until you touch it. The four
+ * backgrounds are the standard shadow pair: two `local` gradients painted in
+ * the page colour that travel WITH the content, parked over the two ends, and
+ * two `scroll` shadows underneath them that do not move. At rest the cover sits
+ * on the shadow and hides it; scroll away from an end and the cover slides off,
+ * uncovering the shadow on the side there is more content on. No script, and it
+ * is self-correcting — it responds to the actual scroll position, so it is
+ * right at every width without anything having to measure the table. */
 .table-container {
   overflow-x: auto;
+  background:
+    linear-gradient(to right, var(--bg) 60%, transparent) left / 2rem 100% no-repeat
+      local,
+    linear-gradient(to left, var(--bg) 60%, transparent) right / 2rem 100% no-repeat
+      local,
+    radial-gradient(
+        farthest-side at 0 50%,
+        color-mix(in srgb, var(--text) 30%, transparent),
+        transparent
+      )
+      left / 0.9rem 100% no-repeat scroll,
+    radial-gradient(
+        farthest-side at 100% 50%,
+        color-mix(in srgb, var(--text) 30%, transparent),
+        transparent
+      )
+      right / 0.9rem 100% no-repeat scroll;
 }
 
 /* Both of the page's scrollable boxes, showing that they have been reached.
@@ -628,27 +655,43 @@ pre:focus-visible {
   padding: 0.2rem 0;
 }
 
-/* The width estimate that used to live on the table is gone. What was
- * `width: max-content` sized the table to its content, so a wide table
- * scrolled inside .table-container and a prose column sat untouched at 450px
- * while the reader scrolled the rest of the way sideways — the exact thing the
- * container was meant to replace. `fixed` + `100%` instead takes the measures
- * the hook put on each <col> and uses them verbatim, so every column stays on
- * the measure and prose wraps at a readable cap instead of running off to the
- * right. The columns already sum to 100%, so the table is exactly the width of
- * the box it sits in.
+/* Automatic layout, and nothing else. Two attempts to size these columns by
+ * hand are behind this rule and both failed in the same place — the width of a
+ * column is a question about glyphs and about the width of the window, and
+ * neither a stylesheet nor a template can see either one.
  *
- * `overflow-wrap: anywhere` and `min-width: 0` are what let a cell wrap
- * rather than fitting its content to one long unbroken line. A fixed table
- * will not wrap a cell on its own; it honours the col width and lets the text
- * break at the box edge — good for prose, but it turns a long unbreakable token
- * into a page-wide overflow. `anywhere` caps that (the stronger of the two
- * break modes, which is what keeps a token from widening the page), and without
- * `min-width: 0` a grid or block child would still force the min-content width
- * and overflow anyway. */
+ * `width: max-content` was the first: it sized the table to its content, so
+ * nothing wrapped and every table wider than the measure became one long line
+ * inside a scroll box, a prose column sitting untouched at 450px while the
+ * reader dragged sideways to reach it.
+ *
+ * `table-layout: fixed` over estimated <col> percentages was the second, and it
+ * traded that for a worse fault: fixed layout honours the declared width no
+ * matter what is in the cell, so a column whose estimate came out at 10% of a
+ * 350px phone was two characters wide and set "Backlinks" as nine stacked
+ * letters. The percentages could not know the viewport; the estimates could not
+ * know the glyphs.
+ *
+ * Automatic layout knows both. It measures each column's content, gives every
+ * one at least the width of its longest word so a header is never broken, and
+ * spends what is left over on the columns that asked for the most — which is
+ * the prose column, every time. When the total will not fit it lets the table
+ * overflow, and .table-container above turns that into a scroll with a shadow
+ * on it. Fits when it can, scrolls when it cannot, and the decision is made at
+ * the width the page is actually being read at.
+ *
+ * `width: 100%` so a table still spans the measure rather than shrink-wrapping
+ * to its content, which is the look the site already had.
+ *
+ * `overflow-wrap: break-word` rather than `anywhere`: `anywhere` lets a break
+ * count towards the minimum width a cell reports, so a column can be squeezed
+ * to one character and still claim to fit — exactly how the fixed layout above
+ * produced its stacked letters. `break-word` breaks the same long token when
+ * one genuinely does not fit, but reports the honest minimum, so a column is
+ * never sized below a word. A token longer than the whole table (a URL) makes
+ * the table wide instead, and it scrolls. */
 table {
   border-collapse: collapse;
-  table-layout: fixed;
   width: 100%;
 }
 
@@ -657,8 +700,7 @@ td {
   border-bottom: 1px solid var(--border);
   padding: 0.4rem 0.6rem;
   text-align: left;
-  overflow-wrap: anywhere;
-  min-width: 0;
+  overflow-wrap: break-word;
 }
 
 /* ── heading anchors ────────────────────────────────────────────────────── */
@@ -1105,6 +1147,22 @@ pagefind-modal {
   h3,
   h4 {
     break-after: avoid;
+  }
+
+  /* Paper does not scroll, so the one thing the screen relies on for a wide
+   * table is not available here. The container stops clipping and the shadows
+   * that advertised the scroll come off — on paper they are two grey smudges
+   * advertising a gesture nobody can make. A table still too wide for the page
+   * is set smaller rather than cut off; below about this size the type stops
+   * being worth printing, so that is where the shrinking stops and a table
+   * wider than that is simply a table this sheet cannot hold. */
+  .table-container {
+    overflow-x: visible;
+    background: none;
+  }
+
+  table {
+    font-size: 0.85em;
   }
 
   pre,

--- a/modules/services/digital-garden/lib/hugo/fixture/Every Element.md
+++ b/modules/services/digital-garden/lib/hugo/fixture/Every Element.md
@@ -119,6 +119,14 @@ A table wide enough to scroll inside its own container:
 | Riverview Lighting Upgrade  | 5871  | 29       | 0         | 2026-08-23 | 2026-08-27 | A year of volunteer work, written down while it is still true |
 | Relationship with Work      | 1604  | 0        | 0         | 2026-08-23 | 2026-08-23 | Work is a trade, and a trade has two sides                    |
 
+And a table holding a token no line break can shorten, which is the case that
+decides how a cell is allowed to wrap — it must widen the table and scroll
+rather than be cut into stacked fragments:
+
+| Endpoint                                                             | Note        |
+| -------------------------------------------------------------------- | ----------- |
+| `https://example.invalid/a/very/long/path/that/never/breaks/anywhere` | It is long. |
+
 ## An image
 
 Diagrams in the vault are frequently light-background scans and exports, which is the case worth looking at on a dark page:

--- a/modules/services/digital-garden/lib/hugo/layouts/_markup/render-table.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_markup/render-table.html
@@ -1,48 +1,33 @@
 {{/*
-  A table, wrapped in the scroll container the stylesheet has always styled,
-  with a column cap so a wide table never overflows the measure.
+  A table, wrapped in the scroll container the stylesheet styles. The cells
+  below are the markup Hugo emits without this hook; the wrapper is the only
+  thing being added, because Hugo emits a bare <table> and there is no other
+  place to put a div around it.
 
-  This hook started with the wrapper and none of the widths: the cells below
-  are the markup Hugo emits without it. `.table-container { overflow-x: auto }`
-  was written when the single-column layout landed, but Hugo emits a bare
-  <table> and there was no hook to put the div around it, so the rule matched
-  nothing and a wide table had no box to scroll inside. It scrolled the PAGE
-  instead — at 390px the reference tables in the Lightning notes made the whole
-  document about twice the width of the phone, so every paragraph on the page
-  could be dragged sideways and had to be dragged back.
+  `.table-container { overflow-x: auto }` was written when the single-column
+  layout landed, but with no hook to emit the div the rule matched nothing and
+  a wide table had no box to scroll inside. It scrolled the PAGE instead — at
+  390px the reference tables in the Lightning notes made the whole document
+  about twice the width of the phone, so every paragraph could be dragged
+  sideways and had to be dragged back.
 
-  The wrapper alone fixed the page-scrolling, but left a table pinned to the
-  measure: `width: max-content` sized the table to its content and the scroll
-  box let the right-hand columns run off to the right, so a prose column sat
-  untouched while the reader scrolled ~500px sideways to reach it. The cap
-  below is the second half. Each table gets a <colgroup> whose columns carry a
-  percentage width estimated from the longest thing in them, so a wide table
-  keeps every column on the measure instead of forcing the page to grow:
+  This hook once also emitted a <colgroup> of estimated percentage widths, to
+  keep a wide table on the measure rather than scrolling. It is gone, and the
+  reasoning is worth keeping because the idea is tempting: the widths were
+  estimated from `len(.Text)`, a codepoint count, and a codepoint count is not
+  a width. Under `table-layout: fixed` those estimates were binding, so where
+  the estimate was wrong the column was wrong — on a phone a 10% column of a
+  350px viewport is about two characters of content, and "Backlinks" came out
+  as nine stacked letters while "2026-08-23" came out as five stacked
+  fragments. Under `table-layout: auto` they are merely a preference the
+  browser can honour, which sounds harmless and is not: measured against the
+  fixture the estimates were simply worse than the browser's own measurement,
+  wrapping "Datelines, theses, captions" onto two lines in a column that had
+  room for one.
 
-    - a short column (a number, a date, a code name) is given what its longest
-      cell actually needs, so "2026-08-23" does not wrap into a two-line cell;
-    - a long prose column is capped high enough (120 codepoints) that it keeps
-      a share of the table proportional to its length, rather than a flat equal
-      share — a term/definition table gives the explanation most of the width;
-    - every column is floored at a minimum so a boxed header like "Headings"
-      is never squeezed into a one-glyph-wide sliver, and a short data column
-      like "Role" or a price stays readable instead of being crushed by a long
-      prose neighbour; the floor prefers the prose to give up width first;
-    - after each width is estimated the widths are normalised to a clean 100%,
-      so the table is exactly as wide as the container it sits in and there is
-      nothing left to scroll.
-
-  `table-layout: fixed` in the stylesheet is what makes these widths stick:
-  under auto layout a <col> width is only a hint the content can outgrow, and a
-  long prose cell blows it wide again — which is exactly the bug being fixed.
-  Percentages instead of pixels matter for the same reason: a fixed layout
-  handed pixel columns summing to the desktop measure overflows a phone that is
-  narrower than them, while percentages squash to whatever the container is.
-
-  The width estimate is deliberately crude — `len(.Text)` counts codepoints,
-  not rendered pixels, so a wide glyph (CJK, say) is underpriced. Nothing in
-  the vault renders one today; if it ever does, this undercounts and the table
-  wraps more than it could. That is the safe failure: it still fits the page.
+  What replaced them is the browser's automatic table layout, which does this
+  arithmetic against real glyph widths and does it at whatever width the page
+  is actually being read at. See `table` in the stylesheet.
 
   The alignment attribute is Goldmark's own (`|:---|---:|` in the markdown) and
   is emitted as an inline style because that is where a per-cell, per-table
@@ -53,131 +38,24 @@
   Nothing in the vault uses one today; it is passed through so that adopting
   this hook does not quietly drop a feature the bare renderer had.
 
-  A one-column table still gets a width of 100, so it behaves like any other
-  table rather than being a special case the CSS has to remember.
-
   tabindex="0" because a scrolling box has to be scrollable by keyboard.
   Firefox makes an overflow container focusable on its own; Chrome does not, so
   without this a reader on a keyboard could reach every other part of the page
-  and not the right-hand columns of a wide table - which would be a worse
+  and not the right-hand columns of a wide table — which would be a worse
   regression than the page-scrolling this replaces, since the page at least
   scrolled. The cost is one tab stop per table, and tables are rare here.
 
   role and aria-label deliberately absent. The pattern usually pairs tabindex
-  with role="region" and a name, but the name would have to be invented - these
-  tables have no captions - and "region: table" announced before every one of
+  with role="region" and a name, but the name would have to be invented — these
+  tables have no captions — and "region: table" announced before every one of
   them is noise bought with nothing. A focusable box with no role is announced
   as what it is, which is accurate.
 */}}
-{{- $headers := index .THead 0 -}}
-{{- if not $headers }}{{ $headers = index .TBody 0 }}{{ end -}}
-{{- $n := len $headers -}}
-
-{{- /* Column width tuning, in px at the 40rem measure. A prose column is
-     capped at $textChars codepoints (120 × $char = 960px): the cap is the bound
-     that stops one pathological cell from eating the table, and it sits high
-     enough that a 150-char column still earns more of the table than a 60-char
-     one — without that a term/definition table splits 50/50 no matter how its
-     columns differ. $min is the per-cell floor, $pad the padding. The share
-     floor $MINW is separate and lives at the end: a short data column keeps at
-     least 10% of the table so that long prose cannot crush "Role" or the price
-     column into a 30px sliver. The floor holds short columns at $MINW but does
-     not guard a column that is long enough to be free: a prose column sitting
-     just above the floor gives up some of its width to the donation and can
-     drop below it. That is the point - prose yields width so a data column is
-     not crushed - and it fails safe because the prose still wraps. */ -}}
-{{- $textChars := 120 }}
-{{- $min := 56 }}
-{{- $char := 8 }}
-{{- $pad := 20 }}
-{{- $MINW := 10.0 }}
-
-{{- /* The longest text in one column, across every header and body row. */ -}}
-{{- $colMax := 0 }}
-
-{{- /* First pass: the sum of every column's weight, so shares can be derived
-     from a known total. $i is the zero-based column index that `range` over the
-     header row provides. */ -}}
-{{- $totalWeight := 0 }}
-{{- range $i, $c := $headers -}}
-  {{- $colMax = 0 -}}
-  {{- range $.THead -}}{{ with (index . $i) }}{{ $l := len .Text }}{{ if gt $l $colMax }}{{ $colMax = $l }}{{ end }}{{ end }}{{ end -}}
-  {{- range $.TBody -}}{{ with (index . $i) }}{{ $l := len .Text }}{{ if gt $l $colMax }}{{ $colMax = $l }}{{ end }}{{ end }}{{ end -}}
-  {{- $w := $colMax -}}
-  {{- if gt $w $textChars }}{{ $w = $textChars }}{{ end -}}
-  {{- $w = mul $w $char -}}
-  {{- if lt $w $min }}{{ $w = $min }}{{ end -}}
-  {{- $totalWeight = add $totalWeight (add $w $pad) -}}
-{{- end -}}
-
-{{- /* Second pass: how much of the table falls below the share floor. A column
-     at or above $MINW is "free" and donates proportionally to raise the others;
-     a column below it is held at $MINW. natural is that column's unrounded
-     percentage of the table. */ -}}
-{{- $nShort := 0 }}
-{{- $freePctSum := 0.0 }}
-{{- range $i, $c := $headers -}}
-  {{- $colMax = 0 -}}
-  {{- range $.THead -}}{{ with (index . $i) }}{{ $l := len .Text }}{{ if gt $l $colMax }}{{ $colMax = $l }}{{ end }}{{ end }}{{ end -}}
-  {{- range $.TBody -}}{{ with (index . $i) }}{{ $l := len .Text }}{{ if gt $l $colMax }}{{ $colMax = $l }}{{ end }}{{ end }}{{ end -}}
-  {{- $w := $colMax -}}
-  {{- if gt $w $textChars }}{{ $w = $textChars }}{{ end -}}
-  {{- $w = mul $w $char -}}
-  {{- if lt $w $min }}{{ $w = $min }}{{ end -}}
-  {{- $w = add $w $pad -}}
-  {{- $natural := div (mul 100.0 (float $w)) (float $totalWeight) -}}
-  {{- if lt $natural $MINW }}
-    {{- $nShort = add $nShort 1 }}
-  {{- else }}
-    {{- $freePctSum = add $freePctSum $natural }}
-  {{- end }}
-{{- end -}}
-{{- /* Apply the floor only when it is achievable. It needs at least one free
-     column to donate from (lt $nShort $n) and the reserved slots to fit
-     ($nShort × $MINW ≤ 100); otherwise short columns outnumber what a 10% share
-     can reserve, forcing $freeRemainder (and a free column's scaled width)
-     negative. In that case the floor is skipped and every column keeps its
-     natural share - no <col> can ever carry a negative width. When the floor
-     does apply, each free column is scaled so the reserved $MINW slots sum with
-     the donated remainder to exactly 100. */ -}}
-{{- $useFloor := false }}
-{{- $minReserve := mul $MINW (float $nShort) }}
-{{- if and (lt $nShort $n) (le $minReserve 100.0) }}{{ $useFloor = true }}{{ end }}
-{{- $freeRemainder := sub 100.0 $minReserve }}
-
-{{- /* used: the exact percentage of every column but the last, so the last can
-     absorb the rounding and the widths sum to a clean 100%. */ -}}
-{{- $used := 0.0 }}
 <div class="table-container" tabindex="0">
   <table
     {{- range $k, $v := .Attributes }}
       {{- with $v }} {{ $k | safeHTMLAttr }}="{{ . }}"{{ end }}
     {{- end }}>
-    <colgroup>
-      {{- range $i, $c := $headers }}
-        {{- $colMax = 0 -}}
-        {{- range $.THead -}}{{ with (index . $i) }}{{ $l := len .Text }}{{ if gt $l $colMax }}{{ $colMax = $l }}{{ end }}{{ end }}{{ end -}}
-        {{- range $.TBody -}}{{ with (index . $i) }}{{ $l := len .Text }}{{ if gt $l $colMax }}{{ $colMax = $l }}{{ end }}{{ end }}{{ end -}}
-        {{- $w := $colMax -}}
-        {{- if gt $w $textChars }}{{ $w = $textChars }}{{ end -}}
-        {{- $w = mul $w $char -}}
-        {{- if lt $w $min }}{{ $w = $min }}{{ end -}}
-        {{- $w = add $w $pad -}}
-        {{- $natural := div (mul 100.0 (float $w)) (float $totalWeight) -}}
-        {{- $pct := $natural -}}
-        {{- if and $useFloor (lt $natural $MINW) }}
-          {{- $pct = $MINW }}
-        {{- else if $useFloor }}
-          {{- $pct = div (mul $natural $freeRemainder) $freePctSum }}
-        {{- end }}
-        {{- if eq $i (sub $n 1) }}
-          <col style="width: {{ printf "%.2f" (sub 100.0 $used) }}%">
-        {{- else }}
-          {{- $used = add $used $pct -}}
-          <col style="width: {{ printf "%.2f" $pct }}%">
-        {{- end }}
-      {{- end }}
-    </colgroup>
     <thead>
       {{- range .THead }}
         <tr>


### PR DESCRIPTION
Third attempt at tables, and the first that does not try to compute a column width ahead of time.

## What was wrong

Both previous attempts sized columns by hand, and both failed in the same place: the width of a column is a question about glyphs and about the width of the window, and neither a template nor a stylesheet can see either one.

- **#91** set `width: max-content`. The table sized itself to its content, so nothing wrapped and every table wider than the measure became one long line inside a scroll box — a prose column sitting untouched at 450px while the reader dragged sideways to reach it.
- **#96** replaced that with a `<colgroup>` of percentages estimated from `len(.Text)` — a codepoint count, not a width — and made them binding with `table-layout: fixed`. Fixed layout honours a declared width whatever is in the cell, so a column estimated at 10% of a 350px phone is about two characters. `Backlinks` came out as nine stacked letters and `2026-08-23` as five stacked fragments. It was happening on desktop too, just less visibly: at 1280px `Words`, `Headings`, `Published` and `Modified` were all broken mid-word.

## What this does

Deletes both overrides and lets automatic table layout do the arithmetic. It measures real glyphs at the width the page is actually being read at, gives every column at least its longest word so a header is never broken, spends what is left over on the columns that asked for the most — the prose column, every time — and overflows only when the content genuinely does not fit, which `.table-container` turns into a scroll. Fits when it can, scrolls when it cannot.

`overflow-wrap` moves from `anywhere` to `break-word` in the same breath, and the fix does not hold without it. `anywhere` lets a break count towards the minimum width a cell reports, so a column can be squeezed to one character and still claim to fit — the same bug under a different layout algorithm. `break-word` reports the honest minimum.

Three supporting changes:

- **A scroll shadow on the container.** A seven-column table whose headers alone want nine characters each cannot be shown at 390px by any method, so one will still scroll — and a phone draws no scrollbar until you touch the box, so a table clipped at the screen edge with nothing to say so reads as broken rather than scrollable. The standard pair: `local` covers over `scroll` shadows, responding to the actual scroll position, so they are right at every width with nothing measuring anything. No script.
- **Print rules.** Paper cannot scroll, so the container stops clipping there, the shadows come off, and tables are set at 0.85em.
- **The check pins the absences.** It asserted the `<colgroup>` was present; it now asserts it is absent, along with the fixed layout, the `max-content` width and the `anywhere` wrap. Auto layout works because of what is *not* there, and an absence is exactly what a later edit reintroduces without noticing.

The fixture gains the case that decides `break-word` against `anywhere`: a table holding a token no line break can shorten.

## Rejected on measurement

- **Keeping the `<colgroup>` under auto layout**, where a `<col>` width is a hint rather than a cap. Measured against the fixture it was strictly worse than no colgroup — it wrapped "Datelines, theses, captions" onto two lines in a column with room for one. The estimates are simply not as good as the browser's measurement.
- **`white-space: nowrap` on inline code in cells**, to stop `--muted` splitting after its hyphens. It works, and it pushed the narrow four-column table into scrolling on a phone. A hyphen break is the cheaper cost.

## Known limitation

At the 40rem measure the seven-column fixture table gives `Thesis` a narrow column that wraps to six lines; #96 gave it three, at the price of crushing every header. Nothing fits seven columns of that shape into 40rem, and of the two available choices — wrap the prose, or break the data — the browser makes the right one.

## Verification

Rendered rather than read: `garden-preview --fixture`, screenshots at 390px, 1280px and 1440px in both themes, and a print-to-PDF confirming the wide table and the unbreakable URL both fit the page. `nix build .#checks.x86_64-linux.digital-garden` and `.#checks.x86_64-linux.publish` pass, `nix fmt -- --ci` is clean.