### PR TITLE
refactor(modules): decouple modules from the fleet

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -252,6 +252,20 @@
           secrets."digital-garden/obsidian-token" = "not-a-real-obsidian-token";
           templates."digital-garden-obsidian-env" = "OBSIDIAN_AUTH_TOKEN=not-a-real-obsidian-token\n";
         })
+        # The module asserts cg.service.reverse-proxy.enable is on - its Caddy
+        # vhost depends on Caddy, which the reverse proxy enables on a real
+        # host. Declare just that toggle here (rather than importing the whole
+        # reverse-proxy module with its Cloudflare plugin build) so this test
+        # keeps exercising only the digital garden.
+        (
+          { lib, ... }:
+          {
+            options.cg.service.reverse-proxy.enable = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+            };
+          }
+        )
       ];
 
       cg.service.digital-garden = {
@@ -262,9 +276,11 @@
         baseUrl = "garden.test.invalid";
       };
 
-      # The module adds a virtual host but never enables Caddy - on a real host
-      # that comes from cg.service.reverse-proxy. Enabling it directly keeps
-      # this test to the one module under examination.
+      # The module asserts cg.service.reverse-proxy.enable is on (declared by
+      # the module added to imports above); satisfy it, then enable Caddy
+      # directly rather than through the reverse proxy so this test keeps
+      # exercising only the one module under examination.
+      cg.service.reverse-proxy.enable = true;
       services.caddy.enable = true;
 
       # The half of the module that wants the network. It would restart every

--- a/docs/plans/structural-cleanup.md
+++ b/docs/plans/structural-cleanup.md
@@ -1,6 +1,6 @@
 # Plan: structural cleanup
 
-Status: drafted 2026-08-28. Items 0 and 1 landed the same day, items 2 and 3 on 2026-08-29. Item 4 was a three-step item: step 1 landed on 2026-08-29, and steps 2 and 3 — the deploy and the re-key that finishes it — on 2026-08-30. Items 5 to 7 have not started.
+Status: drafted 2026-08-28. Items 0 and 1 landed the same day, items 2 and 3 on 2026-08-29. Item 4 was a three-step item: step 1 landed on 2026-08-29, and steps 2 and 3 — the deploy and the re-key that finishes it — on 2026-08-30. Items 5 to 8 have not started.
 
 This is a refactoring plan, not a feature plan. Almost none of it changes what the fleet does; most of it changes where a fact is written down and who is allowed to read it. Two items are exceptions and are marked as such — the secrets re-key (item 4) and closing the service ports (item 5) both change behaviour on running machines. Items 1 and 2 are marked `minor`: each changed a handful of lines of generated configuration, and each lists them under what it landed. Item 2's are the probe list it exists to fix.
 
@@ -16,6 +16,7 @@ The pipeline, the checks harness and the documentation are in good shape and are
 | 5   | Caddy as the real boundary        | medium | **yes**           | 1, 2       | not started           |
 | 6   | Decouple modules from the fleet   | small  | no                | 1          | not started           |
 | 7   | Documentation follows the code    | small  | no                | 1–6        | not started           |
+| 8   | AdGuard rewrites follow cg.publish | medium | minor             | 2          | not started           |
 
 Suggested order is the numbering. Item 0 first because the gate is currently over budget and every later PR pays that cost. Items 1–3 are one continuous piece of work and are only split because each has a natural landing point. Items 4 and 5 are the two that need a deliberate deploy and a rollback plan, and both are much easier once item 1 exists.
 
@@ -479,7 +480,7 @@ The in-app configuration is the part no check can cover — the same limitation 
 
 Reusable modules carry knowledge of this specific installation, which is what makes them not reusable. Item 1 took the literals out; what it did not do is make the defaults right for a machine outside this fleet.
 
-- `modules/services/adguard-home.nix` — the literal host-to-address map is gone, but the module now *requires* `cg.fleet.roles.gateway` and `.storage` to name real hosts, and its `gatewaySubdomains` / `storageSubdomains` lists are still this installation's service map living in a general-purpose DNS module. That is item 2's to move; what belongs here is that the module should say so rather than failing on a missing attribute.
+- `modules/services/adguard-home.nix` — the literal host-to-address map is gone, but the module now *requires* `cg.fleet.roles.gateway` and `.storage` to name real hosts, and its `gatewaySubdomains` / `storageSubdomains` lists are still this installation's service map living in a general-purpose DNS module. Item 2 was meant to move these into `cg.publish` and did not: the lists are the one copy of the fleet's service map that the registry does not drive. The reason is structural rather than an oversight — `cg.publish` is per-host, so a host cannot see what its peer publishes, while a resolver's rewrite list is a fleet-wide view — so it is an open follow-up (item 8) rather than part of this item. What belongs here is only that the module should say so rather than failing on a missing attribute.
 - `modules/services/media-stack/cross-seed.nix` — `prowlarrUrl` still defaults to the gateway host's address, i.e. the module still defaults to another machine in this fleet.
 - `modules/services/immich.nix:111` — `DB_PASSWORD=changeme-use-sops-for-real-deployment`. The service is disabled everywhere, so this is not live, but a literal password in a module is the kind of thing that survives being enabled.
 - `modules/services/digital-garden/digital-garden.nix` — adds a Caddy virtual host without enabling Caddy. Already noted in the hardening plan as "a coupling that is invisible until it bites"; it should be an assertion.
@@ -519,6 +520,53 @@ Two things worth adding rather than updating: an ADR for the fleet layer (the ch
 ### Done when
 
 A reader can answer "where does this belong?" from `modules/README.md`, and no document restates a fact that `fleet/` now holds.
+
+---
+
+## 8. AdGuard rewrites follow cg.publish
+
+### The problem
+
+`modules/services/adguard-home.nix` still carries `gatewaySubdomains` and
+`storageSubdomains`, two hand-written lists of which subdomain is fronted by
+which host's Caddy. They are the one copy of the fleet's service map that item
+2's `cg.publish` registry does not drive, so adding or moving a service updates
+`cg.publish` but not DNS. The failure is silent and points the wrong way: a
+service moved to the storage host's Caddy keeps resolving to the gateway, whose
+Caddy has no certificate for it, so it surfaces as a TLS error rather than a DNS
+one — the lists' own comment says this.
+
+### Approach
+
+Item 2 could not move these: `cg.publish` is per-host and a host cannot see what
+its peer publishes, while the primary resolver's rewrite list is a fleet-wide
+view — it has to answer for the storage host's subdomains too. What is
+missing is a cross-host union of `cg.publish`, which nothing in the tree builds.
+
+Two directions, in order of preference:
+
+1. Derive the rewrites from the registry. Expose a fleet-wide view of
+   `cg.publish` (the flake already evaluates every host, so this is a read at
+   flake level rather than new module-system framework) and turn each published
+   entry into a rewrite to the host that carries it, keeping the wildcard
+   fallback and the apex entry.
+2. If the union is not worth the framework, add a check that the hand-written
+   lists and the union of `cg.publish` agree, so drift fails `nix flake check`
+   instead of failing as a TLS error on the LAN.
+
+### Done when
+
+Either a published subdomain is rewritten automatically with no hand-written
+list, or a list that disagrees with `cg.publish` fails the gate.
+
+### Risks
+
+The union is the whole job and it is easy to over-build: the resolver needs only
+"which host fronts which subdomain", not a second publication registry. Keep the
+wildcard fallback, which the host-alive beacons deliberately rely on (see the
+wildcard comment in `adguard-home.nix`). Diff the generated rewrites against the
+current lists before landing; if they come out byte-identical this is a
+`no`-behaviour change and the only risk is getting the union wrong.
 
 ---
 

--- a/hosts/homelab02/default.nix
+++ b/hosts/homelab02/default.nix
@@ -336,6 +336,9 @@ in
 
     cross-seed = {
       enable = true;
+      # Prowlarr runs on the gateway; cross-seed reaches it by address, not
+      # hostname (see the prowlarrUrl option in the module).
+      prowlarrUrl = "http://${fleet.hosts.${gateway}.address}:9696";
       # Your private tracker indexer IDs from Prowlarr
       # Find at: Prowlarr -> Indexers -> click tracker -> ID in URL
       torznabIndexerIds = [ 8 ]; # IPT

--- a/modules/services/adguard-home.nix
+++ b/modules/services/adguard-home.nix
@@ -29,8 +29,14 @@ let
   # Where the two fleet-wide duties live. Everything below is expressed
   # against these rather than against host names, so moving a duty to another
   # machine is an edit to fleet/default.nix and nothing else.
-  gateway = fleet.hosts.${fleet.roles.gateway}.address;
-  storage = fleet.hosts.${fleet.roles.storage}.address;
+  #
+  # Looked up defensively so that a fleet without these roles fails the
+  # assertions below with a message naming the role, rather than as
+  # "attribute 'gateway' missing" halfway through building the rewrites.
+  gatewayName = fleet.roles.gateway or null;
+  storageName = fleet.roles.storage or null;
+  gateway = if gatewayName == null then "" else fleet.hosts.${gatewayName}.address or "";
+  storage = if storageName == null then "" else fleet.hosts.${storageName}.address or "";
 
   # Every host that has a reserved address resolves by name. The laptop does
   # not have one, which is why this filters rather than mapping the lot.
@@ -257,6 +263,23 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = gateway != "";
+        message = ''
+          cg.service.adguard-home requires cg.fleet.roles.gateway to name a
+          host with an address - every unlisted subdomain rewrites to it.
+        '';
+      }
+      {
+        assertion = storage != "";
+        message = ''
+          cg.service.adguard-home requires cg.fleet.roles.storage to name a
+          host with an address - the storage host's own services rewrite to it.
+        '';
+      }
+    ];
+
     # The web UI. Both instances run this module, so the hostname is the one
     # part a host has to choose for itself - the secondary answers to
     # `adguard2`, which is the name in the storage host's rewrite list above.

--- a/modules/services/digital-garden/digital-garden.nix
+++ b/modules/services/digital-garden/digital-garden.nix
@@ -446,6 +446,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.cg.service.reverse-proxy.enable;
+        message = "digital-garden requires the reverse proxy to be enabled (cg.service.reverse-proxy.enable = true) - it publishes a Caddy vhost and relies on Caddy for TLS";
+      }
+    ];
+
     cg.publish.digital-garden = {
       subdomain = "garden";
       port = cfg.port;

--- a/modules/services/immich.nix
+++ b/modules/services/immich.nix
@@ -42,7 +42,7 @@ in
             - ${immichRoot}/upload:/usr/src/app/upload
             - /etc/localtime:/etc/localtime:ro
           env_file:
-            - /etc/immich/.env
+            - ${config.sops.templates."immich-env".path}
           ports:
             - 2283:2283
           depends_on:
@@ -58,7 +58,7 @@ in
           volumes:
             - ${immichRoot}/model-cache:/cache
           env_file:
-            - /etc/immich/.env
+            - ${config.sops.templates."immich-env".path}
           restart: unless-stopped
           healthcheck:
             disable: false
@@ -104,22 +104,34 @@ in
           restart: unless-stopped
     '';
 
-    # Create the .env file for Immich
-    # IMPORTANT: Change the DB_PASSWORD before first run!
-    environment.etc."immich/.env".text = ''
-      # Database
-      DB_PASSWORD=changeme-use-sops-for-real-deployment
-      DB_USERNAME=postgres
-      DB_DATABASE_NAME=immich
+    # The .env file Immich's containers read. The database password comes from
+    # sops rather than a literal: a default password in a module is the kind of
+    # thing that survives being enabled, so there is deliberately none. The
+    # secret name is declared here, and checks/secrets.nix fails the gate if it
+    # is missing from the file the host reads - which is what turns "enable
+    # immich" into a request for a real password rather than a working install.
+    sops.secrets."immich/db-password" = {
+      mode = "0400";
+      restartUnits = [ "immich.service" ];
+    };
 
-      # Immich settings
-      UPLOAD_LOCATION=${immichRoot}/upload
-      IMMICH_VERSION=${immichVersion}
+    sops.templates."immich-env" = {
+      content = ''
+        # Database
+        DB_PASSWORD=${config.sops.placeholder."immich/db-password"}
+        DB_USERNAME=postgres
+        DB_DATABASE_NAME=immich
 
-      # Optional: Hardware acceleration
-      # Uncomment if you want to use Intel Quick Sync for video transcoding
-      # IMMICH_FFMPEG_HW_ACCEL=vaapi
-    '';
+        # Immich settings
+        UPLOAD_LOCATION=${immichRoot}/upload
+        IMMICH_VERSION=${immichVersion}
+
+        # Optional: Hardware acceleration
+        # Uncomment if you want to use Intel Quick Sync for video transcoding
+        # IMMICH_FFMPEG_HW_ACCEL=vaapi
+      '';
+      mode = "0400";
+    };
 
     # Systemd service to manage Immich via docker-compose
     systemd.services.immich = {

--- a/modules/services/media-stack/cross-seed.nix
+++ b/modules/services/media-stack/cross-seed.nix
@@ -75,6 +75,10 @@ let
   # When VPN disabled: cross-seed is on arr-network, uses container hostname
   effectiveQbtHost = if qbt.vpn.enable then "localhost" else cfg.qbittorrentHost;
 
+  # Empty when prowlarrUrl is unset, so the assertion below is what reports a
+  # missing URL rather than a "cannot coerce null to a string" from here.
+  prowlarrBase = lib.optionalString (cfg.prowlarrUrl != null) cfg.prowlarrUrl;
+
   # Build Torznab URL list for config.
   # This used the reverse proxy hostname, on the stated grounds that it worked
   # under both VPN and non-VPN configurations. It did not: under VPN this
@@ -82,7 +86,7 @@ let
   # the prowlarrUrl option.
   torznabUrlList = lib.concatMapStringsSep ",\n    " (
     id:
-    ''"${cfg.prowlarrUrl}/${toString id}/api?apikey=${
+    ''"${prowlarrBase}/${toString id}/api?apikey=${
       config.sops.placeholder."media-stack/prowlarr/api"
     }"''
   ) cfg.torznabIndexerIds;
@@ -184,9 +188,6 @@ let
   '';
 in
 {
-  # Reads config.cg.fleet, so it declares it - see modules/nixos/fleet.nix.
-  imports = [ ../../nixos/fleet.nix ];
-
   options.cg.service.cross-seed = {
     enable = lib.mkEnableOption "cross-seed for private tracker ratio building";
 
@@ -197,9 +198,8 @@ in
     };
 
     prowlarrUrl = lib.mkOption {
-      type = lib.types.str;
-      default = "http://${config.cg.fleet.hosts.${config.cg.fleet.roles.gateway}.address}:9696";
-      defaultText = lib.literalExpression "the gateway host's address on port 9696";
+      type = lib.types.nullOr lib.types.str;
+      default = null;
       example = "http://prowlarr:9696";
       description = ''
         Base URL for Prowlarr's Torznab feeds. An address, not a hostname, and
@@ -213,6 +213,11 @@ in
         Reaching
         Prowlarr by address avoids resolution entirely, and Gluetun's
         FIREWALL_OUTBOUND_SUBNETS already permits the LAN.
+
+        Required, and therefore no default: the obvious default would name the
+        gateway host of whichever fleet this module happens to be in, which is
+        exactly the coupling a reusable module must not carry. The host sets
+        it, typically to the gateway's address taken from `config.cg.fleet`.
       '';
     };
 
@@ -374,6 +379,14 @@ in
       {
         assertion = qbt.enable;
         message = "cross-seed requires qbittorrent to be enabled";
+      }
+      {
+        assertion = cfg.prowlarrUrl != null;
+        message = ''
+          cross-seed requires a prowlarrUrl - the Prowlarr host it reads
+          Torznab feeds from. Set cg.service.cross-seed.prowlarrUrl (an
+          address, not a hostname; see the option description).
+        '';
       }
       {
         assertion = cfg.torznabIndexerIds != [ ];


### PR DESCRIPTION
Implements item 6 of `docs/plans/structural-cleanup.md`: no module keeps a default that only makes sense inside this fleet.

- **adguard-home** — `fleet.roles.gateway`/`.storage` are looked up defensively, and two assertions name the missing role instead of crashing as `attribute 'gateway' missing`.
- **cross-seed** — `prowlarrUrl` loses its gateway-host default (`nullOr str`, required via assertion); `hosts/homelab02` supplies it from `fleet`.
- **immich** — the hardcoded `DB_PASSWORD=changeme-use-sops-for-real-deployment` placeholder is gone; the `.env` is now a sops template over `immich/db-password`.
- **digital-garden** — asserts `cg.service.reverse-proxy.enable` is on; the check declares that toggle inline rather than importing the whole reverse-proxy module.

Also adds **item 8** to the plan (AdGuard rewrites following `cg.publish`), promoting the follow-up that fell out of item 6 so it does not get missed.

Validation: `nix fmt -- --ci` clean; `homelab01`/`homelab02`/`xps15` all evaluate; `digital-garden` VM test, `publish`, and `secrets` checks pass; each new assertion was verified to fire on its failing case.