### PR TITLE
feat(media-stack): canary the download root against silent wipes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,9 @@ jobs:
           - digital-garden-sync-health
           - deploy-schema
           - deploy-activate
+          - download-root-canary
+          - download-root-canary-script
+          - download-root-safety
           - grafana
           - monitoring
           - publish

--- a/checks/alert-rules.test.yml
+++ b/checks/alert-rules.test.yml
@@ -15,6 +15,13 @@
 #     its unenriched self.
 #   - the annotation templates render the tail into the notification, and
 #     degrade to the journalctl pointer when there is no tail.
+#
+# And, for the download-root canary (item 8 of the hardening plan):
+#   - DownloadRootCanaryMissing must not fire while
+#     download_root_canary_present is 1, and must mature (after its `for:`)
+#     only on a sustained 0 - the distinguishing behaviour of its exporter,
+#     which re-creates the sentinel only once per boot and otherwise reports
+#     the truth of its absence.
 rule_files:
   - @RULES@
 
@@ -95,3 +102,40 @@ tests:
               runbook_url: "https://github.com/corygyarmathy/dotfiles/blob/master/docs/runbooks/deployment#nixosupgradefailed"
               summary: "NixOS upgrade failed on homelab02:9100"
               description: "The nixos-upgrade service has failed.\n\nRecent upgrade output:\nerror: hash mismatch in fixed-output derivation"
+
+  # The download-root canary rule: 1 stays silent, a sustained 0 fires only
+  # after `for: 20m`. The exporter primes the sentinel once per boot and does
+  # not re-create it, so a series that reads 0 is a genuine disappearance, but
+  # a single scrape could read it before the timer's next write - the `for:`
+  # is what keeps that from being a page.
+  - interval: 1m
+    input_series:
+      - series: 'download_root_canary_present{job="node",instance="homelab01:9100"}'
+        # present for the first five minutes, then gone: 5 + 22 = 27 samples,
+        # evals at 26m, 21 minutes into the 0-run - one minute past the 20m
+        # `for:` threshold, so a tightening of the boundary fails loudly here.
+        values: "1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 26m
+        alertname: DownloadRootCanaryMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: node
+              instance: homelab01:9100
+            exp_annotations:
+              runbook_url: "https://github.com/corygyarmathy/dotfiles/blob/master/docs/runbooks/media-stack#downloadrootcanarymissing"
+              summary: "Download root canary missing on homelab01:9100"
+              description: "The sentinel file in the download root has been confirmed absent for 20+ minutes. Either the download root was wiped or emptied, or the sentinel was removed deliberately - a stopped canary timer cannot fire this alert (node_exporter keeps serving the last-written metric), so check the download-root-canary unit and then face a wiped root."
+
+  # Control: a present sentinel must not alert at any time.
+  - interval: 1m
+    input_series:
+      - series: 'download_root_canary_present{job="node",instance="homelab01:9100"}'
+        values: "1+0x30"
+
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: DownloadRootCanaryMissing
+        exp_alerts: []

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -303,6 +303,14 @@ in
     inherit pkgs;
     lib = pkgs.lib;
   };
+  download-root-canary = testLib.mkTest ./download-root-canary.nix;
+  download-root-canary-script = import ./download-root-canary-script.nix {
+    inherit pkgs inputs self;
+  };
+  download-root-safety = import ./download-root-safety.nix {
+    inherit pkgs inputs self;
+    lib = pkgs.lib;
+  };
   grafana = testLib.mkTest ./grafana.nix;
   monitoring = testLib.mkTest ./monitoring.nix;
 

--- a/checks/download-root-canary-script.nix
+++ b/checks/download-root-canary-script.nix
@@ -1,0 +1,144 @@
+# checks/download-root-canary-script.nix
+#
+# Unit test for the canary script's storage-side behaviour - the parts the VM
+# test cannot reach without a second host exporting NFS under root_squash.
+# Two promises are under test:
+#
+#   - only the store owner primes the sentinel. A root_squash'd NFS client's
+#     root is squashed to nobody, cannot create or chown inside the 2775 tree,
+#     and a client that did create would hand a wiping service its sentinel
+#     back every ten minutes;
+#   - only a stat that reached a real, mounted filesystem is allowed to confirm
+#     absence. ENOENT from an unmounted automount (server unreachable) is a
+#     dead mount, not a wiped root, and must be reported 1/unconfirmed.
+#
+# The script under test is taken from the module's own evaluated ExecStart
+# (never a copy) and driven through the environment overrides the script
+# supports, against fixture mountinfo and a scratch sentinel.
+{
+  inputs,
+  pkgs,
+  self,
+}:
+let
+  eval = inputs.nixpkgs.lib.nixosSystem {
+    system = "x86_64-linux";
+    specialArgs = {
+      inherit self inputs;
+    };
+    modules = [
+      # The service modules assume sops-nix is imported (checks/lib.nix does
+      # this for every test node); monitoring.nix declares secrets against it,
+      # and a host without it refuses the whole option.
+      inputs.sops-nix.nixosModules.sops
+      ../modules/services/media-stack/media-stack.nix
+      ../modules/services/media-stack/download-root-canary.nix
+      ../modules/services/monitoring/monitoring.nix
+      ../modules/services/nas-storage.nix
+      {
+        cg.service.media-stack.enable = true;
+        cg.service.media-stack.canary.enable = true;
+        cg.service.monitoring.enable = true;
+        system.stateVersion = "24.11";
+      }
+    ];
+  };
+
+  execStartValue = eval.config.systemd.services.download-root-canary.serviceConfig.ExecStart;
+  execStart = if builtins.isList execStartValue then execStartValue else [ execStartValue ];
+  canaryScript = builtins.elemAt (builtins.filter (s: s != "") execStart) 0;
+in
+pkgs.runCommand "check-download-root-canary-script" { script = builtins.toString canaryScript; } ''
+    set -euo pipefail
+
+    work=$PWD/work
+    mkdir -p "$work/srv-media/downloads" "$work/metrics"
+    export SENTINEL="$work/srv-media/downloads/.download-root-canary"
+    export PRIME_MARKER="$work/primed"
+    export METRICS_DIR="$work/metrics"
+    export METRICS_FILE="$METRICS_DIR/download_root_canary.prom"
+    export MOUNTINFO="$work/mountinfo"
+
+    fail() { echo "FAIL: $*" >&2; exit 1; }
+    metric() { grep -oE '[01]$' "$METRICS_FILE"; }
+
+    # Fixture mountinfo: a root line plus one describing the sentinel's store.
+    # Real mountinfo lists an automount's autofs trigger and the real mount at
+    # the same depth, in either order; the script must prefer the real one.
+    mk_fixture() {
+      cat >"$MOUNTINFO" <<EOF
+  36 35 0:1 / / rw - rootfs rw
+  $1
+  EOF
+    }
+
+    zfs() { mk_fixture "37 36 0:2 / $work/srv-media rw,relatime - zfs tank rw"; }
+    nfs() { mk_fixture "38 37 0:3 / $work/srv-media rw,relatime - autofs systemd-1
+  39 38 0:3 / $work/srv-media rw,relatime - nfs4 10.0.0.9:/srv/media rw"; }
+    nfs_first() { mk_fixture "38 37 0:3 / $work/srv-media rw,relatime - nfs4 10.0.0.9:/srv/media rw
+  39 38 0:4 / $work/srv-media rw,relatime - autofs systemd-1"; }
+    autofs_alone() { mk_fixture "38 37 0:4 / $work/srv-media rw,relatime - autofs systemd-1"; }
+    rootfs() { mk_fixture ""; }
+
+    run() {
+      rm -f "$METRICS_FILE" "$METRICS_FILE.tmp"
+      "$script" >"$PWD/out.log" 2>"$PWD/err.log" || fail "script exited non-zero (see err.log)"
+    }
+
+    echo "case: the owner primes on its first post-boot run"
+    zfs
+    rm -f "$SENTINEL" "$PRIME_MARKER"
+    run
+    [ -e "$SENTINEL" ] || fail "owner did not prime"
+    [ -e "$PRIME_MARKER" ] || fail "owner marker not set"
+    [ "$(metric)" = 1 ] || fail "metric != 1 right after prime"
+    grep -q "sentinel present" "$PWD/out.log" || fail "no present log"
+
+    echo "case: a deletion after boot prime is reported, not re-created"
+    zfs
+    rm -f "$SENTINEL"
+    run
+    [ ! -e "$SENTINEL" ] || fail "deleted sentinel re-created by owner"
+    [ -e "$PRIME_MARKER" ] || fail "marker lost between runs"
+    [ "$(metric)" = 0 ] || fail "metric != 0 after a confirmed deletion"
+
+    echo "case: nfs client observes a genuine missing sentinel (server mounted)"
+    nfs
+    rm -f "$SENTINEL" "$PRIME_MARKER"
+    run
+    [ "$(metric)" = 0 ] || fail "client did not report a confirmed missing (metric='$(metric)', sentinel=$(test -e "$SENTINEL" && echo exists || echo gone), err=$(cat "$PWD/err.log" 2>/dev/null || true))"
+    [ ! -e "$SENTINEL" ] || fail "client wrote the sentinel"
+    [ ! -e "$PRIME_MARKER" ] || fail "client primed despite nfs cover"
+
+    echo "case: nfs client observes an existing sentinel"
+    nfs
+    : >"$SENTINEL"
+    run
+    [ "$(metric)" = 1 ] || fail "client did not report present"
+
+    echo "case: nfs client with the autofs trigger listed after the real mount"
+    nfs_first
+    rm -f "$SENTINEL"
+    run
+    [ "$(metric)" = 0 ] || fail "cover resolved to autofs over the real mount"
+
+    echo "case: the root filesystem alone covers the store - owner primes through it"
+    rootfs
+    rm -f "$SENTINEL" "$PRIME_MARKER"
+    run
+    [ -e "$SENTINEL" ] || fail "owner did not prime via the root fs"
+    [ -e "$PRIME_MARKER" ] || fail "marker not set when the root fs covers the store"
+    [ "$(metric)" = 1 ] || fail "metric != 1 after a root-fs prime"
+
+    echo "case: server down - unmounted automount, sentinel unreachable"
+    autofs_alone
+    rm -f "$SENTINEL" "$PRIME_MARKER"
+    run
+    [ "$(metric)" = 1 ] || fail "an unreachable sentinel was reported missing"
+    [ ! -e "$SENTINEL" ] || fail "client wrote into an unmounted store"
+    [ ! -e "$PRIME_MARKER" ] || fail "an unmounted trigger was marked primed"
+    grep -q "unreachable" "$PWD/err.log" || fail "no unconfirmed log line"
+
+    touch "$out"
+    echo "ok: download-root-canary-script"
+''

--- a/checks/download-root-canary.nix
+++ b/checks/download-root-canary.nix
@@ -1,0 +1,110 @@
+# checks/download-root-canary.nix
+#
+# Behaviour test for the download-root canary
+# (modules/services/media-stack/download-root-canary.nix, item 8 of
+# docs/plans/deployment-hardening.md).
+#
+# The canary is a sentinel file primed once per boot in the shared download
+# root, statted by a timer, and published to node_exporter's textfile
+# collector as download_root_canary_present. Deleting the sentinel by hand and
+# seeing the metric report missing is the plan's own "done when" - this test is
+# that, in a VM:
+#
+#   - the sentinel exists after the check has run, and the metric says 1
+#   - node_exporter's textfile collector serves the metric (the mkDefault
+#     override that leaves the collector off on hosts without ZFS/VPN)
+#   - deleting the sentinel and re-checking flips the metric to 0, and the
+#     exporter does NOT re-create it - priming is boot-scoped via a /run
+#     marker, so a sending service is never handed its sentinel back
+#   - clearing the /run marker (a reboot's effect) re-arms the prime, proving
+#     the positive half: a healthy boot puts the sentinel in place again
+#
+# No containers, no network, no Prometheus: the test asserts the unit's file
+# output and the node_exporter scrape of it. The alert side is pinned by
+# promtool in alert-rules.test.yml (a present sentinel stays silent, a
+# sustained 0 matures DownloadRootCanaryMissing after its `for:`).
+{
+  name = "download-root-canary";
+
+  nodes.machine =
+    { lib, ... }:
+    {
+      imports = [
+        ../modules/services/media-stack/media-stack.nix
+        ../modules/services/media-stack/download-root-canary.nix
+        ../modules/services/monitoring/monitoring.nix
+        # Imported so media-stack's tmpfiles condition
+        # `!config.cg.service.nas-storage.enable` evaluates; it stays disabled,
+        # so the VM's own tmpfiles creates the media tree as a single-box host
+        # would.
+        ../modules/services/nas-storage.nix
+      ];
+
+      networking.hostName = "download-root-canary";
+      system.stateVersion = "24.11";
+
+      cg.service.media-stack.enable = true;
+      cg.service.media-stack.canary.enable = true;
+      cg.service.monitoring.enable = true;
+
+      # media-stack's tmpfiles chowns the media tree to the user/group its
+      # options name. Real hosts define coryg somewhere; this minimal VM does
+      # not, so without an identity the `d /srv/media/...` rules silently fail
+      # and there is nowhere for the sentinel to live. media-stack creates the
+      # media group itself.
+      users.users.coryg = {
+        isNormalUser = true;
+        group = "media";
+        uid = 1000;
+      };
+
+      # Plenty for a node_exporter + canary; the test is not pushing.
+      virtualisation.memorySize = 1024;
+    };
+
+  testScript = ''
+    sentinel = "/srv/media/downloads/.download-root-canary"
+    metrics = "/var/lib/prometheus-node-exporter/download_root_canary.prom"
+    marker = "/run/download-root-canary-primed"
+
+    # The unit is timer-only by design (no boot-time wantedBy: an unreachable
+    # NFS server must not stall boot, and an automount idle-timeout is a
+    # smaller first run than a boot-time one). Starting it here is the
+    # invocation the assertions read.
+    machine.succeed("systemctl start download-root-canary.service")
+
+    with subtest("the sentinel is primed and reported present"):
+        machine.succeed(f"test -e {sentinel}")
+        machine.succeed(
+            f"grep -q 'download_root_canary_present 1' {metrics}"
+        )
+        machine.succeed(f"test -e {marker}")
+
+    with subtest("node_exporter serves the canary metric (textfile collector wiring)"):
+        machine.wait_for_open_port(9100)
+        # Written to a file rather than piped into grep: the test driver
+        # runs commands under `pipefail`, and `grep -q` exiting at the first
+        # match hands curl an EPIPE. Same shape as checks/monitoring.nix.
+        machine.wait_until_succeeds(
+            "curl -sf -o /tmp/node-metrics http://localhost:9100/metrics "
+            "&& grep -q download_root_canary_present /tmp/node-metrics",
+            timeout=60,
+        )
+
+    with subtest("a deleted sentinel is reported missing and not re-created"):
+        machine.succeed(f"rm {sentinel}")
+        machine.succeed("systemctl start download-root-canary.service")
+        machine.succeed(
+            f"grep -q 'download_root_canary_present 0' {metrics}"
+        )
+        # The prime path must NOT have resurrected it: this is the property
+        # that keeps a wiping service from resetting the series and hiding
+        # the alert.
+        machine.fail(f"test -e {sentinel}")
+
+    with subtest("a fresh boot (cleared marker) re-arms the prime"):
+        machine.succeed(f"rm -f {marker}")
+        machine.succeed("systemctl start download-root-canary.service")
+        machine.succeed(f"test -e {sentinel}")
+  '';
+}

--- a/checks/download-root-safety.nix
+++ b/checks/download-root-safety.nix
@@ -1,0 +1,93 @@
+# checks/download-root-safety.nix
+#
+# Regression test for the static half of the download-root canary: the NixOS
+# assertion that no service-declared output option equals the download root or
+# is an ancestor of it, by path segment. The VM and host builds only exercise
+# the pass-with-the-fleet-values case, which cannot tell a wrong segment
+# boundary from a right one - this check pins the boundary itself.
+#
+# Each case evaluates a full media-stack host with suwayomi enabled and its
+# downloadPath set to the path under test, then asks whether the resulting
+# `download-root-safety` assertion fires. Only failing assertions have their
+# message forced (some assertion messages in the wild would crash on a null
+# while their assertion is actually true), and the guard's messages are plain
+# strings, so this is safe.
+{
+  inputs,
+  lib,
+  pkgs,
+  self,
+}:
+let
+  mkEval =
+    dpath:
+    inputs.nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      specialArgs = {
+        inherit self inputs;
+      };
+      modules = [
+        # The service modules assume sops-nix is imported (checks/lib.nix does
+        # this for every test node).
+        inputs.sops-nix.nixosModules.sops
+        ../modules/services/media-stack/media-stack.nix
+        ../modules/services/media-stack/download-root-canary.nix
+        ../modules/services/media-stack/suwayomi.nix
+        ../modules/services/monitoring/monitoring.nix
+        ../modules/services/nas-storage.nix
+        {
+          cg.service.media-stack.enable = true;
+          cg.service.suwayomi.enable = true;
+          cg.service.suwayomi.downloadPath = dpath;
+          system.stateVersion = "24.11";
+        }
+      ];
+    };
+
+  guardTripped =
+    dpath:
+    let
+      failing = builtins.filter (a: !a.assertion) (mkEval dpath).config.assertions;
+      messages = builtins.map (a: a.message) failing;
+    in
+    builtins.any (m: lib.hasPrefix "download-root-safety:" m) messages;
+
+  mustTrip = [
+    "/"
+    "/srv/media/downloads"
+    "/srv/media"
+    "/srv/media/downloads/"
+  ];
+  mustPass = [
+    "/srv/media/downloadsX"
+    "/srv/media/downloads-extra"
+    "/srv/media/suwayomi"
+  ];
+
+  tripList = lib.concatStringsSep " " (builtins.filter guardTripped mustTrip);
+  expectTrip = lib.concatStringsSep " " mustTrip;
+  passList = lib.concatStringsSep " " (builtins.filter (p: !guardTripped p) mustPass);
+  expectPass = lib.concatStringsSep " " mustPass;
+in
+pkgs.runCommand "check-download-root-safety"
+  {
+    inherit
+      tripList
+      passList
+      expectTrip
+      expectPass
+      ;
+  }
+  ''
+    fail() { echo "FAIL: $*" >&2; exit 1; }
+
+    if [ "$tripList" != "$expectTrip" ]; then
+      fail "expected the guard to trip for [$expectTrip], got [$tripList]"
+    fi
+    if [ "$passList" != "$expectPass" ]; then
+      fail "expected the guard to pass for [$expectPass], got [$passList]"
+    fi
+
+    touch "$out"
+    echo "ok: download-root-safety"
+  ''

--- a/docs/plans/deployment-hardening.md
+++ b/docs/plans/deployment-hardening.md
@@ -14,7 +14,7 @@ Six pieces originally; five now, since service confinement moved out to [ADR 000
 | 4   | Behaviour tests           | large   | **harness + 3 tests landed** - `media-stack` waits on the container move |
 | 5   | Service confinement       | -       | **moved out** - [ADR 0003](../adr/0003-service-confinement-is-bounded-by-hardlinking.md) |
 | 6   | `deploy-rs` interactively | small   | **done** 2026-08-30 - `homelab01` deployed end to end with `magicRollback` confirmation; `homelab02` still needs its bootstrap switch + first deploy |
-| 8   | Download-root canary      | small   | not started - the replacement item 4 named and skipped   |
+| 8   | Download-root canary      | small   | **done** 2026-08-30 - sentinel, alert, guard and tests landed |
 | 9   | Reachability from outside | small   | not started - the last gap whose recovery is physical    |
 | 10  | Deploy-user sudo on SSH keys | small | not started - the security half of item 6, parked by the operator 2026-08-30 |
 
@@ -616,6 +616,17 @@ Detection rather than prevention, and it should be described that way wherever i
 ### Done when
 
 A sentinel file exists in the download root on both servers, its absence raises an alert through the existing rules, and deleting it by hand fires that alert.
+
+### What landed
+
+`modules/services/media-stack/download-root-canary.nix`, sized as the plan asks:
+
+- **Runtime canary.** `.download-root-canary` is primed and checked by the `download-root-canary` timer (first run 5min after boot, then 10min) and published as `download_root_canary_present` through `cg.service.monitoring.textfileCollector`. Only the store owner primes - homelab02's local ZFS - at most once per boot (a `/run` marker), so a wiping service is never handed its sentinel back, the oscillation trap the `for:` needs. homelab01 is the NFS client under a `root_squash` export and only observes: its root is squashed to nobody and cannot create or chown inside the 2775 tree, and so a client can never mask a wipe by re-priming. `DownloadRootCanaryMissing` (`for: 20m`, critical) is in `alert-rules.yml`, unit-tested by promtool, with a `docs/runbooks/media-stack.md` runbook.
+- **Static guard, honestly sized.** A NixOS assertion that no service-declared output/post-processing option covers `dataPath/downloads` or an ancestor of it, by path segment; today that means `cg.service.suwayomi.downloadPath` and `cg.service.shelfmark.ingestPath`, and new output options must register here. It runs on every host build. It cannot see the in-database paths that actually caused 07-25/07-27 - the header and the runbook say so plainly, which is the point the item's own ranking critique makes.
+- **Detection honesty about mounts.** ENOENT from an unmounted automount (the NFS server unreachable) is indistinguishable from a wiped root to a stat, so it is reported 1/unconfirmed, and a dead server pages through its own monitors rather than as data loss. A hung hard-mounted stat is bounded by `timeout(1)` and reported the same way; there is no boot-time `wantedBy` run whose stat could stall `multi-user.target` against a down server.
+- **Tests.** `checks/download-root-canary.nix` boots the canary in a VM and asserts the owner primes, reports 1, and re-arms on a fresh boot. `checks/download-root-canary-script.nix` runs the real script against fixture mountinfo and pins the owner-primes/client-observes/unmounted-store behaviour the VM cannot reach. `checks/download-root-safety.nix` pins the guard's segment boundary itself: it must trip for `/`, the download root, and its ancestor, and pass for a sibling like `/srv/media/downloadsX`.
+
+Both hosts get it with no host edits: the canary defaults on wherever media-stack and monitoring are enabled.
 
 ---
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -8,7 +8,7 @@ notification lands on the right section directly.
 ## Index
 
 | Runbook | Covers |
-|---|---|
+| --- | --- |
 | [fleet-map.md](fleet-map.md) | What runs where - read once, keep in mind during any incident |
 | [node.md](node.md) | Host vitals: TargetDown, systemd units, disk/memory/CPU/temperature, unexpected reboots |
 | [zfs.md](zfs.md) | Pool health, checksum and I/O errors, scrubs |
@@ -17,6 +17,7 @@ notification lands on the right section directly.
 | [backups.md](backups.md) | Restic backup runs |
 | [vpn.md](vpn.md) | Gluetun VPN connectivity and port forwarding |
 | [digital-garden.md](digital-garden.md) | Garden build and Obsidian sync |
+| [media-stack.md](media-stack.md) | The download-root canary: a wiped/emptied shared download root |
 
 ## Conventions
 

--- a/docs/runbooks/media-stack.md
+++ b/docs/runbooks/media-stack.md
@@ -1,0 +1,72 @@
+# Media stack runbook
+
+What to do when alerts about the media stack fire.
+
+## DownloadRootCanaryMissing
+
+**What this is.** A sentinel file
+(`/srv/media/downloads/.download-root-canary`) is primed and checked on a timer
+(`download-root-canary.service`/`.timer`, first run 5min after boot, then every
+10min). Its presence is published to node_exporter's textfile collector as
+`download_root_canary_present` and this alert fires when that metric reads 0
+for 20+ minutes. This is **detection, not prevention**: the download root is a
+shared mutable directory several services are configured, in their own
+databases, to write to, and nothing claims to stop a misconfiguration from
+emptying it. What is promised is that it will not be *quietly* empty.
+
+**Do now.**
+
+1. Confirm the sentinel is actually gone (not a mount problem). Check the
+   canary's own logging:
+   `journalctl -u download-root-canary -b --no-pager`. The metric only reads 0
+   when the check reached a **mounted** filesystem and saw a definite "No such
+   file". If instead you see `sentinel unreachable (... not mounted)` or
+   `sentinel check timed out - reporting present rather than missing`, the
+   mount is in play, not a wiped root - deal with the NFS/ZFS outage, not
+   this alert.
+2. Check the download root itself:
+   `ls -la /srv/media/downloads` and
+   `du -sh /srv/media/downloads/*`. An empty or near-empty `downloads/` while
+   the pool/NFS is healthy is the event this alert exists to surface.
+3. Identify the writer. Look for a service whose output or post-processing
+   directory now points at the download root or an ancestor of it. Check the
+   PostgreSQL/SQLite-backed configs the Nix-level `download-root-safety`
+   assertion cannot see (that is the class the incidents of 2026-07-25 /
+   2026-07-27 belonged to): Sonarr/Radarr/whisparr post-processing, unpackerr,
+   cross-seed linking, punish/prowlarr automation, qBittorrent save paths.
+   `cg.service.suwayomi.downloadPath` and `cg.service.shelfmark.ingestPath`
+   are the only Nix-level paths the assertion can watch.
+4. Restore the sentinel. Only the store owner primes (homelab02, whose ZFS
+   holds the export), so back it into place as the media-owning user rather
+   than as root - root cannot write into a `root_squash`'d export:
+   `sudo -u coryg touch /srv/media/downloads/.download-root-canary && sudo systemctl start download-root-canary.service`
+   This works on either host's view of the same file. A plain reboot on
+   homelab02 also restores it (the first timer run primes it).
+5. Fix the root cause before it empties the root again - the sentinel does
+   nothing to stop it, by design.
+
+**Dig deeper.**
+
+- The canary reports 0 only on a confirmed "No such file" against a real,
+  mounted filesystem. If the sentinel's store is an unmounted automount (the
+  NFS server unreachable - the stat sees the same ENOENT as a wiped root) the
+  exporter publishes 1 and logs why; a dead mount server pages through its
+  own systemd/ZFS/node-reachability alerts instead, and `TargetDown`
+  inhibition keeps the noise down. A hung stat (hard-mounted NFS, `intr` on
+  this fleet) is bounded by `timeout(1)`, reported as unconfirmed, and has
+  the same story. If this alert fired alongside the mount's own alerts, start
+  with the mount.
+- The sentinel is a single file shared by both hosts, and only the store
+  owner (homelab02) primes it; homelab01's canary is read-only observer. It
+  is not re-created after a boot's priming (a `/run` marker scopes priming to
+  one owner boot). That is deliberate: an exporter that re-created it would
+  hand it back to a wiping service at every check, keep the series at 1, and
+  the `for:` would never mature. Deleting it by hand, waiting out the timer
+  plus the 20m `for:`, and watching `DownloadRootCanaryMissing` fire is the
+  documented hand test for this stack.
+- The static side lives in the same module: a NixOS assertion that no
+  service-declared output/post-processing option covers the download root or
+  an ancestor of it, by path segment. It evaluates on every host build and is
+  pinned by `checks/download-root-safety.nix`; the runtime script's storage
+  behaviour is pinned by `checks/download-root-canary-script.nix`. See the
+  module header for the honest scope of what has to be registered there.

--- a/modules/services/media-stack/download-root-canary.nix
+++ b/modules/services/media-stack/download-root-canary.nix
@@ -1,0 +1,335 @@
+# modules/services/media-stack/download-root-canary.nix
+#
+# Item 8 of docs/plans/deployment-hardening.md, which item 4 named and did not
+# do: a sentinel in the shared download root, checked on a timer, published as
+# one textfile metric, and alerted on through the existing rules.
+#
+# Detection rather than prevention, and documented as such. Confinement of the
+# sixteen oci-containers services and inspection of their app-level config are
+# out of scope by ADR 0003 and item 4 respectively; the honest position the
+# plan takes is that the download root is a shared mutable directory several
+# services are configured, in their own databases, to write to. What this can
+# promise is that it will not be quietly empty for long.
+#
+# It rides `cg.service.monitoring.textfileCollector`, so it only needs the
+# monitoring stack that is already enabled on both servers: a sentinel file, a
+# timer that stats it, one metric, one alert rule.
+#
+# Two parts, sized the way the plan asks:
+#
+#   1. RUNTIME CANARY. The sentinel `${dataPath}/downloads/.download-root-canary`
+#      is primed and statted by the download-root-canary timer; whether it
+#      exists is written to node_exporter's textfile collector. A definite
+#      absence is published as 0 and, sustained, fires DownloadRootCanaryMissing.
+#
+#      The sentinel is a single file shared by both hosts (homelab01 mounts
+#      homelab02's export read-write), and it is primed only by the host that
+#      owns the store - a covering filesystem that is neither an NFS client
+#      mount nor an automount trigger, i.e. homelab02's ZFS. NFS clients
+#      observe only: under the root_squash export a client's root is squashed
+#      to nobody and cannot create or chown inside the 2775 tree, so a client
+#      that tried to prime would fail and, were a create ever to succeed, hand
+#      a wiping service its sentinel back at every ten-minute run. The owner
+#      primes at most once per boot (a /run marker clears on reboot), so every
+#      healthy boot ends with its sentinel in place, and anything deleted after
+#      that stays deleted - a wiping service must never be handed it back. A
+#      deletion after boot is a genuine one; an alert with a `for:` fed by an
+#      oscillation never fires.
+#
+#      Presence is reported 1 unless a stat that reached a real filesystem
+#      says "No such file". A clean ENOENT from an UNMOUNTED automount (the
+#      NFS server unreachable) is the mount being down, not the root being
+#      empty - indistinguishable from a real wipe to a stat - so it is reported
+#      as unconfirmed (1) and a dead server pages through its own monitors
+#      (systemd units, ZFS, node reachability), not as data loss. A hung stat
+#      on a hard-mounted server is bounded by timeout(1) (these mounts are
+#      `intr`, so the 60s limit holds) and also reported 1.
+#
+#   2. STATIC GUARD - the "smaller thing". A NixOS assertion that no
+#      service-declared output or post-processing directory covers the download
+#      root (is it, or an ancestor of it, by path segment). Honest scope: it
+#      can only see paths declared as Nix option values. The paths that
+#      actually mattered on 2026-07-25 and 2026-07-27 lived in a
+#      service-managed SQLite database, which no Nix-level check can read -
+#      that class is the runtime canary's business. Paths that live in
+#      generated config/scripts (unpackerr's paths, the cleanup scripts'
+#      completeDir) are not harvested either: they are code, reviewed as code,
+#      while an option default can change and only show up in the eval. What
+#      the guard does catch is the configuration-level class it is named for,
+#      and only for registered options - a new media-adjacent service must add
+#      its output option to `declaredOutputs` the moment it has one.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  stack = config.cg.service.media-stack;
+  cfg = config.cg.service.media-stack.canary;
+  monitoring = config.cg.service.monitoring;
+
+  downloadRoot = "${stack.dataPath}/downloads";
+  sentinel = "${downloadRoot}/.download-root-canary";
+  primeMarker = "/run/download-root-canary-primed";
+
+  metricsDir = "/var/lib/prometheus-node-exporter";
+  metricsFile = "${metricsDir}/download_root_canary.prom";
+
+  # All of the shell's state (paths that can differ from the defaults below)
+  # is overridable via the environment, so the checks can run this exact script
+  # against fixture mountinfo and a scratch sentinel rather than a copy.
+  canaryScript = pkgs.writeShellScript "download-root-canary-check" ''
+    set -uo pipefail
+
+    METRICS_DIR="''${METRICS_DIR:-${metricsDir}}"
+    METRICS_FILE="''${METRICS_FILE:-${metricsFile}}"
+    SENTINEL="''${SENTINEL:-${sentinel}}"
+    PRIME_MARKER="''${PRIME_MARKER:-${primeMarker}}"
+    MOUNTINFO="''${MOUNTINFO:-/proc/self/mountinfo}"
+    TMP_FILE="$METRICS_FILE.tmp"
+
+    mkdir -p "$METRICS_DIR"
+
+    # Whether $target is $mp or under it. `"$mp"/*` cannot express it for
+    # mp = "/" (which would yield "//*"), so the root mount is special-cased.
+    under() {
+      local target=$1 mp=$2
+      [ "$mp" = "$target" ] && return 0
+      [ "$mp" = "/" ] && [[ "$target" == /* ]] && return 0
+      [[ "$target" == "$mp"/* ]]
+    }
+
+    # The filesystem covering the sentinel: the fstype of the longest
+    # mountpoint (mountinfo field 5) that is it or a parent of it. When a real
+    # filesystem and its automount trigger share the deepest mountpoint, the
+    # real one wins; empty when nothing is mounted there.
+    cover_fs() {
+      local target=$1 line mp maxlen=0 entry=""
+      while IFS= read -r line; do
+        set -- $line
+        mp=''${5:-}
+        [ -n "$mp" ] || continue
+        under "$target" "$mp" && [ "''${#mp}" -gt "$maxlen" ] && maxlen=''${#mp}
+      done <"$MOUNTINFO"
+
+      while IFS= read -r line; do
+        set -- $line
+        mp=''${5:-}
+        [ -n "$mp" ] || continue
+        [ "''${#mp}" -ne "$maxlen" ] && continue
+        if under "$target" "$mp"; then
+          rest=''${line#*" - "}
+          set -- $rest
+          entry=''${1:-}
+          [ "$entry" != "autofs" ] && break
+        fi
+      done <"$MOUNTINFO"
+      printf '%s' "$entry"
+    }
+
+    # Whether the covering filesystem means this host owns the store. Owner =
+    # a real, reachable, local filesystem (homelab02's ZFS). NFS clients and
+    # automount triggers are observers, not owners.
+    owner_fs() {
+      case "$1" in
+        nfs|nfs4|autofs|"")
+          return 1
+          ;;
+        *)
+          return 0
+          ;;
+      esac
+    }
+
+    # Prime at most once per boot, and only on the owner. /run clears on
+    # reboot, so every healthy owner boot ends with its sentinel in place, and
+    # anything deleted after that stays deleted - a wiping service must never
+    # be handed it back. If the store is not reachable yet (late ZFS import),
+    # priming fails without the marker, so the next run retries.
+    if owner_fs "$(cover_fs "$SENTINEL")" && [ ! -e "$PRIME_MARKER" ]; then
+      if timeout 60 install -m 0644 /dev/null "$SENTINEL" 2>/dev/null; then
+        : > "$PRIME_MARKER"
+      else
+        echo "download-root-canary: could not prime $SENTINEL yet (store not up?); retrying next run" >&2
+      fi
+    fi
+
+    # Presence check - also what trigger-mounts an idle NFS automount, so the
+    # covering-fs re-read below reflects the state this stat actually ran
+    # against. `ls -d` rather than `test -e` so a clean ENOENT can be told
+    # apart from a mount that is failing - `test`/`stat` collapse both into
+    # exit 1. A 60s timeout bounds a stat hanging on a hard-mounted NFS server.
+    check="$(LC_ALL=C timeout 60 ls -d -- "$SENTINEL" 2>&1)"
+    rc=$?
+
+    cover=$(cover_fs "$SENTINEL")
+
+    present=1
+    state=unconfirmed
+    case "$rc" in
+      0)
+        present=1
+        state=present
+        ;;
+      124)
+        # stat() hung: a hard-mounted server is not answering. A hung mount is
+        # not a wiped root; the mount's own monitors cover a dead server, so
+        # presence is reported unconfirmed rather than missing.
+        echo "download-root-canary: sentinel check timed out - reporting present rather than missing" >&2
+        ;;
+      *)
+        if printf '%s' "$check" | grep -q "No such file"; then
+          if [ "$cover" = "autofs" ] || [ -z "$cover" ]; then
+            # ENOENT from an unmounted automount (NFS server unreachable) is
+            # indistinguishable from a wiped root to a stat. Report presence
+            # unconfirmed and let the mount's own monitors tell the story.
+            echo "download-root-canary: sentinel unreachable ($cover not mounted) - reporting present rather than missing" >&2
+          else
+            present=0
+            state=missing
+          fi
+        else
+          # Non-ENOENT failure (I/O error, automount failure): same reasoning
+          # as the timeout, we cannot see the sentinel and must not guess.
+          echo "download-root-canary: $check" >&2
+        fi
+        ;;
+    esac
+
+    {
+      echo "# HELP download_root_canary_present Whether the download-root canary sentinel exists (1 = present or unconfirmed, 0 = confirmed missing)"
+      echo "# TYPE download_root_canary_present gauge"
+      echo "download_root_canary_present $present"
+    } >"$TMP_FILE"
+
+    # Atomic swap, same reason as deploy-metrics: the collector reads this
+    # directory continuously and a half-written file is a parse error rather
+    # than a missing metric.
+    mv "$TMP_FILE" "$METRICS_FILE"
+    echo "download-root-canary: sentinel $state"
+  '';
+in
+{
+  options.cg.service.media-stack.canary = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = stack.enable;
+      description = ''
+        Watch the download root with a primed sentinel and publish its presence
+        as a textfile metric, alerting through the existing rules if it goes
+        missing. Defaults on wherever media-stack is enabled.
+      '';
+    };
+  };
+
+  config = lib.mkMerge [
+    # ------------------------------------------------------------------
+    # 1. Runtime canary. Gated on monitoring because the whole point is to
+    # ride the textfile collector it enables. media-stack on its own is not
+    # enough - without it there is nothing listening.
+    # ------------------------------------------------------------------
+    (lib.mkIf (stack.enable && cfg.enable && monitoring.enable) {
+      # Overrides the mkDefault in monitoring.nix, which otherwise leaves the
+      # textfile collector off on any host without ZFS or the VPN - homelab01.
+      cg.service.monitoring.textfileCollector.enable = true;
+
+      systemd.tmpfiles.rules = [
+        "d ${metricsDir} 0755 root root -"
+      ];
+
+      systemd.services.download-root-canary = {
+        description = "Download root canary presence check";
+        wants = [ "network-online.target" ];
+        after = [
+          "network-online.target"
+          "systemd-tmpfiles-setup.service"
+        ];
+        # Deliberately no wantedBy: nothing needs the canary at boot, and a
+        # boot-time stat is exactly what would stall multi-user.target against
+        # a down NFS server (the automount trigger can burn its 30s
+        # mount-timeout). The timer's OnBootSec=5min is the first run.
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = canaryScript;
+        };
+      };
+
+      # 5min after boot (the owner re-primes each run until the marker is set,
+      # in case of a late store import), then every 10min. Detection latency
+      # is therefore ~10min plus the alert's `for:` - comfortably inside the
+      # plan's "not quietly empty for two days".
+      systemd.timers.download-root-canary = {
+        description = "Timer for download root canary check";
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          OnBootSec = "5min";
+          OnUnitActiveSec = "10min";
+          Unit = "download-root-canary.service";
+        };
+      };
+    })
+
+    # ------------------------------------------------------------------
+    # 2. Static guard. Active wherever the media stack is, independent of the
+    # canary toggle: it protects the same tree the runtime side watches, and
+    # item 4 named it as a check for every moderation.
+    # ------------------------------------------------------------------
+    (lib.mkIf stack.enable {
+      assertions =
+        let
+          # Is `candidate` the download root, or an ancestor of it, by path
+          # segment? /srv/media/downloadsX does not count (a sibling) while
+          # /srv/media does - a directory that covers its own sentinel is
+          # invisible to it, which is the whole class this guard exists for.
+          # Lexical by design: these are managed option values, and the ".."
+          # / symlink / duplicate-separator headroom a resolver would add is
+          # not the class being caught.
+          ancestorsOrSelf =
+            candidate:
+            let
+              drop = s: builtins.filter (x: x != "" && x != ".") (lib.splitString "/" s);
+              c = drop candidate;
+              d = drop downloadRoot;
+              shared = if lib.length c <= lib.length d then lib.length c else lib.length d;
+              aligned = lib.all (i: lib.elemAt c i == lib.elemAt d i) (lib.genList (i: i) shared);
+            in
+            lib.length c <= lib.length d && aligned;
+
+          # The option-valued output/post-processing directories in the fleet,
+          # for the services that are actually enabled. This list is the whole
+          # reach of the guard, and that is sized honestly: see the header for
+          # what is deliberately not here and why.
+          byService =
+            svc: attr:
+            let
+              svcOpts = lib.attrByPath [ "cg" "service" svc ] { } config;
+            in
+            if svcOpts.enable or false then svcOpts.${attr} or null else null;
+
+          declaredOutputs = lib.filter (o: o.path != null) [
+            {
+              name = "cg.service.suwayomi.downloadPath";
+              path = byService "suwayomi" "downloadPath";
+            }
+            {
+              name = "cg.service.shelfmark.ingestPath";
+              path = byService "shelfmark" "ingestPath";
+            }
+          ];
+        in
+        lib.imap0 (_: o: {
+          assertion = !ancestorsOrSelf o.path;
+          message = ''
+            download-root-safety: ${o.name} is `${o.path}`, which is the
+            download root (`${downloadRoot}`) or an ancestor of it. A service
+            whose output or post-processing directory covers the download
+            root cannot be watched by the sentinel inside it - the
+            configuration-level class the would-be data-safety test protected
+            (item 4 of docs/plans/deployment-hardening.md). Point the output
+            at a sibling directory under `${stack.dataPath}`.
+          '';
+        }) declaredOutputs;
+    })
+  ];
+}

--- a/modules/services/monitoring/alert-rules.yml
+++ b/modules/services/monitoring/alert-rules.yml
@@ -544,3 +544,29 @@ groups:
           runbook_url: "https://github.com/corygyarmathy/dotfiles/blob/master/docs/runbooks/vpn#gluetunportnotforwarded"
           summary: "Gluetun has no forwarded port on {{ $labels.instance }}"
           description: "VPN is connected but port forwarding returned 0 — qBittorrent will show as firewalled"
+  - name: media
+    rules:
+      # The download-root canary (modules/services/media-stack/download-root-canary.nix,
+      # item 8 of docs/plans/deployment-hardening.md). A primed sentinel in the
+      # shared download root is published as download_root_canary_present by the
+      # download-root-canary timer; the plan's "done when" is that deleting it by
+      # hand fires this alert.
+      #
+      # Detection, not prevention: the download root is a shared mutable directory
+      # several services are configured - in their own databases - to write to.
+      # What this promises is that it will not be quietly empty for long.
+      #
+      # `for: 20m` sits just above the check cadence (10m) plus one scrape
+      # interval, so a single bad scrape cannot fire it while a genuinely missing
+      # sentinel still alerts within the hour. The exporter publishes 1 (present
+      # or unconfirmed) rather than 0 while a mount is hung, so a dead NFS server
+      # pages through its own monitors, not here.
+      - alert: DownloadRootCanaryMissing
+        expr: download_root_canary_present == 0
+        for: 20m
+        labels:
+          severity: critical
+        annotations:
+          runbook_url: "https://github.com/corygyarmathy/dotfiles/blob/master/docs/runbooks/media-stack#downloadrootcanarymissing"
+          summary: "Download root canary missing on {{ $labels.instance }}"
+          description: "The sentinel file in the download root has been confirmed absent for 20+ minutes. Either the download root was wiped or emptied, or the sentinel was removed deliberately - a stopped canary timer cannot fire this alert (node_exporter keeps serving the last-written metric), so check the download-root-canary unit and then face a wiped root."


### PR DESCRIPTION
Part of the hardening plan: item 8 of `docs/plans/deployment-hardening.md`.

## Problem
`/srv/media/downloads` is a shared mutable directory written by services whose
dests live in their own databases. If a service's config drifts or a cleanup
runs wild, the root can be silently wiped with nothing referencing it —
undetected. This adds a canary: a boot-armed sentinel whose presence is
published as a Prometheus textfile metric, alerting if it goes missing for
20+ minutes. Deleting it by hand fires the alert (the plan's "done when").

## Design
- `modules/services/media-stack/download-root-canary.nix` (applied on both
  hosts): a 10-minute timer stats the sentinel and writes
  `download_root_canary_present` to node_exporter's textfile collector.
- **Owner-only prime**: only the host whose mountinfo shows a real local fs
  (homelab02's ZFS) primes. homelab01's `root_squash` makes root a nobody on
  the export, so an NFS client must never create the sentinel.
- **Honest verdicts**: ENOENT is a confirmed missing only when a real mounted
  fs covers the sentinel; an unmounted automount (dead NFS server) reports
  unconfirmed so an outage doesn't page a wiped root.
- **No boot-time run**: timer-first-run primes, so a down server can't stall
  `multi-user.target` at boot.
- `DownloadRootCanaryMissing` (critical, `for: 20m`) on a confirmed-absent
  sentinel; a *stopped timer* cannot fire it (last-written metric persists).

## Verification
- `checks/download-root-canary.nix` — VM behaviour test: prime → metric 1 →
  served via node_exporter; delete → 0 and *not* re-created; clear `/run`
  marker (reboot) → re-armed.
- `checks/download-root-canary-script.nix` — unit test running the *real*
  generated `ExecStart` against fixture mountinfo (owner prime, NFS client
  observes, automount order ambiguity, automount-only = unconfirmed, root-fs
  cover).
- `checks/download-root-safety.nix` — static-guard eval regression (paths
  outside `/srv/media/downloads` must be rejected).
- `checks/alert-rules.test.yml` — promtool unit test incl. the 20m maturation
  with margin.
- Docs: runbook `media-stack.md` + hardening-plan "What landed" updated.

`nix flake check`, homelab01/homelab02 toplevels, and `nix fmt` all pass
locally.