### PR TITLE
fix(digital-garden): make the dates ledger rename-stable

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -1038,5 +1038,49 @@
             "fn:3 has an empty margin above it and must sit on its citation: "
             f"note={notes['fn:3']} cite={cites['fn:3']}"
         )
+
+    with subtest("a renamed note keeps its publication date"):
+        # The ledger is keyed by the note's filename, so a rename used to
+        # look like a brand-new note: the old key disappears, the new key
+        # has no entry, and `published` silently reset to today. That is the
+        # defect this pins, and it is pinned by giving the note a date that
+        # is NOT today first.
+        #
+        # The first build dated every note today, so a naive "rename and
+        # assert the date is unchanged" would pass with or without the fix -
+        # a reset lands on today and today is what the note already had. The
+        # ledger is therefore seeded with a past date before the rename, and
+        # the assertion is that the renamed note still carries it.
+        machine.succeed(
+            "python3 - <<'PY'\n"
+            "import json\n"
+            'ledger = json.load(open("/var/lib/digital-garden/dates.json"))\n'
+            'assert "on-gates" in ledger, ledger\n'
+            'ledger["on-gates"]["published"] = "2001-01-01"\n'
+            'json.dump(ledger, open("/var/lib/digital-garden/dates.json", "w"))\n'
+            "PY"
+        )
+
+        # Rename the note in the vault. The rename changes both gates (the
+        # file list and the content tree), so the builder runs the filter
+        # rather than skipping. The watcher may also fire a build a few
+        # seconds later; it runs the same filter over the same state, so the
+        # result is the same either way.
+        machine.succeed(
+            "mv /var/lib/digital-garden/vault/essays/on-gates.md "
+            "/var/lib/digital-garden/vault/essays/on-gates-renamed.md"
+        )
+        machine.succeed("systemctl start digital-garden-build.service")
+
+        # The renamed note keeps the seeded date, in the ledger and on the
+        # page a reader sees.
+        ledger = json.loads(machine.succeed("cat /var/lib/digital-garden/dates.json"))
+        assert "on-gates-renamed" in ledger, ledger.keys()
+        assert ledger["on-gates-renamed"]["published"] == "2001-01-01", (
+            f"renamed note was re-dated: {ledger['on-gates-renamed']}"
+        )
+        assert "on-gates" not in ledger, "the old key lingered after the rename"
+        page = served("/on-gates-renamed")
+        assert 'datetime="2001-01-01"' in page, page[-400:]
   '';
 }

--- a/modules/services/digital-garden/publish-filter.py
+++ b/modules/services/digital-garden/publish-filter.py
@@ -312,6 +312,41 @@ def coalesce_aliases(front):
     return out
 
 
+def carry_renames(ledger, published):
+    """Move a ledger entry across a rename, keyed by content hash.
+
+    The ledger is keyed by the note's filename (see `update_ledger`), so a
+    renamed note looks like a new one: its entry is never found, and
+    `published` silently resets to today. Detect the rename the way git
+    does, from the hash the ledger already stores: where exactly one ledger
+    key has disappeared and exactly one published key is new, and the two
+    share a content hash, they are the same note and the entry moves.
+
+    The 1:1 restriction is the whole of the safety argument. Two notes with
+    identical content are rare but possible — a stub duplicated as a
+    starting point — and a wrong carry is worse than a reset date, because
+    it would silently attribute one note's history to another. Anything that
+    is not an unambiguous pair stays a new note, which is exactly what
+    happens without this function.
+    """
+    new_by_hash = {}
+    for key in set(published) - set(ledger):
+        digest = hashlib.sha256(published[key][1].encode("utf-8")).hexdigest()
+        new_by_hash.setdefault(digest, []).append(key)
+    gone_by_hash = {}
+    for key, entry in ledger.items():
+        if key in published:
+            continue
+        if isinstance(entry, dict) and "hash" in entry:
+            gone_by_hash.setdefault(entry["hash"], []).append(key)
+    for digest, keys in new_by_hash.items():
+        if len(keys) != 1:
+            continue
+        gone = gone_by_hash.get(digest, [])
+        if len(gone) == 1:
+            ledger[keys[0]] = ledger.pop(gone[0])
+
+
 def update_ledger(ledger, key, text, today):
     """First sighting sets `published`; a changed note bumps `modified`.
 
@@ -322,6 +357,8 @@ def update_ledger(ledger, key, text, today):
     Keyed by the note's filename, deliberately not by its URL. The two are
     nearly the same string, and conflating them would mean that any future
     change to how a URL is derived silently re-dates every note on the site.
+    A rename moves the entry before this runs (see `carry_renames`), so the
+    changed key does not re-date the note.
     """
     digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
     entry = ledger.get(key)
@@ -478,6 +515,13 @@ def main(argv):
             ledger = {}
     except (OSError, ValueError):
         ledger = {}
+
+    # A note that was renamed has a new key and no entry, which would re-date
+    # it. Carry the entry across before the write loop looks anything up, so
+    # a rename preserves `published` (and, from item 14 on, the revision
+    # counter). Runs against the filtered `published` set, so a note that was
+    # dropped as unparseable is not mistaken for a rename.
+    carry_renames(ledger, published)
 
     today = date.today().isoformat()
     tmp = staging.with_name(staging.name + ".new")


### PR DESCRIPTION
## What

Item 13 of the digital-garden plan. The dates ledger in `publish-filter.py` is keyed on the note's filename, so renaming a note changes its key, finds no entry, and silently resets its `published` date to today.

## How

Rename detection, the way git does it, from the content hash the ledger already stores. After the publish set is decided, collect the ledger keys that disappeared and the keys that are new; where exactly one disappeared key and exactly one new key share a content hash, they are the same note and the entry is carried to the new key.

The 1:1 restriction is the whole safety argument: two notes with identical content (a stub duplicated as a starting point) must not let a wrong carry attribute one note's history to another. Anything not an unambiguous pair stays a new note — exactly today's behaviour.

This also makes item 14's revision counter (which will live in the same ledger) survive renames.

## Verification

- `carry_renames` unit-style local runs: plain rename preserves `published`; identical-content duplicate does not steal history; rename+edit falls back to new-note (safe default).
- VM check grew one subtest: seed the ledger with a past date, rename a note, rebuild, assert the date survived in both the ledger and the served dateline. Passes.
- `nix build .#checks.x86_64-linux.digital-garden` and `nix flake check` both green.
- Rebased onto master (which includes the repo-wide formatting pass) with no conflicts; `nix fmt -- --ci` clean.