### PR TITLE
fix(starship): disable the sudo module to stop prompt freezes

### DIFF
--- a/configs/starship/starship.toml
+++ b/configs/starship/starship.toml
@@ -178,8 +178,13 @@ unknown_indicator = '?_'
 format = '[ $indicator ]($style)'
 style = "bg:bg_dark fg:fg"
 
+# Disabled: the sudo module probes `sudo -Nnv` on every prompt render to check
+# the credential cache. Combined with the short `timestamp_timeout=5` sudoers
+# setting and multiple terminals sharing the same user's sudo cache, this
+# caused periodic 2-3s freezes across all terminals at once (starship reported
+# "Executing command 'sudo' timed out"). sudo itself is unaffected.
 [sudo]
-disabled = false
+disabled = true
 style = "bg:bg_dark fg:fg"
 symbol = '󱕴 '
 format = '[$symbol]($style)'


### PR DESCRIPTION
## What & why

Terminals (including `nvim`) intermittently freeze for 2-3 seconds, always
across every terminal at once, with starship reporting that the `sudo` utility
"did not respond in time".

**Root cause:** starship's `[sudo]` module is enabled and `$sudo` is in the
prompt `format`. On **every prompt render**, starship runs `sudo -Nnv` to check
whether sudo credentials are cached. Combined with the system's
`Defaults timestamp_timeout=5` (in `modules/nixos/user-security.nix`), cached
credentials expire every 5 minutes, and then all concurrent starship prompts
(shared user's sudo credential cache) simultaneously block on the sudo check,
freezing every terminal at once.

The freeze was often noticed around SUPER+P because project-launcher opens new
ghostty/nvim windows, each spawning a fresh starship prompt that probes
`sudo -Nnv` right after the credential cache has expired — correlation, not
causation.

## Change

Set `[sudo] disabled = true` (with an explanatory comment). This removes the
entire per-prompt subprocess rather than merely bounding it with
`command_timeout`. **sudo itself is unaffected** — credential caching, password
requirement, and all of `user-security.nix` still apply.

## Verification

- Reviewed in a sub-agent; validated the `$sudo` format token and `[sudo]`
  block, repo conventions, security impact (none), and lint impact (none —
  this file is not touched by `nix fmt`).
- `starship prompt` and `starship explain` render cleanly with `sudo` gone.
- `git diff --check` clean.

CI will build all three hosts and run the checks; since the starship config is
shipped verbatim via `xdg.configFile` into each host toplevel, this gate
protects the change.