### PR TITLE
build(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -267,11 +267,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1788060129,
-        "narHash": "sha256-la0YyjqDV/UYBa+fEApQg7IeMsH/LzvzSIKSHd4SRYo=",
+        "lastModified": 1788127064,
+        "narHash": "sha256-fC4A4mde4WeGSynrHUkLZtV/lmValH6Idw/QJn0MUDs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "026907ed9c7f58251c0ed0c73cc1c796e85c40b7",
+        "rev": "3633f4ab859cd646d244802286d916f107ffeda7",
         "type": "github"
       },
       "original": {
@@ -283,11 +283,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1787900134,
-        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
+        "lastModified": 1788039129,
+        "narHash": "sha256-pa4Q0qErvCvzCaaUph7Sm37RhR4xvPrYI8Lgz6k85+A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
+        "rev": "d2f67949798825fe853f7c5d0492b8bf016d3f88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `flake.lock` update.

The per-host deltas below are recorded in the commit body so they
land in `git log` on merge (ADR 0001).

Each host was built at the current lock and at the updated one, and
the closures compared. All three builds passing is a precondition of
this PR existing at all — but the `nixos ci` gate still has to pass
before it can merge, and merging is what promotes `deploy`.

### homelab01

initrd-linux: 6.18.47 → 6.18.48, 23.6 KiB
linux: 6.18.47 → 6.18.48, -24.7 KiB
nixos-manual: 10.2 KiB
nixos-system-homelab01: 26.11.20260828.83199d0 → 26.11.20260829.d2f6794
shfmt: 3.13.1 → 3.14.0, 40.1 KiB
source: 216.7 KiB

### homelab02

initrd-linux: 6.18.47 → 6.18.48, -94.0 KiB
linux: 6.18.47 → 6.18.48, -24.7 KiB
nixos-manual: 10.2 KiB
nixos-system-homelab02: 26.11.20260828.83199d0 → 26.11.20260829.d2f6794
shfmt: 3.13.1 → 3.14.0, 40.1 KiB
source: 216.7 KiB
zfs-kernel: 2.4.4-6.18.47 → 2.4.4-6.18.48

### xps15

discord: 1.0.154, 1.0.154-fhsenv → 1.0.155, 1.0.155-fhsenv
discord-unwrapped: 1.0.154 → 1.0.155
firefox-unwrapped: 122.0 KiB
initrd-linux: 7.2.1 → 7.2.2, 28.1 KiB
linux: 7.2.1 → 7.2.2
nixos-manual: 10.2 KiB
nixos-system-xps15: 26.11.20260828.83199d0 → 26.11.20260829.d2f6794
nss: 3.127 → 3.128, 211.6 KiB
nvidia-open: 595.91.07-7.2.1 → 595.91.07-7.2.2, -12.1 MiB
obs-studio: 32.2.1 → 32.2.2
opencode: 1.18.21 → 1.18.25, 60.0 KiB
shfmt: 3.13.1 → 3.14.0, 40.1 KiB
source: 216.7 KiB
x86_energy_perf_policy: 6.18.47 → 6.18.48