### PR TITLE
chore(opencode): pin the harness formatter to the CI gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,19 @@ checkout.
 6. Run the narrowest useful checks, then run the full relevant check when
    practical. Report commands, results, and any checks that could not run.
 
+## Formatting
+
+The opencode harness runs a formatter on a file after every write or edit
+(`nixfmt` for `.nix`, `black` for Python, `markdownlint-cli2` for Markdown).
+Treat that output as final:
+
+- Do not re-read a file and re-edit it purely to adjust formatting, and do not
+  run `nixfmt`/`nix fmt` yourself to polish an edit - the harness already
+  formatted it.
+- If `nix fmt -- --ci` fails, run `nix fmt` once, accept the resulting diff,
+  and stop. If it still disagrees after one pass, report the mismatch instead
+  of retrying.
+
 ## Validation
 
 Useful checks include:

--- a/configs/opencode/opencode.jsonc
+++ b/configs/opencode/opencode.jsonc
@@ -93,6 +93,18 @@
     "markdownlint-cli2": {
       "command": ["markdownlint-cli2", "--fix", "$FILE"],
       "extensions": [".md"]
+    },
+
+    // The CI gate (`nix fmt -- --ci`, ci.yml) resolves the flake's `formatter`
+    // output - nixfmt-tree built from the nixpkgs pinned in flake.lock. The
+    // built-in nixfmt would use whatever is on PATH (host-installed from the
+    // unstable channel), which can drift from the gate. Delegate to the flake's
+    // own formatter so auto-format output is byte-identical to what CI accepts,
+    // even across flake.lock bumps: `nix fmt -- $FILE` hands the single file to
+    // nixfmt-tree, which resolves its tree root from the enclosing git repo.
+    "nixfmt": {
+      "command": ["nix", "fmt", "--", "$FILE"],
+      "extensions": [".nix"]
     }
   },
 


### PR DESCRIPTION
## Problem

AI agents in the opencode harness occasionally loop on formatting. The harness
auto-formats `.nix` files after every edit using its built-in `nixfmt`, which
runs the **PATH binary** (host-installed from the unstable channel). The CI gate
(`nix fmt -- --ci`, ci.yml) resolves the flake's `formatter` output -
`nixfmt-tree` built from the nixpkgs **pinned in flake.lock**. When those two
versions disagree, the agent's formatting passes locally, the gate rejects it,
and the agent keeps re-formatting forever.

## Change

1. **`configs/opencode/opencode.jsonc`** - override the harness `nixfmt`
   formatter to `nix fmt -- $FILE`, i.e. the flake's own `formatter` output.
   Harness auto-format output is now byte-identical to what the gate accepts by
   construction, and stays aligned across `flake.lock` bumps (verified on the
   real repo: single-file format, exit 0, handles absolute paths and untracked
   files).

2. **`AGENTS.md`** - new `## Formatting` section telling agents to treat
   harness auto-format output as final and to run `nix fmt` at most once when
   the gate fails, reporting mismatches instead of looping.

## Verification

- `nix fmt -- <abs-path>` single-file formatting works on the real repo.
- JSONC validated.
- `markdownlint-cli2 AGENTS.md` - no new issues (one pre-existing MD013 at
  line 83, untouched).
- No `.nix` files changed, so `nix fmt -- --ci` and host builds are unaffected.

## Notes

- Takes effect on the host after the next home-manager switch re-sources
  `~/.config/opencode/opencode.jsonc`.
- `nix fmt` per write adds ~3s one-time flake eval overhead (background).