### PR TITLE
build(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -203,11 +203,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1787144466,
-        "narHash": "sha256-HHfv2/HkNSKbbSyU9iD/g8lbP6r4tl33sSw1W4rXCk0=",
+        "lastModified": 1788044418,
+        "narHash": "sha256-cmOd3iGoE140M2GidgQMQbyxHZ4dT7C0QZq2+CrXQyA=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "0471accf8d0a8210b31d947497d179ecc99e0021",
+        "rev": "dc3f0cfde2050172abf6c3cdb684f735c15a57c5",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1787848966,
-        "narHash": "sha256-7gDpu5hpq0rOYnYMcOWqSzquK4HA/xU8Xf3CjUBOOJA=",
+        "lastModified": 1787962033,
+        "narHash": "sha256-u6z9VTZA4Kf3RkHQo9sQI7NI4Ei/uiU9vrMqOiwWP1Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d57af924f160a5084293c71c2043f058bd1cdb60",
+        "rev": "c5c4a43b0e8056328ec4529f735cabdb8f1942bb",
         "type": "github"
       },
       "original": {
@@ -267,11 +267,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1787948808,
-        "narHash": "sha256-eGTDlxFCHGX/SI9ygF48RWTg5u88ikF0O3KRLA7i3+w=",
+        "lastModified": 1788060129,
+        "narHash": "sha256-la0YyjqDV/UYBa+fEApQg7IeMsH/LzvzSIKSHd4SRYo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "66b643c7d4e3f50124081b60845fd07a8455d263",
+        "rev": "026907ed9c7f58251c0ed0c73cc1c796e85c40b7",
         "type": "github"
       },
       "original": {
@@ -283,11 +283,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1787736819,
-        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
+        "lastModified": 1787900134,
+        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
+        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `flake.lock` update.

The per-host deltas below are recorded in the commit body so they
land in `git log` on merge (ADR 0001).

Each host was built at the current lock and at the updated one, and
the closures compared. All three builds passing is a precondition of
this PR existing at all — but the `nixos ci` gate still has to pass
before it can merge, and merging is what promotes `deploy`.

### homelab01

crun: 1.27.1 → 1.29.1, 218.2 KiB
fd: 10.4.2 → 10.5.0, -37.4 KiB
initrd-linux: 6.18.46 → 6.18.47, -32.3 KiB
jellyfin-ffmpeg: -314.6 KiB
katex: 0.16.28 → 0.18.4, -234.8 MiB
linux: 6.18.46 → 6.18.47, 41.6 KiB
nixos-manual: 22.7 KiB
nixos-system-homelab01: 26.11.20260826.9fbb54b → 26.11.20260828.83199d0
prettier: 3.8.3 → 3.9.6, 1.3 MiB
source: 296.6 KiB
yajl: 2.1.0-unstable-2024-02-01 removed, -51.4 KiB

### homelab02

crun: 1.27.1 → 1.29.1, 218.2 KiB
fd: 10.4.2 → 10.5.0, -37.4 KiB
initrd-linux: 6.18.46 → 6.18.47, 61.6 KiB
linux: 6.18.46 → 6.18.47, 41.6 KiB
nixos-manual: 22.7 KiB
nixos-system-homelab02: 26.11.20260826.9fbb54b → 26.11.20260828.83199d0
prettier: 3.8.3 → 3.9.6, 1.3 MiB
source: 296.6 KiB
yajl: 2.1.0-unstable-2024-02-01 removed, -51.4 KiB
zfs-kernel: 2.4.4-6.18.46 → 2.4.4-6.18.47

### xps15

fd: 10.4.2 → 10.5.0, -37.4 KiB
initrd-linux: 7.2 → 7.2.1
linux: 7.2 → 7.2.1
nixos-manual: 22.7 KiB
nixos-system-xps15: 26.11.20260826.9fbb54b → 26.11.20260828.83199d0
nvidia-open: 595.91.07-7.2 → 595.91.07-7.2.1
prettier: 3.8.3 → 3.9.6, 1.3 MiB
source: 296.6 KiB
uwsm: 0.26.6 → 0.26.7
x86_energy_perf_policy: 6.18.46 → 6.18.47