### PR TITLE
fix(qbittorrent): gate vpn-port-sync on gluetun being connected

### DIFF
--- a/modules/services/media-stack/qbittorrent.nix
+++ b/modules/services/media-stack/qbittorrent.nix
@@ -66,6 +66,17 @@ in
         default = "protonvpn";
         description = "VPN service provider for Gluetun";
       };
+
+      syncReadyTimeoutSeconds = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 90;
+        description = ''
+          How long `vpn-port-sync` waits for gluetun to report an active VPN
+          connection before skipping the run (polling every 5 seconds). A
+          skipped run retries on the next timer fire; a gluetun that never
+          connects is alerted separately by `GluetunVpnDisconnected`.
+        '';
+      };
     };
   };
 
@@ -260,6 +271,36 @@ in
           QB_USER=$(cat "$CREDENTIALS_DIRECTORY/qbt-user")
           QB_PASS=$(cat "$CREDENTIALS_DIRECTORY/qbt-pass")
           API_KEY=$(cat "$CREDENTIALS_DIRECTORY/gluetun-api-key" | sed 's/^HTTP_CONTROL_SERVER_API_KEY=//')
+
+          # Gate on gluetun actually being connected, not merely on its
+          # container unit being active. podman-gluetun.service reaches
+          # "active" as soon as the container has started; the WireGuard
+          # handshake and the port-forward request happen after that. On a cold
+          # boot this unit's OnBootSec fired inside that gap, exited 1, and sat
+          # in the `failed` state long enough for upgrade verification to read
+          # it as "the new generation came up broken" (2026-08-31).
+          #
+          # Connectivity is not this unit's to fail on: it is
+          # gluetun-health-exporter's business and already alerts as
+          # GluetunVpnDisconnected. So wait a bounded time, then skip the run
+          # rather than fail it - the timer fires again every 5 minutes.
+          STATUS=""
+          attempts=$(( ${toString cfg.vpn.syncReadyTimeoutSeconds} / 5 ))
+          while [ "$attempts" -gt 0 ]; do
+            attempts=$(( attempts - 1 ))
+            STATUS=$(curl -sf --max-time 5 -H "X-API-Key: $API_KEY" \
+              "http://localhost:8000/v1/vpn/status" 2>/dev/null \
+              | jq -r '.status // empty' 2>/dev/null)
+            if [ "$STATUS" = "running" ]; then
+              break
+            fi
+            sleep 5
+          done
+
+          if [ "$STATUS" != "running" ]; then
+            echo "Gluetun did not connect within ${toString cfg.vpn.syncReadyTimeoutSeconds}s; skipping this run. Connectivity alerts separately as GluetunVpnDisconnected."
+            exit 0
+          fi
 
           FORWARDED_PORT=$(curl -sf -H "X-API-Key: $API_KEY" \
             "http://localhost:8000/v1/portforward" 2>/dev/null \


### PR DESCRIPTION
## Summary

`vpn-port-sync.service` on `homelab02` fires at `OnBootSec=1min`, before gluetun has finished its WireGuard handshake. The port-forward fetch then failed with an empty port, `exit 1`, and left a terminal `failed` unit — which `nixos-upgrade-verify` read as "the new generation came up broken" (see the 2026-08-31 incident, where the alert fired at 04:30 and self-resolved at 05:02 once gluetun connected and the hourly recheck passed).

## Change

Gate the sync on gluetun actually being connected rather than merely on the `podman-gluetun` container unit being active:

- New option `cg.service.qbittorrent.vpn.syncReadyTimeoutSeconds` (default `90`).
- Before the port-forward fetch, poll `/v1/vpn/status` every 5s for up to the timeout. If gluetun reports `running`, proceed; otherwise **skip (`exit 0`) instead of failing** — the timer retries every 5 minutes.

Connectivity stays a separate concern: `gluetun-health-exporter` (1-min scrape, enabled by `monitoring.vpn.enable`) feeds `GluetunVpnDisconnected` (`gluetun_vpn_connected == 0`, `for: 2m`). No alerting changes were needed.

## Checks

- `nix eval` of the generated `vpn-port-sync.script` + confirmed service `PATH` includes coreutils
- `bash -n` and `shellcheck -s sh` on the generated script — clean
- `nix build --no-link .#nixosConfigurations.homelab02.config.system.build.toplevel` — exit 0

## Notes / residual risk

- `FORWARDED_PORT` empty/`0` still exits 1 (distinct gluetun state, covered by `GluetunPortNotForwarded`); can be made to skip the same way if preferred.
- Not covered by a VM check — the media-stack containers can't run in the Nix sandbox, so the gate is only provable on the host at runtime.