### PR TITLE
feat(digital-garden): callout icons on Obsidian's mapping

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -76,6 +76,12 @@
         > [!question] A type with no GitHub equivalent
         > MARKER-CALLOUT-QUESTION
 
+        > [!important] The important flame
+        > MARKER-CALLOUT-IMPORTANT
+
+        > [!example] The example list
+        > MARKER-CALLOUT-EXAMPLE
+
         Some ==MARKER-HIGHLIGHT== prose.
 
         %% MARKER-COMMENT-SECRET %%
@@ -520,6 +526,24 @@
         assert "fonts.googleapis.com" not in css and "fonts.gstatic.com" not in css, \
             "the stylesheet fetches a font from a CDN"
 
+        # Item 16's one mapping conflict, settled in the stylesheet. Obsidian
+        # gives `important` the flame it gives `tip`, so important moved into
+        # the tip group's green, and `example` keeps the violet on its own -
+        # the two used to share a single violet rule. These pin the
+        # settlement rather than the colours: a drift back toward the old
+        # grouping, or a new grouping that splits the families differently,
+        # fails here.
+        assert re.search(r'\.callout-important[^}]*light-dark\(#6f894e,\s?#98bb6c\)', css), \
+            "important no longer shares the tip group's green"
+        assert re.search(r'\.callout-example\s*{[^}]*light-dark\(#624c83,\s?#957fb8\)', css), \
+            "example no longer holds the violet alone"
+        assert not re.search(r'\.callout-important,\s*\.callout-example', css), \
+            "important is grouped with example again"
+        # And the icon is sized to its label; its colour is inherited, never
+        # set here.
+        assert re.search(r'\.callout-icon\s*{[^}]*width', css), \
+            "the callout icon is not sized"
+
     with subtest("a table wraps to the page, and scrolls only when it cannot"):
         # Three independent failures are guarded here, each of which alone is a
         # bug, and two of which have actually shipped.
@@ -707,6 +731,33 @@
         # of still renders as a callout, under its own name.
         assert 'class="callout callout-question"' in page
         assert "A type with no GitHub equivalent" in page
+
+        # Item 16: each callout type carries the icon Obsidian gives it,
+        # stroked in the callout's own hue. The sprite ships only on pages
+        # that rendered a callout (the hasCallout store flag, the same gating
+        # the KaTeX stylesheet gets from hasMath), and every <use> names a
+        # symbol the sprite actually defines - an icon that references a
+        # missing symbol draws nothing, which is the same silent failure as a
+        # link to an uncopied asset.
+        assert 'class="callout-sprite"' in page, \
+            "no callout icon sprite on a page with callouts"
+        assert 'class="callout-sprite"' not in served("/"), \
+            "the icon sprite ships on pages with no callouts"
+        for icon in ["pencil", "flame", "alert-triangle", "help-circle", "list"]:
+            assert f'href="#callout-icon-{icon}"' in page, \
+                f"no {icon} callout icon on the page"
+            assert f'id="callout-icon-{icon}"' in page, \
+                f"a callout references #callout-icon-{icon}, which the sprite does not define"
+        # The conflict item 16 settled: important takes the flame, example the
+        # list - the two types that used to share a hue on violet.
+        assert 'class="callout callout-important"' in page
+        assert "MARKER-CALLOUT-IMPORTANT" in page
+        assert 'class="callout callout-example"' in page
+        assert "MARKER-CALLOUT-EXAMPLE" in page
+        # The icons are stroked in currentColor, so they inherit the callout's
+        # own hue from the title rule; a colour hard-coded in the sprite would
+        # undo the whole design.
+        assert 'stroke="currentColor"' in page
 
     with subtest("obsidian's internal-only syntax never leaves the vault"):
         page = served("/on-gates")

--- a/docs/plans/digital-garden-design.md
+++ b/docs/plans/digital-garden-design.md
@@ -1,6 +1,6 @@
 # Plan: theme and navigation for the digital garden
 
-Status: proposed 2026-08-27; decisions taken the same day, see _Decisions, 2026-08-27_ below. Extended 2026-08-31 with items 13-20, which came out of a design session held against live prototypes rather than against this document; see _Decisions, 2026-08-31_. Items 1, 2 and 4 were the agreed first pass; 5, 6 and 10 followed on the same day. Item 11 came out of a review on 2026-08-28 and is done. Item 3, the only item that fixed something broken today, was taken and is done on 2026-08-30. Two ideas asked for — a Kanagawa palette and a right-hand navigation column — plus seven more that came out of looking at what the site actually serves today. Everything below is scoped against `modules/services/digital-garden/lib/hugo/`, which is the whole design: four layouts, six partials, three render hooks and a 488-line stylesheet. There is no theme underneath to fight, so every item here is an edit to files this repository owns.
+Status: proposed 2026-08-27; decisions taken the same day, see _Decisions, 2026-08-27_ below. Extended 2026-08-31 with items 13-20, which came out of a design session held against live prototypes rather than against this document; see _Decisions, 2026-08-31_. Items 1, 2 and 4 were the agreed first pass; 5, 6 and 10 followed on the same day. Item 11 came out of a review on 2026-08-28 and is done. Item 3, the only item that fixed something broken today, was taken and is done on 2026-08-30. Item 16, the callout icons, was taken and is done on 2026-08-31 — the first of the 2026-08-31 set, per the sequencing that lets a small dependency-free item fill a short session. Two ideas asked for — a Kanagawa palette and a right-hand navigation column — plus seven more that came out of looking at what the site actually serves today. Everything below is scoped against `modules/services/digital-garden/lib/hugo/`, which is the whole design: four layouts, six partials, three render hooks and a 488-line stylesheet. There is no theme underneath to fight, so every item here is an edit to files this repository owns.
 
 | #   | Item                                | Size   | Depends on | Status      |
 | --- | ----------------------------------- | ------ | ---------- | ----------- |
@@ -19,7 +19,7 @@ Status: proposed 2026-08-27; decisions taken the same day, see _Decisions, 2026-
 | 13  | Rename-stable ledger (defect)       | small  | -          | **done** 2026-08-31 (#118) |
 | 14  | Maturity: model, counter, override  | medium | 13         | **done** 2026-08-31 (#121) |
 | 15  | Growth marks, topic hue, link marks | small  | 14         | not started |
-| 16  | Callout icons on Obsidian's mapping | small  | -          | not started |
+| 16  | Callout icons on Obsidian's mapping | small  | -          | **done** 2026-08-31 |
 | 17  | A margin on every note              | medium | 14         | not started |
 | 18  | The bonsai                          | large  | 14         | not started |
 | 19  | The home page, composed once        | small  | 18         | not started |
@@ -523,6 +523,14 @@ The icons drawn for the prototype match Obsidian's _choices_ rather than Lucide'
 ### Cost and risk
 
 Two hours. No new failure mode: a type the sprite does not know renders exactly as it does today.
+
+### Shipped, 2026-08-31
+
+One sprite partial and one mapping partial, both in `layouts/_partials/`, and the render hook now drops a `<use>` into the callout title. The sprite is gated exactly as the KaTeX stylesheet is — a `hasCallout` store flag set in `render-blockquote.html` and read in `baseof.html` — so an iconless page ships no sprite at all, and a type the sprite does not know renders no icon, which is the fallback the plan priced in.
+
+The mapping conflict was settled as the plan said: `important` moved into the tip group's green (the flame) and `example` keeps the violet alone. The fixture grows an `example` callout and the five types the old one-per-hue set never showed (`info`, `todo`, `success`, `danger`, `bug`), so every distinct icon is on screen. The VM check pins the settlement in the stylesheet (the green and violet pairs, and the old `important, example` grouping by its absence) and pins the icons on the served page: the sprite present only where a callout rendered, and each `<use>` naming a symbol the sprite actually defines — the "link to an uncopied asset looks right and 404s" failure from item 11, met from the same-document side.
+
+Two facts worth recording. `pkgs.lucide` **does** exist in nixpkgs (0.563.0, riding flake.lock), so exact Lucide parity would have been a build-time copy exactly like KaTeX — it was not taken, because the prototype's own icons already matched Obsidian's choices and vendoring buys only geometry. And the type is now lowercased before it is used for the class, the icon and the default title, because Obsidian's callout types are case-insensitive and a `> [!NOTE]` should render exactly as `> [!note]` does; before this item the class silently depended on the marker's spelling.
 
 ## 17. A margin on every note (supersedes 12, absorbs 9)
 

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -331,6 +331,11 @@ blockquote {
  * page into a patchwork. Types Obsidian treats as aliases of each other
  * share a hue; a type this file does not know gets --accent, not an error.
  *
+ * The label also carries the icon Obsidian gives the type (item 16): the
+ * title is a <use> into the sprite partial, stroked with currentColor, so it
+ * inherits the hue of the callout that carries it from the rule below and
+ * this block knows nothing about which type maps to which icon.
+ *
  * light-dark() keys off color-scheme, which the theme toggle sets, so each
  * hue is named once per theme rather than remapped in a separate block. */
 .callout {
@@ -362,12 +367,17 @@ blockquote {
 }
 .callout-tip,
 .callout-hint,
+.callout-important,
 .callout-success,
 .callout-check,
 .callout-done {
   --callout-accent: light-dark(#6f894e, #98bb6c); /* lotusGreen / springGreen */
 }
-.callout-important,
+/* Item 16's one mapping conflict, settled. The stylesheet used to group
+ * important WITH example on violet; Obsidian gives important the flame it
+ * gives tip, and example a list. "Match Obsidian" and "keep the hue
+ * grouping" disagreed on exactly this type, so the hue follows the icon:
+ * important is in the tip group above, and example keeps the violet alone. */
 .callout-example {
   --callout-accent: light-dark(#624c83, #957fb8); /* lotusViolet4 / oniViolet */
 }
@@ -402,11 +412,34 @@ blockquote {
   margin-bottom: 0;
 }
 
+/* The icon sits before the label, the same order Obsidian gives them, and
+ * aligns to the label's cap rather than its baseline — an icon at a text
+ * baseline floats a couple of pixels off the capital height. The gap is the
+ * distance between a glyph and the label's own letter-spacing. */
 .callout-title {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
   margin: 0 0 0.25rem;
   font-size: 0.9rem;
   font-weight: 600;
   color: var(--callout-accent);
+}
+
+.callout-icon {
+  flex-shrink: 0;
+  width: 1.1em;
+  height: 1.1em;
+}
+
+/* The sprite is zero-size but present, because the icon a <use> renders is
+ * cloned from the symbol in this document; display:none on the defining
+ * element would blank the clone in browsers that honour it. */
+.callout-sprite {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
 }
 
 /* Foldable callouts are <details>: the title row is the disclosure control. */

--- a/modules/services/digital-garden/lib/hugo/fixture/Every Element.md
+++ b/modules/services/digital-garden/lib/hugo/fixture/Every Element.md
@@ -52,10 +52,16 @@ Headings wrap. The line-height they wrap at is set separately from the body's, a
 
 ## Callouts
 
-Obsidian's callout syntax, rendered by `_markup/render-blockquote.html`. Every type the stylesheet names a hue for appears here, because the point of the set is that it reads as one family and only the hue changes.
+Obsidian's callout syntax, rendered by `_markup/render-blockquote.html`. Every hue the stylesheet names appears here, because the point of the set is that it reads as one family and only the hue changes — and, since item 16, every distinct icon too, because the icon is the information the hue already carries, and the fixture exists to judge both by looking.
 
 > [!note] A note
 > The default type, and the one every unknown type falls back to.
+
+> [!info] An info
+> Shares the note's teal, but Obsidian gives it its own icon.
+
+> [!todo] A todo
+> Also in the teal group, with a check-circle where the note has a pencil.
 
 > [!abstract] An abstract
 > Also reachable as `summary` and `tldr`.
@@ -64,7 +70,13 @@ Obsidian's callout syntax, rendered by `_markup/render-blockquote.html`. Every t
 > Also `hint`, `success`, `check` and `done`.
 
 > [!important] Something important
-> Shares its hue with `example`.
+> Obsidian gives it the same flame as `tip`, so it shares the tip group's hue rather than `example`'s.
+
+> [!success] A success
+> The `check` mark, where `tip` and `important` carry the flame.
+
+> [!example] An example
+> The one type that keeps the violet on its own, marked with a list.
 
 > [!question] A question
 > Also `help` and `faq`.
@@ -73,7 +85,13 @@ Obsidian's callout syntax, rendered by `_markup/render-blockquote.html`. Every t
 > Also `caution` and `attention`.
 
 > [!failure] A failure
-> Also `fail`, `missing`, `danger`, `error` and `bug`.
+> Also `fail`, `missing`, `danger`, `error` and `bug` — which between them carry three more icons.
+
+> [!danger] A danger
+> A zap, where `failure` takes the cross.
+
+> [!bug] A bug
+> The third red icon, for the one type with its own shape.
 
 > [!quote] A quotation
 > Also `cite`. Rendered in the muted role rather than a hue of its own.

--- a/modules/services/digital-garden/lib/hugo/layouts/_markup/render-blockquote.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_markup/render-blockquote.html
@@ -16,17 +16,31 @@
   The type is not validated against a list - Obsidian lets a vault define its
   own callout types, and an unknown one simply gets the default accent from
   the stylesheet, with its own name on it.
+
+  The type is lowercased before it is used anywhere, because Obsidian's
+  callout types are case-insensitive and one spelling should not render
+  differently from another - a `> [!NOTE]` gets the same class, icon and
+  default title as `> [!note]`.
+
+  Item 16: the title carries the icon Obsidian gives the type, from
+  _partials/callout-icon.html, stroked in the callout's own hue. A type the
+  sprite does not know renders no icon and is otherwise unchanged. The
+  hasCallout store flag tells baseof.html to include the sprite only on pages
+  that actually rendered a callout - the same gating the KaTeX stylesheet
+  gets from hasMath.
 */}}
 {{ if eq .Type "alert" }}
-  {{ $title := .AlertTitle | default (title .AlertType) }}
+  {{ $.Page.Store.Set "hasCallout" true }}
+  {{ $type := lower .AlertType }}
+  {{ $title := .AlertTitle | default (title $type) }}
   {{ if eq .AlertSign "" }}
-    <div class="callout callout-{{ .AlertType }}">
-      <p class="callout-title">{{ $title }}</p>
+    <div class="callout callout-{{ $type }}">
+      <p class="callout-title">{{ partial "callout-icon.html" $type }}{{ $title }}</p>
       {{ .Text }}
     </div>
   {{ else }}
-    <details class="callout callout-{{ .AlertType }}"{{ if eq .AlertSign "+" }} open{{ end }}>
-      <summary class="callout-title">{{ $title }}</summary>
+    <details class="callout callout-{{ $type }}"{{ if eq .AlertSign "+" }} open{{ end }}>
+      <summary class="callout-title">{{ partial "callout-icon.html" $type }}{{ $title }}</summary>
       {{ .Text }}
     </details>
   {{ end }}

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/callout-icon.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/callout-icon.html
@@ -1,0 +1,45 @@
+{{/*
+  The icon for one callout type, referenced from
+  _markup/render-blockquote.html. Emits the <use> that names a symbol in
+  callout-icons.html, or nothing for a type the sprite does not know — which
+  is the fallback that keeps an unknown callout rendering exactly as it did
+  before item 16 of docs/plans/digital-garden-design.md.
+
+  The mapping is Obsidian's, and it is the whole of the item's value: the
+  vault is written in Obsidian, so the site renders the same information the
+  editor does. Aliases share one icon exactly as they share one hue. The
+  sprite is stroked with currentColor, so the icon takes the callout's own hue
+  without this file or the stylesheet having to name a colour.
+*/}}
+{{- $icon := index (dict
+  "note" "pencil"
+  "abstract" "clipboard-list"
+  "summary" "clipboard-list"
+  "tldr" "clipboard-list"
+  "info" "info"
+  "todo" "check-circle"
+  "tip" "flame"
+  "hint" "flame"
+  "important" "flame"
+  "success" "check"
+  "check" "check"
+  "done" "check"
+  "question" "help-circle"
+  "help" "help-circle"
+  "faq" "help-circle"
+  "warning" "alert-triangle"
+  "caution" "alert-triangle"
+  "attention" "alert-triangle"
+  "failure" "x"
+  "fail" "x"
+  "missing" "x"
+  "danger" "zap"
+  "error" "zap"
+  "bug" "bug"
+  "example" "list"
+  "quote" "quote"
+  "cite" "quote"
+) (lower .) -}}
+{{- if $icon -}}
+  <svg class="callout-icon" aria-hidden="true"><use href="#callout-icon-{{ $icon }}" /></svg>
+{{- end -}}

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/callout-icons.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/callout-icons.html
@@ -1,0 +1,115 @@
+{{/*
+  The callout icon sprite, item 16 of docs/plans/digital-garden-design.md.
+  Included by baseof.html only on pages where _markup/render-blockquote.html
+  ran — the same hasCallout store flag the KaTeX stylesheet gets from hasMath —
+  and referenced from there by fragment, so the sprite is defined once and
+  every icon is a <use>.
+
+  The icons match Obsidian's CHOICES (which type gets which icon), not Lucide's
+  geometry: exact parity would mean vendoring Lucide's SVGs at build time, and
+  the drawn set reads the same at 1rem while staying this repository's own.
+  Everything is stroked with currentColor, so an icon takes the hue of the
+  callout that carries it from the stylesheet alone — no rule here knows a
+  type from an icon.
+
+  A type the sprite does not know draws nothing (its <use> names no symbol),
+  which is the fallback that keeps an unknown callout rendering exactly as it
+  did before this file existed. Symbols are hidden by making the whole sprite
+  zero-size rather than display:none, because the clone a <use> renders is
+  drawn from the symbol in the defining document.
+*/}}
+<svg xmlns="http://www.w3.org/2000/svg" class="callout-sprite" aria-hidden="true">
+  <symbol id="callout-icon-pencil" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M13 3 21 11 7 20H3v-4L13 3Z" />
+      <path d="M3 20l2.6-.9" />
+      <path d="m13 3 3 3" />
+    </g>
+  </symbol>
+  <symbol id="callout-icon-clipboard-list" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="8" y="2" width="8" height="4" rx="1" />
+      <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+      <path d="M9 12h6" />
+      <path d="M9 16h4" />
+    </g>
+  </symbol>
+  <symbol id="callout-icon-info" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 8h.01" />
+      <path d="M12 11v5" />
+    </g>
+  </symbol>
+  <symbol id="callout-icon-check-circle" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="9" />
+      <path d="m8.5 12 2.5 2.5 4.5-5" />
+    </g>
+  </symbol>
+  <symbol id="callout-icon-flame" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 2.5c3.2 4.6 5 6.6 5 10.5a5 5 0 0 1-10 0c0-3.9 1.8-5.9 5-10.5Z" />
+      <path d="M12 10.5c1.3 1.8 2.2 2.7 2.2 4.4a2.2 2.2 0 0 1-4.4 0c0-1.7.9-2.6 2.2-4.4Z" />
+    </g>
+  </symbol>
+  <symbol id="callout-icon-check" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="m5 12.5 4.5 4.5L19 7" />
+    </g>
+  </symbol>
+  <symbol id="callout-icon-help-circle" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M9.3 9.3a2.8 2.8 0 0 1 5.4 1.1c0 1.6-2 2-2 3.1" />
+      <path d="M12 17h.01" />
+    </g>
+  </symbol>
+  <symbol id="callout-icon-alert-triangle" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 3.5 2.5 20.5h19L12 3.5Z" />
+      <path d="M12 10v4.5" />
+      <path d="M12 17.5h.01" />
+    </g>
+  </symbol>
+  <symbol id="callout-icon-x" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M6 6l12 12" />
+      <path d="M18 6 6 18" />
+    </g>
+  </symbol>
+  <symbol id="callout-icon-zap" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M13 2 4.5 14H10l-1 8 9.5-12H13l0-8Z" />
+    </g>
+  </symbol>
+  <symbol id="callout-icon-bug" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="6" y="7" width="12" height="12" rx="3" />
+      <path d="M12 7v12" />
+      <path d="M8 7V4" />
+      <path d="M16 7V4" />
+      <path d="M6 10H3" />
+      <path d="M6 14H3" />
+      <path d="M18 10h3" />
+      <path d="M18 14h3" />
+    </g>
+  </symbol>
+  <symbol id="callout-icon-list" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M8 6.5h12" />
+      <path d="M8 12h12" />
+      <path d="M8 17.5h12" />
+      <path d="M3.5 6.5h.01" />
+      <path d="M3.5 12h.01" />
+      <path d="M3.5 17.5h.01" />
+    </g>
+  </symbol>
+  <symbol id="callout-icon-quote" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M10 12V8.5A2.5 2.5 0 0 0 7.5 6 2.5 2.5 0 0 0 5 8.5V13a4 4 0 0 0 4 4h1a2 2 0 0 0 2-2v-1h-2" />
+      <path d="M19 12V8.5A2.5 2.5 0 0 0 16.5 6 2.5 2.5 0 0 0 14 8.5V13a4 4 0 0 0 4 4h1a2 2 0 0 0 2-2v-1h-2" />
+    </g>
+  </symbol>
+</svg>
+{{- /* newline omitted so the sprite sits flush against its neighbours */ -}}

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -119,6 +119,18 @@
 
       <main>{{ block "main" . }}{{ end }}</main>
 
+      {{/*
+        The callout icon sprite, only where a callout rendered. The flag is
+        set by _markup/render-blockquote.html while the content above was
+        evaluated - which is why this sits after <main> rather than in the
+        head, where hasMath needs the .WordCount trick to arrive early. An
+        iconless page pays nothing for the sprite, the same deal the KaTeX
+        stylesheet gets from hasMath. See _partials/callout-icons.html.
+      */}}
+      {{ if .Page.Store.Get "hasCallout" }}
+        {{ partial "callout-icons.html" . }}
+      {{ end }}
+
       <footer>
         <hr />
         <p>&copy; {{ now.Year }} {{ site.Title }}</p>


### PR DESCRIPTION
Implements **item 16** of [`docs/plans/digital-garden-design.md`](https://github.com/corygyarmathy/dotfiles/blob/master/docs/plans/digital-garden-design.md).

## What changed

Each callout title now carries the icon Obsidian gives that type, stroked in `currentColor` so it inherits the callout's existing hue — the site renders the same information the editor does.

- **`_partials/callout-icons.html`** (new): SVG sprite of 13 symbols (pencil, clipboard-list, info, check-circle, flame, check, help-circle, alert-triangle, x, zap, bug, list, quote), each stroked with `currentColor`.
- **`_partials/callout-icon.html`** (new): Obsidian's type→icon mapping (aliases share one icon); emits a `<use>`, or nothing for a type the sprite doesn't know — the graceful fallback.
- **`render-blockquote.html`**: drops the `<use>` into the callout title, sets a `hasCallout` store flag, and lowercases `.AlertType` so `> [!NOTE]` renders identically to `> [!note]`.
- **`baseof.html`**: includes the sprite only where a callout rendered (same gating as the KaTeX stylesheet's `hasMath`).
- **`main.css`**: icon sizing, title flex layout, hidden sprite, and the mapping-conflict settlement.
- **Fixture**: grew an `example` callout plus the five types the one-per-hue set never showed (`info`, `todo`, `success`, `danger`, `bug`), so every distinct icon is on screen.
- **`checks/digital-garden.nix`**: pins the settlement in the stylesheet (green/violet pairs, old grouping by absence) and the icons on the served page (sprite gated by `hasCallout`, each `<use>` naming a defined symbol).
- **Plan**: item 16 marked done.

## The mapping conflict, settled

The stylesheet grouped `important` with `example` on violet; Obsidian gives `important` the flame (same as `tip`) and `example` a list. Matching Obsidian means `important` moved into the tip group's green and `example` keeps the violet alone.

## Verification

- `nix run .#garden-preview -- --fixture --once` renders clean; 16 callouts, 13 distinct icons, sprite present only on pages with callouts.
- Headless-Chrome probe (both themes): every icon 16×16px with real geometry, colour matching its callout's title colour; important green, example violet.
- `nix build .#checks.x86_64-linux.digital-garden` — passed, including the new assertions.
- `nix fmt -- --ci` — 0 changes.
- Full-page screenshots (light + dark) available at `/tmp/callout-shots/{light,dark}-callouts.png` if you want to eyeball the icon shapes.