### PR TITLE
feat(digital-garden): compute note maturity

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -127,6 +127,7 @@
         publish: true
         thesis: Prose about money is not maths.
         published: 2001-02-03
+        maturity: evergreen
         ---
 
         # On Money
@@ -1038,6 +1039,64 @@
             "fn:3 has an empty margin above it and must sit on its citation: "
             f"note={notes['fn:3']} cite={cites['fn:3']}"
         )
+
+    with subtest("every published note carries a computed maturity"):
+        # Item 14: the maturity model lives in publish-filter.py, which emits a
+        # stage and a score into every staged note's frontmatter. Nothing
+        # renders them yet - the margin that will is item 17 - so the contract
+        # to pin is the staging tree, where the filter wrote them.
+        staged = sorted(machine.succeed("ls /var/lib/digital-garden/content").split())
+        assert staged, "no staged notes to check maturity on"
+        for note in staged:
+            head = machine.succeed(f"sed -n '1,25p' /var/lib/digital-garden/content/{note}")
+            assert re.search(r"^maturity: (seedling|sapling|evergreen)$", head, re.M), (
+                f"{note} has no maturity stage:\n{head}"
+            )
+            assert re.search(r"^maturity_score: \d+(\.\d+)?$", head, re.M), (
+                f"{note} has no maturity score:\n{head}"
+            )
+
+    with subtest("a hand-written maturity wins over the computed score"):
+        # on-money is a short note with no links, sections or rewrites: its
+        # computed score is well below the sapling threshold. Its frontmatter
+        # says `maturity: evergreen`, and that hand-written stage must survive
+        # the filter unchanged - exactly as a hand-written `published:` beats
+        # the ledger. The score stays computed, so the override can be read
+        # next to what the model thinks.
+        head = machine.succeed("sed -n '1,25p' /var/lib/digital-garden/content/on-money.md")
+        assert re.search(r"^maturity: evergreen$", head, re.M), head
+        m = re.search(r"^maturity_score: ([0-9.]+)$", head, re.M)
+        assert m, "on-money lost its computed score"
+        assert float(m.group(1)) < 1.5, (
+            "on-money's score is not below the sapling threshold, so the "
+            f"evergreen override proves nothing: {m.group(1)}"
+        )
+
+    with subtest("a changed note's revision counter advances, its neighbours' do not"):
+        # The ledger counts substantial rewrites per note: editing a note's
+        # text changes its stored hash, which advances that note's `revisions`
+        # by one and nobody else's. The fixture vault has no git history, so
+        # every counter was seeded at zero on the first build.
+        ledger = json.loads(machine.succeed("cat /var/lib/digital-garden/dates.json"))
+        assert ledger["on-money"]["revisions"] == 0, ledger["on-money"]
+
+        machine.succeed(
+            "printf '\\nMARKER-REVISED-BODY\\n' >> /var/lib/digital-garden/vault/essays/on-money.md"
+        )
+        machine.succeed("systemctl start digital-garden-build.service")
+
+        # The watcher may also fire a build a few seconds later; it runs the
+        # same filter over the same state, so the counter settles at 1 either
+        # way - the second run sees the hash it recorded and bumps nothing.
+        ledger = json.loads(machine.succeed("cat /var/lib/digital-garden/dates.json"))
+        assert ledger["on-money"]["revisions"] == 1, (
+            f"on-money revisions did not advance: {ledger['on-money']}"
+        )
+        for neighbour in ["on-gates", "on boundaries", "on-sidenotes"]:
+            assert ledger[neighbour]["revisions"] == 0, (
+                f"{neighbour} revisions moved while its text did not: "
+                f"{ledger[neighbour]}"
+            )
 
     with subtest("a renamed note keeps its publication date"):
         # The ledger is keyed by the note's filename, so a rename used to

--- a/docs/plans/digital-garden-design.md
+++ b/docs/plans/digital-garden-design.md
@@ -16,7 +16,7 @@ Status: proposed 2026-08-27; decisions taken the same day, see _Decisions, 2026-
 | 10  | Polish: print, selection, motion    | small  | 2          | **done** 2026-08-27 |
 | 11  | Rendering gaps found by review      | small  | 1          | **done** 2026-08-28 |
 | 12  | The dateline in the empty margin    | small  | 4          | **superseded by 17** |
-| 13  | Rename-stable ledger (defect)       | small  | -          | not started |
+| 13  | Rename-stable ledger (defect)       | small  | -          | **done** 2026-08-31 (#118) |
 | 14  | Maturity: model, counter, override  | medium | 13         | not started |
 | 15  | Growth marks, topic hue, link marks | small  | 14         | not started |
 | 16  | Callout icons on Obsidian's mapping | small  | -          | not started |

--- a/docs/plans/digital-garden-design.md
+++ b/docs/plans/digital-garden-design.md
@@ -17,7 +17,7 @@ Status: proposed 2026-08-27; decisions taken the same day, see _Decisions, 2026-
 | 11  | Rendering gaps found by review      | small  | 1          | **done** 2026-08-28 |
 | 12  | The dateline in the empty margin    | small  | 4          | **superseded by 17** |
 | 13  | Rename-stable ledger (defect)       | small  | -          | **done** 2026-08-31 (#118) |
-| 14  | Maturity: model, counter, override  | medium | 13         | not started |
+| 14  | Maturity: model, counter, override  | medium | 13         | **done** 2026-08-31 (#121) |
 | 15  | Growth marks, topic hue, link marks | small  | 14         | not started |
 | 16  | Callout icons on Obsidian's mapping | small  | -          | not started |
 | 17  | A margin on every note              | medium | 14         | not started |

--- a/modules/services/digital-garden/digital-garden.nix
+++ b/modules/services/digital-garden/digital-garden.nix
@@ -62,7 +62,10 @@
 # The filter also FLATTENS published notes to the root, so a URL is /some-essay/
 # and stays that way when the vault is reorganised, and derives `published:`
 # dates from a ledger at ${stateDir}/dates.json rather than asking for them to
-# be written by hand. Both are explained in publish-filter.py.
+# be written by hand. The same ledger counts each note's substantial rewrites
+# (`revisions`, seeded from git history when the vault is a repository) and the
+# filter turns that into a computed `maturity:` stage. Both are explained in
+# publish-filter.py.
 #
 # Secrets required, depending on `source` (which file they live in is decided
 # by cg.sops-nix; see secrets/README.md):
@@ -151,12 +154,26 @@ let
           ''
             export GIT_SSH_COMMAND="ssh -i ${stateDir}/deploy-key -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
             if [ -d "${vaultDir}/.git" ]; then
-              git -C "${vaultDir}" fetch --depth 1 origin "${cfg.branch}"
+              # A plain fetch on a shallow clone stays shallow (the history the
+              # revision counter needs is never fetched), and --unshallow
+              # errors on a complete repo - so deepen only when shallow. That
+              # is a one-time transition: clones made before this change are
+              # depth 1, and every clone after it is full.
+              if [ "$(git -C "${vaultDir}" rev-parse --is-shallow-repository)" = "true" ]; then
+                git -C "${vaultDir}" fetch --unshallow origin "${cfg.branch}"
+              else
+                git -C "${vaultDir}" fetch origin "${cfg.branch}"
+              fi
               git -C "${vaultDir}" reset --hard "origin/${cfg.branch}"
               git -C "${vaultDir}" clean -fdx
             else
               rm -rf "${vaultDir}"
-              git clone --depth 1 --branch "${cfg.branch}" "${cfg.vaultRepo}" "${vaultDir}"
+              # Full history, not depth 1. The vault is a small notes repo, and
+              # publish-filter.py seeds each note's revision counter from
+              # `git log --follow` - a depth-1 clone has exactly one commit to
+              # count, so the counter would be worthless wherever this source
+              # is used.
+              git clone --branch "${cfg.branch}" "${cfg.vaultRepo}" "${vaultDir}"
             fi
           ''
         else

--- a/modules/services/digital-garden/lib/preview.nix
+++ b/modules/services/digital-garden/lib/preview.nix
@@ -49,6 +49,10 @@ pkgs.writeShellApplication {
     pkgs.caddy
     pkgs.inotify-tools
     pkgs.coreutils
+    # For publish-filter.py's revision counter: against a git vault it seeds
+    # each new note's count from `git log --follow`, and the preview runs the
+    # same filter as the service.
+    pkgs.git
   ];
   text = ''
     vault=''${GARDEN_VAULT:-${defaultVault}}

--- a/modules/services/digital-garden/publish-filter.py
+++ b/modules/services/digital-garden/publish-filter.py
@@ -70,6 +70,19 @@ generator to render. Frontmatter written by hand always wins, so the ledger is a
 not an authority — which also means losing the ledger costs you nothing that
 matters.
 
+Maturity is derived the same way. The ledger also counts substantial rewrites
+(`revisions`), seeded from the vault's git history the first time a note is
+seen (`git log --follow`, counting commits whose diff to the note exceeded
+fifteen lines) and bumped whenever the note's hash changes; where there is no
+repository, the counter simply starts at zero. Each note is then given a
+`maturity_score` — a weighted sum of length, backlinks, forward links, `##`
+sections and revisions, in one table in one file so the weights can be tuned —
+and a `maturity:` stage cut from it (seedling below 1.5, sapling to 5.0,
+evergreen from there). A hand-written `maturity:` in the note wins over the
+computed stage, exactly as a hand-written `published:` already beats the
+ledger; `maturity_score` is always the computed number, for debugging and for
+the margin that will show it.
+
 `thesis:` is the note's claim in one sentence. It becomes the page description
 and the RSS item's summary, and it is appended to any list item elsewhere that
 is nothing but a link to the note — so an index or hub page reads as claims,
@@ -100,6 +113,7 @@ import hashlib
 import json
 import re
 import shutil
+import subprocess
 import sys
 import unicodedata
 from datetime import date
@@ -178,6 +192,24 @@ ATTACHMENT_SUFFIXES = {
     ".ogg",
     ".wav",
 }
+# A level-2 ATX heading: `##` NOT followed by a third `#`, so `###` does not
+# count. The maturity model and the rail both care about `##` only - a `###`
+# is a subsection, not a section.
+H2_HEADING = re.compile(r"^##(?!#)[ \t]+", re.M)
+# The maturity model, in one place so the weights are one edit. These are the
+# numbers the 2026-08-31 prototypes were tuned to; they are a starting point,
+# not a finding (see docs/plans/digital-garden-design.md, item 14). The stage
+# cuts: seedling below MATURITY_SAPLING, sapling up to MATURITY_EVERGREEN.
+MATURITY_SAPLING = 1.5
+MATURITY_EVERGREEN = 5.0
+# The length term saturates at this many words. A linear length term let two
+# long unrevised notes outrank a short careful one, which is the failure that
+# started the model: past the saturation point, longer stops being evidence of
+# anything.
+MATURITY_LENGTH_SATURATION = 800
+# A commit counts as a substantial rewrite only when its diff to the note
+# exceeds this many lines (added + deleted).
+REWRITE_LINES = 15
 
 
 def slugify(name):
@@ -312,6 +344,93 @@ def coalesce_aliases(front):
     return out
 
 
+def git_revisions(vault, rel):
+    """Count substantial rewrites of a note from its git history, or 0.
+
+    The seed for the ledger's revision counter. A commit counts when the note's
+    own diff in it exceeds REWRITE_LINES lines (added + deleted), which is the
+    line that separates a rewrite from a touch-up. `--follow` survives renames,
+    the same property `carry_renames` gets from the content hash, so the count
+    is stable under the renames that would otherwise reset it.
+
+    Returns 0 rather than raising when there is no history to count in: the
+    vault may be an obsidian-sync mirror with no `.git` directory, or git may
+    not be on PATH (the preview without this package in its runtime inputs).
+    The counter then accrues from first deploy, which is a worse signal but
+    not a broken one.
+    """
+    if shutil.which("git") is None or not (vault / ".git").exists():
+        return 0
+    try:
+        out = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(vault),
+                "log",
+                "--follow",
+                "--numstat",
+                "--format=",
+                "--",
+                rel.as_posix(),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return 0
+    if out.returncode != 0:
+        return 0
+    rewrites = 0
+    for line in out.stdout.splitlines():
+        added, sep, rest = line.partition("\t")
+        deleted, _, _ = rest.partition("\t")
+        # `--numstat` writes `-\t-` for a binary file; skipping those is the
+        # same decision as not counting them.
+        if sep and added.isdigit() and deleted.isdigit():
+            if int(added) + int(deleted) > REWRITE_LINES:
+                rewrites += 1
+    return rewrites
+
+
+def maturity_score(words, backlinks, forward, sections, revisions):
+    """The number behind the maturity stage, as the plan lists its parts.
+
+    Components, with the weights the prototypes were tuned to:
+
+      length:    min(words / 800, 1) * 2  - saturating, not linear
+      backlinks: 1.2 each                 - the only signal from outside
+      forward:   0.5 each                 - resolved against the published set
+      sections:  +1 if the note has >= 3 `##`s - structured, not dumped
+      rewrites:  min(n, 4) * 0.35         - substantial commits
+
+    Rounded to three decimals so a computed score is stable in the emitted
+    frontmatter - a raw float sum can carry binary noise out to a sixteenth
+    decimal, which is a debugging number nobody asked to read.
+
+    The weights are all here, in one table in one file, so tuning them is one
+    edit and one commit. 800 is the number most worth revisiting once the vault
+    has grown.
+    """
+    score = min(words / MATURITY_LENGTH_SATURATION, 1.0) * 2
+    score += 1.2 * backlinks
+    score += 0.5 * forward
+    if sections >= 3:
+        score += 1
+    score += min(revisions, 4) * 0.35
+    return round(score, 3)
+
+
+def maturity_stage(score):
+    """seedling below 1.5, sapling from 1.5, evergreen at 5.0."""
+    if score >= MATURITY_EVERGREEN:
+        return "evergreen"
+    if score >= MATURITY_SAPLING:
+        return "sapling"
+    return "seedling"
+
+
 def carry_renames(ledger, published):
     """Move a ledger entry across a rename, keyed by content hash.
 
@@ -347,12 +466,26 @@ def carry_renames(ledger, published):
             ledger[keys[0]] = ledger.pop(gone[0])
 
 
-def update_ledger(ledger, key, text, today):
+def update_ledger(ledger, key, text, today, seed_revisions=0):
     """First sighting sets `published`; a changed note bumps `modified`.
 
     The hash covers the note as it was READ, not as it is written below, so a
     note's date does not move because some *other* note was published and its
     links here turned back into links.
+
+    The ledger also carries `revisions`, a count of substantial rewrites, which
+    is the signal `maturity_score` reads. It is seeded the first time a note is
+    seen and bumped once per hash change after that. The seed comes from git
+    (see `git_revisions`); where there is no repository the seed is 0 and the
+    counter accrues from first deploy.
+
+    The bump applies only to entries that already carried a counter. An entry
+    written by an older version of the filter has no `revisions`, and seeding
+    it from git is exactly right rather than approximate: git already counts
+    every commit in its history, including the one that produced the current
+    hash, so the seed is not followed by the bump. This is what makes the
+    counter land on the real number for notes published before it existed,
+    instead of treating a year of history as rewrites-since-yesterday.
 
     Keyed by the note's filename, deliberately not by its URL. The two are
     nearly the same string, and conflating them would mean that any future
@@ -363,9 +496,21 @@ def update_ledger(ledger, key, text, today):
     digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
     entry = ledger.get(key)
     if not isinstance(entry, dict) or "published" not in entry:
-        entry = {"published": today, "modified": today, "hash": digest}
+        ledger[key] = {
+            "published": today,
+            "modified": today,
+            "hash": digest,
+            "revisions": seed_revisions,
+        }
+        return ledger[key]
+    revisions = entry.get("revisions")
+    if revisions is None:
+        revisions = seed_revisions
     elif entry.get("hash") != digest:
+        revisions = revisions + 1
+    if entry.get("hash") != digest:
         entry = {**entry, "modified": today, "hash": digest}
+    entry["revisions"] = revisions
     ledger[key] = entry
     return entry
 
@@ -508,6 +653,17 @@ def main(argv):
             # A set, so a note that links to another five times is one entry.
             backlinks.setdefault(dest, set()).add(source)
 
+    # Maturity reads the graph in both directions. Backlinks are who cites this
+    # note; forward links are who this note cites, which is the transpose of
+    # `backlinks` - every (target, source) edge above is a link from source to
+    # target. The index is absent from both directions: it was skipped as a
+    # source in the loop above, so it has no edges for the transpose to count
+    # either, and a table of contents carries no maturity signal of its own.
+    forward_links = {}  # source slug -> how many published notes it links to
+    for dest, sources in backlinks.items():
+        for source in sources:
+            forward_links[source] = forward_links.get(source, 0) + 1
+
     # ---- pass 5: derive dates, then write a flat tree and swap it in --------
     try:
         ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
@@ -569,11 +725,25 @@ def main(argv):
         # ran - the H1 is stripped here, but it is not decided here.
         front["title"] = titles[slug]
 
-        entry = update_ledger(ledger, key, text, today)
+        entry = ledger.get(key)
+        # Seed the revision counter from git only when the ledger has nothing
+        # to bump: a brand-new note, or an entry written before the counter
+        # existed. Every other run passes 0 and `update_ledger` either keeps
+        # the count or advances it by one, so the seed (a git log walk) is paid
+        # once per note, not once per build.
+        needs_seed = not (
+            isinstance(entry, dict) and isinstance(entry.get("revisions"), int)
+        )
+        seed = git_revisions(vault, rel) if needs_seed else 0
+        entry = update_ledger(ledger, key, text, today, seed)
+
+        # The word count is a signal for maturity, so it is computed for every
+        # note, index included - the overlong report below is what stays
+        # essay-only.
+        words = len(body.split())
         # The landing page is a table of contents, not an essay: it has no
         # publication date worth showing and owes nobody a thesis.
         if rel.name.lower() != "index.md":
-            words = len(body.split())
             if words > LONG_NOTE_WORDS:
                 overlong.append((rel, words))
             # As real YAML dates, so they match a hand-written `published:` and
@@ -591,6 +761,23 @@ def main(argv):
                 front["description"] = str(thesis).strip()
             if not thesis:
                 no_thesis.append(rel)
+
+        # Maturity is computed here because it needs the whole graph (from
+        # pass 4) and the ledger (the revision counter just updated above),
+        # neither of which exists earlier. A hand-written `maturity:` in the
+        # note wins over the computed stage, exactly as a hand-written
+        # `published:` beats the ledger; `maturity_score` is always the computed
+        # number, so the override can sit next to what the model thinks.
+        score = maturity_score(
+            words=words,
+            backlinks=len(backlinks.get(slug, ())),
+            forward=forward_links.get(slug, 0),
+            sections=len(H2_HEADING.findall(body)),
+            revisions=entry["revisions"],
+        )
+        front["maturity_score"] = score
+        if "maturity" not in front:
+            front["maturity"] = maturity_stage(score)
 
         # A list item that is only a link gets the target's thesis appended, so
         # an index or hub page reads as claims rather than as bare titles, and


### PR DESCRIPTION
Implements item 14 of `docs/plans/digital-garden-design.md` — the session every downstream item (15, 17, 18, 19) reads from.

## What this does

`publish-filter.py` now computes a maturity for every published note and emits it as frontmatter:

- **`maturity_score`** — a weighted sum, all in one table in one file: length `min(words/800, 1)*2` (saturating), backlinks `1.2` each, forward links `0.5` each, `+1` for ≥ 3 `##` sections, rewrites `min(n, 4)*0.35`.
- **`maturity`** — the stage cut from it (seedling < 1.5, sapling ≥ 1.5, evergreen ≥ 5.0), unless the note carries a hand-written `maturity:` — the override wins, exactly as hand-written `published:` already beats the ledger. `maturity_score` is always the computed number.
- The ledger gains a **`revisions`** counter, bumped on each hash change. It is **seeded from git** the first time a note is seen (`git log --follow --numstat`, commits whose diff to the note exceeded 15 lines); obsidian-sync vaults (no git) start at zero and accrue from first deploy.

To make the seed real, the vault clone is now full history instead of `--depth 1` (a depth-1 clone has exactly one commit to count), with a one-time `--unshallow` transition for existing shallow clones. The preview gains `pkgs.git` so it can seed against the working-tree vault.

## Checks

- New VM subtests pin the mechanism: every staged note carries maturity; a hand-written `maturity: evergreen` on a note whose computed score is < 1.5 survives unchanged; editing one note advances only its `revisions` while neighbours stay 0.
- `nix build .#checks.x86_64-linux.digital-garden` — all 30 subtests pass.
- `nix fmt -- --ci` — clean. `.#nixosConfigurations.homelab01.config.system.build.toplevel` builds.
- Filter exercised by hand against a scratch git repo (seeding, old-ledger seeding, rename survival) and the rendering fixture.

## Also in this PR

A one-line plan-doc fix: item 13 (rename-stable ledger) shipped in #118 but was left "not started"; the status column is now correct. Item 14's row should flip to done on merge.

## Residual notes

- The plan's "six seedlings, eleven saplings, one evergreen" can only be confirmed against the private vault; the model is exactly as specified.
- Nothing renders the new frontmatter yet — that is item 15/17.