### PR TITLE
fix(profiles): ship ghostty terminfo so hosts resolve xterm-ghostty

### DIFF
--- a/profiles/common.nix
+++ b/profiles/common.nix
@@ -13,7 +13,7 @@
 #
 # Imported by every host. ./server.nix and ./workstation.nix sit on top of this
 # file and are imported alongside it, not instead of it.
-{ ... }:
+{ pkgs, ... }:
 {
   # ============================================================================
   # Boot
@@ -64,6 +64,19 @@
     isNormalUser = true;
     extraGroups = [ "wheel" ];
   };
+
+  # ============================================================================
+  # Terminfo
+  # ============================================================================
+  # Ghostty advertises TERM=xterm-ghostty, and any machine in this fleet is a
+  # possible SSH target, so every one of them must be able to resolve that
+  # terminal name. systemPackages is what makes it work: its share/terminfo is
+  # collated into /run/current-system/sw/share/terminfo, and NixOS login shells
+  # export TERMINFO_DIRS with that path via /etc/set-environment - the same
+  # mechanism that supplies xterm-256color from ncurses. This covers interactive
+  # SSH and sudo; a non-interactive `ssh host 'command'` does not read
+  # /etc/set-environment.
+  environment.systemPackages = [ pkgs.ghostty.terminfo ];
 
   # ============================================================================
   # Environment


### PR DESCRIPTION
Fixes the annoying `'xterm-ghostty': unknown terminal type.` error in interactive SSH sessions (e.g. `systemctl status`) on the fleet hosts.

**Diagnosis**: Ghostty advertises `TERM=xterm-ghostty`, which propagates over SSH, but the fleet hosts' ncurses terminfo database only knew terminals supplied by their installed packages (xterm-256color from ncurses, etc.), not xterm-ghostty.

**Fix**: add `pkgs.ghostty.terminfo` to `environment.systemPackages` in the shared `profiles/common.nix`. NixOS collates `share/terminfo` from system packages into `/run/current-system/sw/share/terminfo`, which login shells export via `TERMINFO_DIRS` in `/etc/set-environment` — the same mechanism that already supplies xterm-256color. This covers interactive SSH login shells and `sudo`.

**Verification**
- Built `.#nixosConfigurations.homelab01.config.system.build.toplevel`; `sw/share/terminfo/x/xterm-ghostty` present.
- Reproduced the login-shell lookup against that artifact: `infocmp xterm-ghostty` resolves; xterm-256color unaffected.
- All three hosts evaluate with the terminfo package.
- `nix fmt -- --ci` clean.

Reviewed by sub-agent; no blocking findings.