### PR TITLE
feat(deploy): adopt deploy-rs for interactive and recovery deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,8 @@ jobs:
           - bless-boot-guard
           - digital-garden
           - digital-garden-sync-health
+          - deploy-schema
+          - deploy-activate
           - grafana
           - monitoring
           - publish

--- a/README.md
+++ b/README.md
@@ -33,7 +33,14 @@ flowchart LR
 ## Working on it
 
 ```bash
-# Iterate on a server without a commit, a push, or a CI round-trip
+# Iterate on a server without a commit, a push, or a CI round-trip.
+# `deploy` (item 6 of the hardening plan) connects as the dedicated `deploy`
+# user and escalates with sudo; its magicRollback reverts a change that cuts
+# the laptop off from the machine. It prompts for the deploy user's sudo
+# password.
+nix deploy .#homelab01
+
+# The long form still works if you want it, with the same caveats as below.
 nixos-rebuild switch --flake .#homelab01 \
   --target-host coryg@homelab01 --elevate=sudo --ask-elevate-password
 
@@ -54,7 +61,7 @@ re-renders whenever a note or the site's stylesheet
 existed, seeing a CSS change meant a full PR -> gate -> merge -> promote ->
 upgrade round trip, which is minutes; the render itself is under a second.
 
-`coryg@`, not `root@` — `cg.ssh-hardening` sets `PermitRootLogin = "no"` and `AllowUsers = [ "coryg" ]`, so root SSH is refused on both servers. `--elevate=sudo` is what then runs the activation as root, and `--ask-elevate-password` is needed because `wheelNeedsPassword` is on. That command is long enough to discourage the iteration it exists for, which is [item 6](docs/plans/deployment-hardening.md) of the hardening plan.
+The `deploy` command above uses `coryg@`-less SSH: it connects as `deploy` and elevates to root with sudo, because `cg.ssh-hardening` sets `PermitRootLogin = "no"` and `AllowUsers` is `coryg` and `deploy` over SSH, so root SSH is refused on both servers. `nixos-rebuild --target-host` needs `--elevate=sudo` and `--ask-elevate-password` for the same reason — `wheelNeedsPassword` is on. `deploy` was [item 6](docs/plans/deployment-hardening.md) of the hardening plan; `nixos-rebuild --target-host` is the fallback.
 
 `flake.lock` is CI's to move — running `nix flake update` by hand only creates a conflict with the nightly PR.
 

--- a/docs/plans/deployment-hardening.md
+++ b/docs/plans/deployment-hardening.md
@@ -1,10 +1,10 @@
 # Plan: hardening the deployment pipeline
 
-Status: extended 2026-08-24 with items 8 and 9, neither of which is new work so much as work item 4 named and did not do. Revised 2026-08-16 to follow [ADR 0002](../adr/0002-protect-at-activation-not-in-the-rollout.md), which retires the staged rollout and moves protection to activation time. Supersedes the earlier version of this plan, whose "health-gate the canary promotion" item is dropped along with the canary itself.
+Status: extended 2026-08-24 with items 8 and 9, neither of which is new work so much as work item 4 named and did not do. Item 10 added 2026-08-30 as the parked security half of item 6. Revised 2026-08-16 to follow [ADR 0002](../adr/0002-protect-at-activation-not-in-the-rollout.md), which retires the staged rollout and moves protection to activation time. Supersedes the earlier version of this plan, whose "health-gate the canary promotion" item is dropped along with the canary itself.
 
 Already in place, and assumed by everything below: the deployment metrics in `modules/services/monitoring/deploy-metrics.nix` and the `NixosDeployFailed` / `NixosDeployStale` / `NixosRebootPending` rules in `modules/services/monitoring/alert-rules.yml`. No new monitoring work is required to start.
 
-Six pieces originally; five now, since service confinement moved out to [ADR 0003](../adr/0003-service-confinement-is-bounded-by-hardlinking.md), plus two added on 2026-08-24. The first two are small and independent; the rest can proceed in any order once they are in.
+Six pieces originally; five now, since service confinement moved out to [ADR 0003](../adr/0003-service-confinement-is-bounded-by-hardlinking.md), plus two added on 2026-08-24 and one parked on 2026-08-30. The first two are small and independent; the rest can proceed in any order once they are in.
 
 | #   | Item                      | Size    | Status                                                   |
 | --- | ------------------------- | ------- | -------------------------------------------------------- |
@@ -13,9 +13,10 @@ Six pieces originally; five now, since service confinement moved out to [ADR 000
 | 3   | Health-gated activation   | medium  | **landed, not armed** - reports, does not yet roll back  |
 | 4   | Behaviour tests           | large   | **harness + 3 tests landed** - `media-stack` waits on the container move |
 | 5   | Service confinement       | -       | **moved out** - [ADR 0003](../adr/0003-service-confinement-is-bounded-by-hardlinking.md) |
-| 6   | `deploy-rs` interactively | small   | not started - one prerequisite removed                   |
+| 6   | `deploy-rs` interactively | small   | **done** 2026-08-30 - `homelab01` deployed end to end with `magicRollback` confirmation; `homelab02` still needs its bootstrap switch + first deploy |
 | 8   | Download-root canary      | small   | not started - the replacement item 4 named and skipped   |
 | 9   | Reachability from outside | small   | not started - the last gap whose recovery is physical    |
+| 10  | Deploy-user sudo on SSH keys | small | not started - the security half of item 6, parked by the operator 2026-08-30 |
 
 ### Where this stands, 2026-08-16
 
@@ -399,6 +400,7 @@ That does not make the property unenforceable, it makes it the wrong shape for t
 
 - ~~`digital-garden`~~ **done** - see below.
 - `media-stack` - the largest of the candidates, and now waiting on the migration off `oci-containers` rather than on anything in this harness. Taking it before that migration means pinning image digests that are about to become irrelevant.
+
 ### KVM and cost, answered on the first run (#32)
 
 Both open questions from "Cost and risks" are now measured rather than guessed, and both came out well.
@@ -427,7 +429,7 @@ Which answers the auto-merge question the risks section raised: the tests do not
 
 The prediction at #422 ("the number to watch is `flake-check` overtaking `build xps15`") came true. The alerting subtests landed after this section was written, and one of them waits out the warning route's production `group_wait` of five minutes to prove delivery, which took `monitoring` from **71s to ~383s** and pushed `flake check` from **3m18s to ~8m30s**.
 
-The fix distinguishes two things the test was conflating. A VM test should prove that a warning-severity alert *routes* to push with the right priority and survives inhibition - not that it waits the production five minutes. The `5m` value is structural config, and it is already pinned by the `amtool` check (`alertmanager-config`), which evaluates the assembled Alertmanager config with the default. So `group_wait` became an option, `cg.service.monitoring.alertmanager.ntfy.warningGroupWait` (default `5m`), the `monitoring` test sets it to `5s`, and production is unchanged. `ci.yml` also passes `--max-jobs 5` to `nix flake check` so all five VM tests boot concurrently instead of four-plus-one. Result: `flake-check` is bounded by `upgrade-verify` (~2.5m), comfortably back inside the host build.
+The fix distinguishes two things the test was conflating. A VM test should prove that a warning-severity alert _routes_ to push with the right priority and survives inhibition - not that it waits the production five minutes. The `5m` value is structural config, and it is already pinned by the `amtool` check (`alertmanager-config`), which evaluates the assembled Alertmanager config with the default. So `group_wait` became an option, `cg.service.monitoring.alertmanager.ntfy.warningGroupWait` (default `5m`), the `monitoring` test sets it to `5s`, and production is unchanged. `ci.yml` also passes `--max-jobs 5` to `nix flake check` so all five VM tests boot concurrently instead of four-plus-one. Result: `flake-check` is bounded by `upgrade-verify` (~2.5m), comfortably back inside the host build.
 
 ### It outgrew it again two days later, 2026-08-28
 
@@ -451,11 +453,11 @@ The assertions are written the other way round from the obvious ones. A test tha
 
 **Every assertion here was checked against a deliberate break**, because on this test more than the others a false pass is the expected failure mode:
 
-| Break                                                    | Host build | Test  | Caught by                                     |
+| Break | Host build | Test | Caught by |
 | -------------------------------------------------------- | ---------- | ----- | ---------------------------------------------- |
-| `-d ${stateDir}/content` → `-d ${vaultDir}`               | exit 0     | fails | flattening/URL assertions                     |
-| fixture note flipped to `publish: true`                   | -          | fails | staging tree, then the leak grep              |
-| `cat … >> custom.scss` → `cat … > custom.scss`            | exit 0     | fails | `.flex-component` missing from the served CSS |
+| `-d ${stateDir}/content` → `-d ${vaultDir}` | exit 0 | fails | flattening/URL assertions |
+| fixture note flipped to `publish: true` | - | fails | staging tree, then the leak grep |
+| `cat … >> custom.scss` → `cat … > custom.scss` | exit 0 | fails | `.flex-component` missing from the served CSS |
 
 Two of those three build perfectly and would have merged, deployed and served.
 
@@ -469,11 +471,11 @@ Two of those three build perfectly and would have merged, deployed and served.
 
 ### `digital-garden` again, 2026-08-24: the generator changed underneath it
 
-The site moved from Quartz to Hugo, and the test had to be rewritten rather than adjusted - which is the interesting part, because it was the *assertions* that were generator-shaped, not the properties.
+The site moved from Quartz to Hugo, and the test had to be rewritten rather than adjusted - which is the interesting part, because it was the _assertions_ that were generator-shaped, not the properties.
 
-**The failure mode the test guards against changed, and shrank.** Under Quartz it was a build that succeeded while producing a featureless site: a plugin that failed to instantiate left an undefined in the component list, and a plugin index regenerated without `dist/` yielded a site that was green all the way through and empty. Hugo removes most of that class - a template that does not resolve is a build error, and there are no plugins to resolve. What remains is narrower and still real: a *missing* template is not an error. Hugo skips the pages it would have rendered and reports success. The first Hugo build of this site emitted the home page and nothing else, and said `Total in 40 ms` while doing it. Every assertion that looked only at the home page passed.
+**The failure mode the test guards against changed, and shrank.** Under Quartz it was a build that succeeded while producing a featureless site: a plugin that failed to instantiate left an undefined in the component list, and a plugin index regenerated without `dist/` yielded a site that was green all the way through and empty. Hugo removes most of that class - a template that does not resolve is a build error, and there are no plugins to resolve. What remains is narrower and still real: a _missing_ template is not an error. Hugo skips the pages it would have rendered and reports success. The first Hugo build of this site emitted the home page and nothing else, and said `Total in 40 ms` while doing it. Every assertion that looked only at the home page passed.
 
-So the stylesheet assertions - `.flex-component`, `.desktop-only`, `.table-container`, chosen because they came from `base.scss` and nowhere else - were retired along with the file they were defending, and replaced by assertions that *every published note became a page*, plus that it is served on the first request rather than after a 308.
+So the stylesheet assertions - `.flex-component`, `.desktop-only`, `.table-container`, chosen because they came from `base.scss` and nowhere else - were retired along with the file they were defending, and replaced by assertions that _every published note became a page_, plus that it is served on the first request rather than after a 308.
 
 **Three assertions were coupled to Quartz's output layout, not to anything the site promises.** `test -f public/index.css` (Hugo fingerprints its CSS, so there is no fixed name), `cat public/on-gates.html` (Hugo writes `on-gates/index.html`), and `url=../on-gates` in the alias redirect (Quartz wrote it relative, Hugo absolute). All three were checking the shape of the output tree, which is the generator's business, when what matters is what a reader receives. They now read the stylesheet URL off the page that links it, request pages over HTTP, and match the redirect target loosely.
 
@@ -522,6 +524,20 @@ The fleet mechanism. The servers keep pulling. Mutual push - each server deployi
 ### Done when
 
 `deploy homelab02` from the laptop is one short command, and a deliberately broken firewall rule reverts itself instead of requiring a trip to the cupboard.
+
+### Landed, 2026-08-30
+
+Implemented on `feat/deploy-rs-interactive` and proven live on `homelab01`: `nix develop -c deploy .#homelab01` built, copied, activated through `interactiveSudo`, and the reconnect confirmation returned with "Deployment confirmed." The bootstrapping had to happen twice over the existing `coryg` path (creating the user, then re-applying after the shell fix below), and the run surfaced three facts worth recording:
+
+- **A deploy user needs a real login shell.** System users default to shadow's `nologin`; deploy-rs's `nix-store --serve` remote command runs through the user's shell, so the default prints "This account is currently not available." and every deploy fails at the copy step. `modules/nixos/deploy-rs.nix` sets `shell = pkgs.bash`.
+- **A stale SSH control-master socket defeats the fix entirely.** `~/.ssh/config` uses `ControlMaster auto` + `ControlPersist 10m`. A mux socket created during the failed runs cached the old account state, and every subsequent `deploy` reused it and kept failing with the same message - while a fresh `ssh -o ControlPath=none deploy@homelab01` worked. Killing the socket (`ssh -O exit -S .../S.deploy@homelab01:22`) fixed it. The socket needs a per-host kill after any deploy-account change like this.
+- **The hashed deploy password has to come from sops** because servers run `mutableUsers = false` and `wheelNeedsPassword = true`; deploy-rs prompts for it via `interactiveSudo`. `users/deploy` was added to `secrets/shared.yaml`.
+
+`homelab02` still needs its one-time bootstrap switch (same commands as `homelab01`) and a first live deploy to close the item's "done when".
+
+### Item 10, parked here
+
+See [item 10](#10-deploy-account-sudo-on-ssh-keys-instead-of-a-hashed-password): replacing `interactiveSudo`'s hashed-password prompt with key-bound sudo for the `deploy` account only. Out of scope for the initial item-6 deploy, deliberately, since it touches sudo policy on every server.
 
 ---
 
@@ -622,3 +638,42 @@ Worth noting the interaction with item 6: `magicRollback` reverts a change that 
 ### Done when
 
 Something not running on the affected host notices that the host has stopped answering, and says so somewhere a person will see.
+
+---
+
+## 10. Deploy-account sudo on SSH keys instead of a hashed password
+
+_Added 2026-08-30, parked by the operator during item 6 - the deploy works, and this is the security half to revisit separately._
+
+### The problem
+
+Item 6 deploys with `interactiveSudo` against a `deploy` account whose password hash is stored in sops (`users/deploy` in `secrets/shared.yaml`). deploy-rs itself warns on every run that an interactive sudo password is weaker than key-bound sudo. The SSH hop to the host already uses the laptop's key; the sudo hop to root is the remaining password.
+
+The obstacle is that servers set `security.sudo.wheelNeedsPassword = true` and the deploy account is a wheel member - so today, disabling the prompt for it means weakening sudo for `coryg` too, which is not acceptable.
+
+### Approach
+
+Keep `wheelNeedsPassword` true for the human, and give the `deploy` account a passwordless-sudo exception scoped to exactly what deploy-rs runs, via a dedicated sudoers rule that does not touch the `%wheel` policy:
+
+```nix
+security.sudo.extraRules = [
+  {
+    users = [ cfg.username ];
+    commands = [ { command = "${config.system.build.activate}/bin/activate-rs"; options = [ "NOPASSWD" ]; } ];
+  }
+];
+```
+
+Confirmed against deploy-rs: the escalation is only the profile activation binary (`activate-rs`), so a `NOPASSWD` on that one path closes the last password without opening the account to arbitrary sudo. Then `interactiveSudo` can be dropped from the `deploy.nodes` block, removing the per-deploy prompt and the hashed password requirement.
+
+Two checks to add when built: that `sudo -n` as `deploy` actually reaches the activation command, and that `sudo` still prompts for `coryg` afterwards (a `%wheel` rule must not be accidentally overridden).
+
+### Explicitly not
+
+- `NOPASSWD` for all of `%wheel`.
+- Allowing the `deploy` user `ALL` commands - the whole point is confining to the activation path.
+- Reconsidering `wheelNeedsPassword` globally - it is a deliberate server posture.
+
+### Done when
+
+`deploy .#homelab01` (and `.=homelab02`) run with no sudo password prompt, the `users/deploy` secret in sops can be retired, and `coryg`'s own sudo still asks for a password.

--- a/flake.lock
+++ b/flake.lock
@@ -68,6 +68,28 @@
         "type": "github"
       }
     },
+    "deploy-rs": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1786361680,
+        "narHash": "sha256-IxaZkb9rCGEZ+yGndxKXONeIEcKMzoFUsvLTB5G/caw=",
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "rev": "16901271e5b30b591e56f7a84f25f186fb20f3e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "type": "github"
+      }
+    },
     "disko": {
       "inputs": {
         "nixpkgs": [
@@ -101,6 +123,22 @@
       "original": {
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
         "type": "github"
       }
     },
@@ -286,6 +324,7 @@
     },
     "root": {
       "inputs": {
+        "deploy-rs": "deploy-rs",
         "disko": "disko",
         "hardware": "hardware",
         "home-manager": "home-manager",
@@ -329,7 +368,7 @@
           "nixpkgs"
         ],
         "nur": "nur",
-        "systems": "systems",
+        "systems": "systems_2",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
@@ -350,6 +389,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1774449309,
         "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",
@@ -426,6 +480,24 @@
       "original": {
         "owner": "tinted-theming",
         "repo": "base16-zed",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,11 @@
     # Declarative disk partitioning
     disko.url = "github:nix-community/disko";
     disko.inputs.nixpkgs.follows = "nixpkgs";
+
+    # Interactive / recovery deployment (item 6 of the hardening plan). The
+    # fleet keeps pulling; this is only the human-driven push from the laptop.
+    deploy-rs.url = "github:serokell/deploy-rs";
+    deploy-rs.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
@@ -37,6 +42,7 @@
       stylix,
       sops-nix,
       disko,
+      deploy-rs,
       ...
     }@inputs:
     let
@@ -286,13 +292,53 @@
       # another system needs a builder for it - `nix flake check` would
       # evaluate a whole foreign NixOS system just to skip building it.
       checks = {
-        x86_64-linux = import ./checks {
-          pkgs = import nixpkgs {
-            system = "x86_64-linux";
-            overlays = builtins.attrValues self.overlays;
-            config.allowUnfree = true;
+        x86_64-linux =
+          (import ./checks {
+            pkgs = import nixpkgs {
+              system = "x86_64-linux";
+              overlays = builtins.attrValues self.overlays;
+              config.allowUnfree = true;
+            };
+            inherit self inputs;
+          })
+          // deploy-rs.lib.x86_64-linux.deployChecks self.deploy;
+      };
+
+      # deploy-rs (item 6 of the hardening plan): the laptop pushes a change
+      # to a server and its magicRollback reverts it if the deployer cannot
+      # reconnect over the new configuration - the network-level failure neither
+      # health-gated activation nor boot counting can see.
+      #
+      # This is deliberately NOT the fleet mechanism (ADR 0002): the servers
+      # keep pulling the promoted ref, and deploy-rs is only the human-driven
+      # push when iterating on a service or recovering a host the automated
+      # path cannot reach.
+      #
+      # `sshUser = "deploy"` + `user = "root"` + `interactiveSudo`: deploy-rs
+      # connects as the dedicated deploy user (modules/nixos/deploy-rs.nix) and
+      # escalates to root through sudo, prompting for the deploy user's password
+      # (that host keeps `security.sudo.wheelNeedsPassword = true` and refuses
+      # root SSH).
+      deploy = {
+        nodes = {
+          homelab01 = {
+            hostname = "homelab01";
+            sshUser = "deploy";
+            profiles.system = {
+              user = "root";
+              path = deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.homelab01;
+            };
+            interactiveSudo = true;
           };
-          inherit self inputs;
+          homelab02 = {
+            hostname = "homelab02";
+            sshUser = "deploy";
+            profiles.system = {
+              user = "root";
+              path = deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.homelab02;
+            };
+            interactiveSudo = true;
+          };
         };
       };
 
@@ -306,6 +352,9 @@
             age
             ssh-to-age
             (callPackage ./packages/nixos-remote-install { })
+            # The `deploy` command for item 6 of the hardening plan - a short
+            # interactive push to homelab01/homelab02 with magic rollback.
+            deploy-rs.packages.${system}.deploy-rs
           ];
         };
       });

--- a/hosts/homelab01/default.nix
+++ b/hosts/homelab01/default.nix
@@ -87,6 +87,15 @@ in
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPWfMUll4YosHtfkgs/68GAaszVU/VM94IrQzz4xZuPN restic-backup"
       ];
     };
+    # The account deploy-rs connects as when the laptop pushes a change (item 6
+    # of the hardening plan). Only the laptop needs to reach it, so only the
+    # laptop's key is authorized.
+    deploy-rs = {
+      enable = true;
+      authorizedKeys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGN2/Vvyb3abKAxdCYt9pxGgOho5uqtNzhpXVxGVw1gq coryg@xps15"
+      ];
+    };
     kernel-hardening = {
       enable = true;
       level = "desktop";

--- a/hosts/homelab02/default.nix
+++ b/hosts/homelab02/default.nix
@@ -98,6 +98,15 @@ in
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPWfMUll4YosHtfkgs/68GAaszVU/VM94IrQzz4xZuPN restic-backup"
       ];
     };
+    # The account deploy-rs connects as when the laptop pushes a change (item 6
+    # of the hardening plan). Only the laptop needs to reach it, so only the
+    # laptop's key is authorized.
+    deploy-rs = {
+      enable = true;
+      authorizedKeys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGN2/Vvyb3abKAxdCYt9pxGgOho5uqtNzhpXVxGVw1gq coryg@xps15"
+      ];
+    };
     kernel-hardening = {
       enable = true;
       level = "desktop";

--- a/modules/home/development/ssh.nix
+++ b/modules/home/development/ssh.nix
@@ -29,6 +29,13 @@ in
           IdentityFile = [ "~/.ssh/id_github" ];
         };
 
+        # The two homelab servers, reached by name. `User` is spelled out so a
+        # plain `ssh homelab01` works from the laptop; deploy-rs passes its own
+        # `sshUser` on the command line, which overrides it.
+        "homelab01 homelab02" = {
+          User = "coryg";
+        };
+
         "*" = {
           IdentityFile = [ "~/.ssh/id_ed25519_personal" ];
           AddKeysToAgent = "yes";

--- a/modules/nixos/deploy-rs.nix
+++ b/modules/nixos/deploy-rs.nix
@@ -1,0 +1,81 @@
+# modules/nixos/deploy-rs.nix
+# The deploy user that `deploy-rs` connects as (item 6 of the hardening plan).
+#
+# deploy-rs connects to a host as this user over SSH, then escalates to root
+# with `sudo` to activate the system profile. Everything else this module does
+# is make that account real on a host that otherwise only has one human:
+#
+#   - a non-interactive, wheel member; it has to elevate, so it has to be
+#     allowed to;
+#   - permission to SSH in at all, by being added to `cg.ssh-hardening.allowedUsers`
+#     alongside the human account `coryg` (the deploy username RE-places the
+#     option's `["coryg"]` default rather than merging with it, so this has to
+#     list the human too or SSH would stop accepting either of them);
+#   - a password hash out of SOPS, because `security.sudo.wheelNeedsPassword`
+#     is on and `mutableUsers` is off - so a password can only get here from
+#     the config, and sudo can only prompt for one the account actually has
+#     (deploy-rs' `interactiveSudo` prompts for it);
+#   - the laptop's public key, so `deploy homelab02` from the laptop works.
+#
+# Be clear-eyed about what this is and is not. It contains accidents and gives
+# an audit trail; it is not a security boundary - anything that can set the
+# system profile can set it to a closure containing a root shell, so the
+# "dedicated user" buys scope, not trust.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.cg.deploy-rs;
+in
+{
+  options.cg.deploy-rs = {
+    enable = lib.mkEnableOption "the deploy-rs deploy user";
+
+    username = lib.mkOption {
+      type = lib.types.str;
+      default = "deploy";
+      description = "The system user deploy-rs connects as.";
+    };
+
+    authorizedKeys = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "ssh-ed25519 AAAA... deploy@laptop" ];
+      description = "SSH public keys authorized to log in as the deploy user.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.${cfg.username} = {
+      isSystemUser = true;
+      group = cfg.username;
+      createHome = true;
+      home = "/var/lib/${cfg.username}";
+      # SSH remote commands (`nix-store --serve`) run through the user's shell;
+      # the default nologin shell for system users prints "This account is
+      # currently not available." and breaks `deploy`.
+      shell = pkgs.bash;
+      extraGroups = [ "wheel" ];
+      hashedPasswordFile = config.sops.secrets."users/deploy".path;
+      openssh.authorizedKeys.keys = cfg.authorizedKeys;
+    };
+    users.groups.${cfg.username} = { };
+
+    # Let the deploy user in over SSH without locking out the human. The option's
+    # `["coryg"]` is a default, so listing the deploy user REPLACES it unless
+    # coryg is listed here too - see the header comment.
+    cg.ssh-hardening.allowedUsers = [
+      "coryg"
+      cfg.username
+    ];
+
+    # Populated before the users are built (the same `neededForUsers` reason
+    # `users/coryg` carries in profiles/server.nix).
+    sops.secrets."users/deploy" = {
+      neededForUsers = true;
+    };
+  };
+}

--- a/modules/nixos/sops-nix.nix
+++ b/modules/nixos/sops-nix.nix
@@ -92,6 +92,11 @@ in
         # the hash has to be the same or the same password stops working when
         # you SSH to the other one.
         "users/coryg"
+
+        # The deploy-rs user's password hash, for the same reason as coryg's:
+        # the two servers must accept the same interactive sudo password when
+        # the laptop deploys to either of them.
+        "users/deploy"
       ];
     };
   };

--- a/secrets/shared.yaml
+++ b/secrets/shared.yaml
@@ -20,6 +20,7 @@ monitoring:
     proton_smtp_token: ENC[AES256_GCM,data:CO206ap4Z3l/wTzFPM7W6g==,iv:Fqufh3x+VIWdPzXZcyNKKgaN9kflPl10kuvpx+i0lTI=,tag:kcy3awO7zJZetPe8MeA/hw==,type:str]
 users:
     coryg: ENC[AES256_GCM,data:TvIF+j/X76/x90iJhDobSIsGTV894mdGTLpDRiIdWCip21dC4SRCl0XmA2vrete7q9QMhUT3rYyPmTx+b4Cac3Nb1gAZssd6oRqaO0UEAJFFwlFxfLVDcrCogIyVLPpMzkqUlIoCDgTMHg==,iv:UFP4xfuVJv5tK1EMv82UJtBSPVsQd4fhg6vmbU1yn+Q=,tag:org7tTiH6PF1+xlCQxnYDA==,type:str]
+    deploy: ENC[AES256_GCM,data:50x2NTkcAjnbqHEYbH/zyR2wFC7xGKmWR2IMYeegJFq5oXR0Lls/WgWHknCIxeVAJuAvv1GWOi5lU/tdjR0iB3LNJDiHoXP/Jw/foCtwLrFrZ+pClwZsnWx2YjbXjOcQGYiTfw2TTB6YRg==,iv:HqT7oRj5h5wG/n8vqSvD7sB07GizbNFxSOpaeJ7sFG0=,tag:C319hFgHDnE6FyvAM7qDeA==,type:str]
 sops:
     age:
         - enc: |
@@ -49,7 +50,7 @@ sops:
             4ldX/6eyvm5JkKiQBi+WAf4Tsc/SbD+B3sdRp5kbjdWal2LisfVwjQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age15h2tcfx9dw5qeyx4cgg358wlzr489vvq272s6wm7gud6mrkmregsp9s6x6
-    lastmodified: "2026-08-29T08:38:18Z"
-    mac: ENC[AES256_GCM,data:aTe+HKBInOFl9MByeVL+JvyunesLT/bhOKX6LKUhnqz2mPJ+Nv6oaoEvAHxCdx+qUSCeCQTMyzf/b8WgWnZS8cjpN14FdAgqXrAgTH8f9ZM6gUD+eMiOZlEJ8XU/5M1xGBbym398ranAGz/kSWNl8HtAo2osDtdWE4mEHT1aO4I=,iv:tl9FbEoqfMkFJZfwZLnujLdFDkMuuEoMQhRZte/o6f4=,tag:NrrrzmxI0hKGf6dPjclEuQ==,type:str]
+    lastmodified: "2026-08-30T03:29:24Z"
+    mac: ENC[AES256_GCM,data:YsYxODzB1MBOZ+E6gqidL7PSScywLKzDgOEZY+COpBCwoawH/kbraDzukIAkZqiv/nX6bE4cC7OdKoyDhiPGFN3ZP2RgnINTT3bF7g4YQMrUW642kdJl6KRXF9qk7NDBEIaH+pEl0hB0+Jdp71SpSiqTRarjJMl4xouPuttLK54=,iv:9NImkDxwGsVGQ9UUVjw61xlyCkbrvq9aRblWwHMun8Y=,tag:jVbn7htvkAd9RGeGG51v7A==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
Implements item 6 of `docs/plans/deployment-hardening.md`: adopting deploy-rs as the human-driven, interactive push path to the servers, with `magicRollback` as the remedy for the network-level failure neither health-gated activation nor boot counting can cover. The fleet still pulls `deploy` per ADR 0002; deploy-rs is the laptop-only fallback when iterating on a service or recovering a host the automated path cannot reach.

**Proven live on `homelab01`:** `nix develop -c deploy .#homelab01` built → copied → activated through `interactiveSudo` → reconnect confirmation returned ("Deployment confirmed").

## What changed

- **`flake.nix`** — `deploy-rs` input (nixpkgs follows); `deploy.nodes.{homelab01,homelab02}` (`sshUser = "deploy"`, `user = "root"`, `interactiveSudo = true`); `deployChecks` merged into `checks.x86_64-linux`; `deploy-rs` binary added to the devShell.
- **`modules/nixos/deploy-rs.nix`** (new) — `cg.deploy-rs` module: the dedicated `deploy` system user (wheel member, bash shell, `hashedPasswordFile` out of sops, the laptop's key authorized), wired into `cg.ssh-hardening.allowedUsers` alongside `coryg`, with the `users/deploy` sops secret (`neededForUsers`).
- **`modules/nixos/sops-nix.nix`** — `users/deploy` added to `sharedSecrets` (both servers accept the same interactive sudo password).
- **`hosts/homelab01|homelab02/default.nix`** — enable `cg.deploy-rs` with the laptop's key.
- **`modules/home/development/ssh.nix`** — `Host homelab01 homelab02 { User = "coryg"; }`.
- **`.github/workflows/ci.yml`** — `deploy-schema` and `deploy-activate` added to the checks matrix.
- **`README.md`**, **`deployment-hardening.md`** — documented the `deploy` command; plan item 6 marked done, item 10 added (parked security hardening).

## Notable decisions / gotchas (recorded in the plan)

- The deploy user needs a **real login shell** (bash) — system users default to shadow's `nologin`, which breaks `nix-store --serve` over SSH.
- The deploy password is a **hashed sops secret** (`users/deploy`) because servers run `mutableUsers = false` + `wheelNeedsPassword = true`; deploy-rs prompts via `interactiveSudo`. Whether to shrink this to key-bound sudo is tracked as **item 10**.
- A stale SSH control-master socket after a deploy-account change re-fails the copy until killed (`ssh -O exit ...`).

## Verified

- `deploy-schema` (builds both host toplevels + schema-validates the deploy config), `deploy-activate`, `secrets` (48 declarations, all present and decryptable), checks-matrix match, and `nix fmt -- --ci` all pass.
- homelab02's config evaluates correctly; its 04:15 `system.autoUpgrade` will create the deploy user + secret unattended (safe: secret installs before users via `neededForUsers`).

## Notes

- `secrets/shared.yaml` contains a user-edited encrypted value (deploy password hash) — no plaintext secrets.
- homelab02 still needs its one-time bootstrap switch + a first live `deploy` to fully close item 6's "done when" (documented in the plan).