### PR TITLE
feat(deploy): key-bound sudo and a dedicated key for the deploy user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,7 @@ jobs:
           - digital-garden-sync-health
           - deploy-schema
           - deploy-activate
+          - deploy-sudo
           - download-root-canary
           - download-root-canary-script
           - download-root-safety

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -303,6 +303,7 @@ in
     inherit pkgs;
     lib = pkgs.lib;
   };
+  deploy-sudo = testLib.mkTest ./deploy-sudo.nix;
   download-root-canary = testLib.mkTest ./download-root-canary.nix;
   download-root-canary-script = import ./download-root-canary-script.nix {
     inherit pkgs inputs self;

--- a/checks/deploy-sudo.nix
+++ b/checks/deploy-sudo.nix
@@ -1,0 +1,162 @@
+# checks/deploy-sudo.nix
+#
+# Behaviour test for item 10 of docs/plans/deployment-hardening.md: the deploy
+# user's sudo is confined to the activation path, and nothing else changed
+# around it.
+#
+# The two ways this change can go wrong are both silent in a build. Too narrow
+# and the first real `deploy` dies at the copy step or the activation step with
+# a sudo error; too wide and the "scoped exception" is the old `sudo ALL`
+# wearing different clothes. Neither shows up until someone runs deploy-rs
+# against a host, so this boots the module and drives the *exact* command
+# shapes deploy-rs emits:
+#
+#   - `activate` / `wait` / `revoke` are one binary - <closure>/activate-rs -
+#     with different subcommands, escalated via `sudo -u root`;
+#   - magicRollback's confirmation is `sudo -u root rm /tmp/deploy-rs-canary-<hash>`.
+#
+# The fake closure is a store path whose name matches the real deploy-rs
+# closure (`activatable-nixos-system-…`) and whose only content is an
+# `activate-rs` that records how it ran - so the sudoers wildcard is exercised
+# against a path with the real shape, and "it ran as root" is asserted, not
+# assumed.
+{
+  lib,
+  pkgs,
+  ...
+}:
+let
+  fakeClosure = pkgs.runCommand "activatable-nixos-system-deploy-sudo" { } ''
+    mkdir -p $out
+    cat > $out/activate-rs <<'EOF'
+    #!/bin/sh
+    printf 'ran as %s: %s\n' "$(id -u)" "$*" > /tmp/activate-rs-ran
+    EOF
+    chmod +x $out/activate-rs
+  '';
+in
+{
+  name = "deploy-sudo";
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [
+        ../modules/nixos/deploy-rs.nix
+        ../modules/nixos/ssh-hardening.nix
+      ];
+
+      networking.hostName = "deploy-sudo";
+      system.stateVersion = "24.11";
+
+      cg.deploy-rs = {
+        enable = true;
+        # Fixture only - this VM never runs sshd, so the key content is unused.
+        authorizedKeys = [ "ssh-ed25519 AAAA... deploy@xps15" ];
+      };
+
+      # A human, wheel member, with a password - the account whose sudo must
+      # still prompt. The `%wheel` rule must survive the deploy rule next to
+      # it, and this user is the check.
+      users.users.coryg = {
+        isNormalUser = true;
+        extraGroups = [ "wheel" ];
+        password = "coryg-password";
+      };
+
+      # Both servers run user-security with execWheelOnly (the setuid sudo
+      # wrapper is wheel-exec only). The deploy user is not in wheel, so this
+      # is the setting that decides whether the module's wrapper-group grant
+      # lets it execute sudo at all - omitting it would make the test green
+      # while every real deploy dies at the first escalation.
+      security.sudo.execWheelOnly = true;
+      security.sudo.wheelNeedsPassword = true;
+
+      # Referenced so the fake closure is present in the VM's store; the
+      # system-path symlink is a side effect, the assertion only needs the
+      # path to exist.
+      environment.systemPackages = [ fakeClosure ];
+    };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+
+    # Nix-interpolated once here so the f-strings below only reference Python
+    # variables (the test driver type-checks the script as Python).
+    FAKE = "${fakeClosure}/activate-rs"
+    CLOSURE = "${fakeClosure}"
+    COREUTILS_ECHO = "${pkgs.coreutils}/bin/echo"
+
+    with subtest("the deploy account is out of wheel and passwordless"):
+        groups = machine.succeed("id deploy")
+        assert "wheel" not in groups, groups
+        # NixOS marks a passwordless system account locked ("L") rather than
+        # "NP"; either way the point is that no password stands behind the
+        # sudo rule.
+        status = machine.succeed("passwd -S deploy").split()[1]
+        assert status != "P", status
+
+    with subtest("sudo -n as deploy reaches activate-rs and nothing else"):
+        # The three deploy-rs escalation shapes, verbatim except for the
+        # closure path.
+        machine.succeed(
+            f"su deploy -c 'sudo -n -u root {FAKE} activate {CLOSURE} "
+            "--profile-path /nix/var/nix/profiles/system --temp-path /tmp "
+            "--confirm-timeout 30 --magic-rollback'"
+        )
+        machine.succeed(f"su deploy -c 'sudo -n -u root {FAKE} wait {CLOSURE} --temp-path /tmp'")
+        machine.succeed(f"su deploy -c 'sudo -n -u root {FAKE} revoke --profile-path /nix/var/nix/profiles/system'")
+        assert machine.succeed("cat /tmp/activate-rs-ran").startswith("ran as 0")
+
+        # Everything else is refused, passwordlessly and without a rule.
+        machine.fail("su deploy -c 'sudo -n -u root /bin/sh -c id'")
+        machine.fail(f"su deploy -c 'sudo -n -u root {COREUTILS_ECHO} hi'")
+        machine.fail("su deploy -c 'sudo -n -u root id'")
+
+    with subtest("magicRollback's confirmation rm is scoped to the canary"):
+        canary = "/tmp/deploy-rs-canary-0123456789abcdef0123456789abcdef"
+        machine.succeed(f"touch {canary}")
+        machine.succeed(f"su deploy -c 'sudo -n -u root rm {canary}'")
+        machine.fail(f"test -e {canary}")
+
+        # The regex is anchored: a name sharing the prefix is not covered (a
+        # second dash is outside [a-z0-9]), and a second argument cannot ride
+        # along.
+        machine.succeed("touch /tmp/deploy-rs-canary-not-a-canary")
+        machine.fail("su deploy -c 'sudo -n -u root rm /tmp/deploy-rs-canary-not-a-canary'")
+        machine.fail("su deploy -c 'sudo -n -u root rm /tmp/deploy-rs-canary-aa /etc/hostname'")
+        machine.succeed("rm /tmp/deploy-rs-canary-not-a-canary")
+
+    with subtest("sudo -l for deploy lists only the scoped commands"):
+        listing = machine.succeed("su deploy -c 'sudo -l -n'")
+        assert "NOPASSWD:" in listing, listing
+        assert "activate-rs" in listing, listing
+        assert "deploy-rs-canary" in listing, listing
+        assert "(ALL" not in listing, listing
+
+    with subtest("coryg's own sudo still requires a password"):
+        # `-S` feeds the password over stdin: this both proves the prompt is
+        # still there (without -S and without a TTY, sudo would fail before
+        # listing) and that the wheel rule still works for the human.
+        listing = machine.succeed(
+            "su coryg -c \"printf 'coryg-password\\n' | sudo -S -l\""
+        )
+        # The %wheel rule is present (NixOS renders it with its default
+        # SETENV tag) and carries no NOPASSWD - it must still prompt.
+        assert "(ALL : ALL)" in listing, listing
+        assert "NOPASSWD" not in listing, listing
+        machine.fail("su coryg -c 'sudo -n true'")
+
+    with subtest("deploy stays a trusted nix user for the copy step"):
+        # Item 10 drops deploy from wheel, which is also what made the deploy
+        # *copy* work (unsigned closures need a trusted user on the receiving
+        # daemon). The module must grant that explicitly or every deploy fails
+        # at the copy step with "lacks a signature by a trusted key". The
+        # `@wheel` half of the host setting comes from flake.nix, not from
+        # this module, so the assertion is that deploy is listed at all.
+        trusted = machine.succeed("awk '/^trusted-users/ {print}' /etc/nix/nix.conf")
+        assert "deploy" in trusted, trusted
+        assert "root" in trusted, trusted
+  '';
+}

--- a/docs/plans/deployment-hardening.md
+++ b/docs/plans/deployment-hardening.md
@@ -16,7 +16,7 @@ Six pieces originally; five now, since service confinement moved out to [ADR 000
 | 6   | `deploy-rs` interactively | small   | **done** 2026-08-30 - `homelab01` deployed end to end with `magicRollback` confirmation; `homelab02` still needs its bootstrap switch + first deploy |
 | 8   | Download-root canary      | small   | **done** 2026-08-30 - sentinel, alert, guard and tests landed |
 | 9   | Reachability from outside | small   | done - cross-host probes via the peer's public endpoints |
-| 10  | Deploy-user sudo on SSH keys | small | not started - expanded 2026-08-31 to also drop `deploy` from `wheel` and give it a dedicated key |
+| 10  | Deploy-user sudo on SSH keys | small | **done** 2026-08-31 - wheel dropped, sudo scoped to the activation path, password retired, dedicated `deploy@xps15` key landed, `checks/deploy-sudo` in the gate; the live `deploy` runs on both hosts remain |
 | 11  | Split the backup transport account | small | not started - move `restic-backup` off `coryg` onto a dedicated unprivileged `backup` account |
 | 12  | Hardware-backed admin key | small | not started - optional; move the human admin key to a hardware token |
 
@@ -773,6 +773,27 @@ Two checks to add when built: that `sudo -n` as `deploy` reaches `activate-rs` a
 ### Done when
 
 `deploy .#homelab01` (and `.=homelab02`) run with no sudo password prompt, `sudo -u deploy sudo -l` shows only `activate-rs`, the `users/deploy` secret in sops is retired, and `coryg`'s own sudo still asks for a password.
+
+### What landed
+
+Implemented on `feat/item10-deploy-sudo-key`. The approach above held, with two corrections found by reading the pinned deploy-rs and sudo source rather than trusting the sketch:
+
+- **The sudoers command path in the sketch does not exist.** `${config.system.build.activate}/bin/activate-rs` is not what deploy-rs escalates. deploy-rs's `activate.nixos` wraps the toplevel in a `buildEnv` named `activatable-nixos-system-<host>-<version>` and runs `<closure>/activate-rs` with subcommands `activate`, `wait` and `revoke`; the closure path changes every build. The rule is therefore a wildcard, `/nix/store/*/activate-rs` (matched by sudoers' glob machinery, spanning a single store component). There is also a fourth escalation the sketch missed: magicRollback's confirmation is not the activation binary at all, it is `sudo -u root rm /tmp/deploy-rs-canary-<hash>`, and it needs its own rule.
+- **The `rm` rule must name the resolved path, not a store path.** sudoers `command_matches` compares canonical parent directories before it gets to its inode fallback, so `${pkgs.coreutils}/bin/rm` would never match a user command resolved to `/run/current-system/sw/bin/rm`. The rule names that path, with args anchored as a regex (`^/tmp/deploy-rs-canary-[a-z0-9]*$`) because sudoers globs match across word boundaries and `*` in an argument matches `/`.
+
+**Two things the plan did not foresee, one in each half of the flow.** On the sudo side, both servers run `security.sudo.execWheelOnly = true` (`modules/nixos/user-security.nix`), which makes the setuid `sudo` wrapper executable by `wheel` only - so dropping `wheel` did not just confine deploy's sudo, it removed its ability to execute sudo at all. The module grants exec the way `execWheelOnly` intends: the wrapper group is pointed at the deploy user's own group, with `coryg` added to it, so exactly the two SSH accounts can exec sudo and deploy stays out of `wheel`. (Re-adding `wheel` would not work either: the `%wheel` rule is ordered before the scoped rule, so a wheel-member deploy would match password-required `sudo ALL` first.) On the copy side, `nix copy --to ssh-ng://deploy@host` pushes unsigned, locally-built closures and the receiving daemon only imports them for a trusted user; `modules/nixos/deploy-rs.nix` now grants `nix.settings.trusted-users` membership explicitly. Both are the same privilege deploy had via wheel, so nothing is widened - but a first pass that removed wheel without either would have failed every deploy, the sudo half at the first escalation and the copy half with `lacks a signature by a trusted key`.
+
+Landed:
+
+- `modules/nixos/deploy-rs.nix` - `wheel` gone, `hashedPasswordFile` and `sops.secrets."users/deploy"` gone, `security.sudo.extraRules` with the two NOPASSWD rules above, `nix.settings.trusted-users` membership, and the sudo-wrapper exec grant (the wrapper group becomes the deploy group, with `coryg` added to it) that replaces what wheel supplied against `execWheelOnly`.
+- `flake.nix` - `interactiveSudo` dropped from both `deploy.nodes`; the `deploy-rs` schema check accepts the omission.
+- `secrets/shared.yaml` - `users/deploy` deleted with `sops unset` (recipients unchanged); `modules/nixos/sops-nix.nix` drops the name from `sharedSecrets`.
+- `hosts/homelab01/default.nix`, `hosts/homelab02/default.nix` - the deploy account now authorizes a dedicated `deploy@xps15` key (`~/.ssh/deploy` on the laptop), not the human's `coryg@xps15`.
+- `modules/home/development/ssh.nix` - a `Host deploy@homelab01 deploy@homelab02` block offers only `~/.ssh/deploy`, so the personal key is never presented to the deploy account.
+- `secrets/operator.yaml` + `modules/home/security/sops-nix.nix` - the deploy key's private half is stored under `private_keys/deploy` (user-key-only, like `personal` and `github`) and declared so home-manager restores it to `~/.ssh/deploy` on the laptop.
+- `checks/deploy-sudo.nix` - a VM test that drives the real deploy-rs command shapes: `sudo -n` as `deploy` reaches an `activatable-nixos-system-…` closure's `activate-rs` (and runs it as root) and the scoped `rm`, and nothing else; `sudo -l` for `deploy` shows only the two rules; `coryg`'s `%wheel` rule still prompts; and the generated `nix.conf` still lists `deploy` among `trusted-users`. The test node sets `security.sudo.execWheelOnly = true` to match the servers, so the wrapper-exec grant above is exercised rather than assumed.
+
+The "done when" is met on the config side. The two live `deploy .#homelab01` / `.#homelab02` runs and the `sudo -u deploy sudo -l` on each host remain to be done against the promoted revision, as with every change to this pipeline.
 
 ---
 

--- a/flake.nix
+++ b/flake.nix
@@ -313,11 +313,12 @@
       # push when iterating on a service or recovering a host the automated
       # path cannot reach.
       #
-      # `sshUser = "deploy"` + `user = "root"` + `interactiveSudo`: deploy-rs
-      # connects as the dedicated deploy user (modules/nixos/deploy-rs.nix) and
-      # escalates to root through sudo, prompting for the deploy user's password
-      # (that host keeps `security.sudo.wheelNeedsPassword = true` and refuses
-      # root SSH).
+      # `sshUser = "deploy"` + `user = "root"`: deploy-rs connects as the
+      # dedicated deploy user (modules/nixos/deploy-rs.nix) and escalates to
+      # root through the scoped NOPASSWD sudo rule item 10 added - only the
+      # activation binary (and the magic-rollback confirmation `rm`) are
+      # reachable, and no password is asked (that host keeps
+      # `security.sudo.wheelNeedsPassword = true` and refuses root SSH).
       deploy = {
         nodes = {
           homelab01 = {
@@ -327,7 +328,6 @@
               user = "root";
               path = deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.homelab01;
             };
-            interactiveSudo = true;
           };
           homelab02 = {
             hostname = "homelab02";
@@ -336,7 +336,6 @@
               user = "root";
               path = deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.homelab02;
             };
-            interactiveSudo = true;
           };
         };
       };

--- a/hosts/homelab01/default.nix
+++ b/hosts/homelab01/default.nix
@@ -87,13 +87,14 @@ in
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPWfMUll4YosHtfkgs/68GAaszVU/VM94IrQzz4xZuPN restic-backup"
       ];
     };
-    # The account deploy-rs connects as when the laptop pushes a change (item 6
-    # of the hardening plan). Only the laptop needs to reach it, so only the
-    # laptop's key is authorized.
+    # The account deploy-rs connects as when the laptop pushes a change (items 6
+    # and 10 of the hardening plan). Only the laptop needs to reach it, so only
+    # the laptop's dedicated deploy key is authorized - revoking deploy access
+    # must not require rotating the human admin key.
     deploy-rs = {
       enable = true;
       authorizedKeys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGN2/Vvyb3abKAxdCYt9pxGgOho5uqtNzhpXVxGVw1gq coryg@xps15"
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEptc3aZw3UltEoKboluqNvpFsYmirJxaoZg3AM3eB6f deploy@xps15"
       ];
     };
     kernel-hardening = {

--- a/hosts/homelab02/default.nix
+++ b/hosts/homelab02/default.nix
@@ -98,13 +98,14 @@ in
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPWfMUll4YosHtfkgs/68GAaszVU/VM94IrQzz4xZuPN restic-backup"
       ];
     };
-    # The account deploy-rs connects as when the laptop pushes a change (item 6
-    # of the hardening plan). Only the laptop needs to reach it, so only the
-    # laptop's key is authorized.
+    # The account deploy-rs connects as when the laptop pushes a change (items 6
+    # and 10 of the hardening plan). Only the laptop needs to reach it, so only
+    # the laptop's dedicated deploy key is authorized - revoking deploy access
+    # must not require rotating the human admin key.
     deploy-rs = {
       enable = true;
       authorizedKeys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGN2/Vvyb3abKAxdCYt9pxGgOho5uqtNzhpXVxGVw1gq coryg@xps15"
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEptc3aZw3UltEoKboluqNvpFsYmirJxaoZg3AM3eB6f deploy@xps15"
       ];
     };
     kernel-hardening = {

--- a/modules/home/development/ssh.nix
+++ b/modules/home/development/ssh.nix
@@ -36,6 +36,16 @@ in
           User = "coryg";
         };
 
+        # deploy-rs connects as `deploy@…` (item 10 of the hardening plan) and
+        # that account only accepts its own key, not the human's. Offer only
+        # the dedicated deploy key on those connections so the personal key is
+        # never presented to the deploy account.
+        "deploy@homelab01 deploy@homelab02" = {
+          User = "deploy";
+          IdentitiesOnly = true;
+          IdentityFile = [ "~/.ssh/deploy" ];
+        };
+
         "*" = {
           IdentityFile = [ "~/.ssh/id_ed25519_personal" ];
           AddKeysToAgent = "yes";

--- a/modules/home/security/sops-nix.nix
+++ b/modules/home/security/sops-nix.nix
@@ -47,6 +47,9 @@ in
         "private_keys/personal" = {
           path = "${config.home.homeDirectory}/.ssh/id_ed25519_personal";
         };
+        "private_keys/deploy" = {
+          path = "${config.home.homeDirectory}/.ssh/deploy";
+        };
 
         # Example: Personal API token
         # "tokens/openai" = {

--- a/modules/nixos/deploy-rs.nix
+++ b/modules/nixos/deploy-rs.nix
@@ -1,26 +1,38 @@
 # modules/nixos/deploy-rs.nix
-# The deploy user that `deploy-rs` connects as (item 6 of the hardening plan).
+# The deploy user that `deploy-rs` connects as (items 6 and 10 of the hardening
+# plan).
 #
 # deploy-rs connects to a host as this user over SSH, then escalates to root
 # with `sudo` to activate the system profile. Everything else this module does
 # is make that account real on a host that otherwise only has one human:
 #
-#   - a non-interactive, wheel member; it has to elevate, so it has to be
-#     allowed to;
+#   - a non-interactive account whose *only* sudo is the deployment path. Item
+#     10 took it out of `wheel` and gave it two NOPASSWD rules: the deploy-rs
+#     profile activation binary (`/nix/store/*/activate-rs` - the store hash
+#     changes every build), and the `rm` that magicRollback uses to confirm an
+#     activation. `security.sudo.wheelNeedsPassword` stays on for the human;
+#     this is the scoped exception that replaces the deploy password;
 #   - permission to SSH in at all, by being added to `cg.ssh-hardening.allowedUsers`
 #     alongside the human account `coryg` (the deploy username RE-places the
 #     option's `["coryg"]` default rather than merging with it, so this has to
 #     list the human too or SSH would stop accepting either of them);
-#   - a password hash out of SOPS, because `security.sudo.wheelNeedsPassword`
-#     is on and `mutableUsers` is off - so a password can only get here from
-#     the config, and sudo can only prompt for one the account actually has
-#     (deploy-rs' `interactiveSudo` prompts for it);
-#   - the laptop's public key, so `deploy homelab02` from the laptop works.
+#   - membership of `nix.settings.trusted-users`. This is what makes the copy
+#     step of a deploy work: deploy-rs pushes unsigned, locally-built closures
+#     over `ssh-ng://`, and the receiving daemon only imports paths that lack a
+#     signature by a trusted key for a trusted user. Wheel used to supply this;
+#     it was load-bearing, not incidental - dropping wheel without replacing it
+#     would break every deploy at the copy step with "lacks a signature by a
+#     trusted key";
+#   - the laptop's dedicated deploy key, so `deploy homelab02` from the laptop
+#     works without sharing the human admin key.
 #
 # Be clear-eyed about what this is and is not. It contains accidents and gives
 # an audit trail; it is not a security boundary - anything that can set the
-# system profile can set it to a closure containing a root shell, so the
-# "dedicated user" buys scope, not trust.
+# system profile can set it to a closure containing a root shell, and
+# `trusted-users` is root-equivalent in nix's own documentation. The point of
+# item 10 is narrower: the weakest credential on the fleet - a hashed sudo
+# password typed by a human - no longer gates the widest escalation. What
+# remains is scoped to the activation path and granted to a revocable key.
 {
   config,
   lib,
@@ -58,8 +70,6 @@ in
       # the default nologin shell for system users prints "This account is
       # currently not available." and breaks `deploy`.
       shell = pkgs.bash;
-      extraGroups = [ "wheel" ];
-      hashedPasswordFile = config.sops.secrets."users/deploy".path;
       openssh.authorizedKeys.keys = cfg.authorizedKeys;
     };
     users.groups.${cfg.username} = { };
@@ -72,10 +82,54 @@ in
       cfg.username
     ];
 
-    # Populated before the users are built (the same `neededForUsers` reason
-    # `users/coryg` carries in profiles/server.nix).
-    sops.secrets."users/deploy" = {
-      neededForUsers = true;
-    };
+    # The copy step (item 10's otherwise-unsung half). deploy-rs pushes
+    # unsigned closures over ssh-ng, which the receiving daemon rejects for
+    # anyone outside trusted-users - the exact failure `@wheel` used to mask.
+    # The account is deploy-only and already root-equivalent through the
+    # activation path below, so this grants no capability it does not have.
+    nix.settings.trusted-users = [ cfg.username ];
+
+    # The whole of the deploy user's sudo, scoped to the activation path
+    # (item 10). deploy-rs runs every escalation as `sudo -u root`; the
+    # `%wheel` rule stays password-gated and does not apply to this user.
+    #
+    # Both servers also run `security.sudo.execWheelOnly = true`
+    # (user-security.nix), which makes the setuid sudo wrapper executable by
+    # the `wheel` group only. The deploy user is deliberately not in wheel, so
+    # the wrapper group is pointed at the deploy user's own group instead,
+    # with the human added to it - exactly the two SSH accounts can exec sudo,
+    # which is the same restricted set execWheelOnly intends. sudoedit stays
+    # wheel-only, since deploy never calls it.
+    security.wrappers.sudo.group = lib.mkForce cfg.username;
+    users.users.coryg.extraGroups = [ cfg.username ];
+    security.sudo.extraRules = [
+      {
+        users = [ cfg.username ];
+        runAs = "root";
+        commands = [
+          # The profile activation binary. deploy-rs's `activate`, `wait` and
+          # `revoke` are all this one binary with different subcommands; the
+          # store path changes every build, hence the wildcard spanning a
+          # single store component. An account that can deploy can already put
+          # a closure in the store, so this is the role's own capability, not
+          # a widening.
+          {
+            command = "/nix/store/*/activate-rs";
+            options = [ "NOPASSWD" ];
+          }
+          # magicRollback's confirmation step: the deployer removes the canary
+          # lock file, proving the new profile is healthy. The path is the
+          # *resolved* one - sudo compares canonical parent directories, so a
+          # store path in this rule would not match `/run/current-system/sw/bin/rm`.
+          # The anchored regex confines the args to a single canary file, so a
+          # second argument cannot ride along (sudoers globs match across word
+          # boundaries; `*` in an argument matches `/` too).
+          {
+            command = "/run/current-system/sw/bin/rm ^/tmp/deploy-rs-canary-[a-z0-9]*$";
+            options = [ "NOPASSWD" ];
+          }
+        ];
+      }
+    ];
   };
 }

--- a/modules/nixos/sops-nix.nix
+++ b/modules/nixos/sops-nix.nix
@@ -92,11 +92,6 @@ in
         # the hash has to be the same or the same password stops working when
         # you SSH to the other one.
         "users/coryg"
-
-        # The deploy-rs user's password hash, for the same reason as coryg's:
-        # the two servers must accept the same interactive sudo password when
-        # the laptop deploys to either of them.
-        "users/deploy"
       ];
     };
   };

--- a/secrets/operator.yaml
+++ b/secrets/operator.yaml
@@ -1,6 +1,7 @@
 private_keys:
     github: ENC[AES256_GCM,data:iKfGRmiFBq4L4oWMh53lvAyiC5Za8Bct9j185RRQyWyay7cmweYIM80YXFS7VZ7NGU//eUtLJRJGQpd/JxAxRAk5qxBnlhK4sdlQKSUF7F6PT9+Jg9eNceC/9Zvoi+DLy8uPsdi2aVX+Cv4kPz5W0mg2epvACqwRosBvvihrfYpvzsyje9iwm7H2F1qLuXPttPn8K/9WCWioH330EjnFJEd4m3vlftOw1bImF2d2w9WIFZjtlOnhTDZPoDHcpjer5eVDRp6wJ7L/8FMzmmaI4N7neNKLf29Y7rX/ZQOWNnxgWpnqvW+y+jcDM5fvKCAfeWIEfvlu/0v+udtrpkBcRU2GQawPM737VnOSkzJ6+THpKMHzYuZyn9Tgqmqjx8mnY5a3Z0dIJZgHCydycHEw0CpeazUHSx3eaunYtgvumNe595PBM2URuCwKU2viuNMAFtzsYJ5CCnv06IB5TlCMW/1hsaXo4/zGnRkPsKwhpOk579MvciPU+tnFKjsG5ETMC1EH8l+K95cR29myKWcIqc3NwtgNqGOYyLJeJD9m65zUTXc=,iv:zKBXaCajLWOEI4E/mPby3miQOHGLxheTDtwS5rsyrg4=,tag:KEvZODo+ZYxJvTBG6kaS6A==,type:str]
     personal: ENC[AES256_GCM,data:K8pub0g+owcBBOhLMOnD3VqSBjeLxXt1lgNCKeOkwgxpmexS+koL8/BjH4s0j16x6MTx9RIjKxUp7bxWmKG/dQ52IP4+UknGb0NA1pg9GAN/ibWO/fbkHet+sn+pBqWobm1G+LCaBgC7dAkXhzOx7TdNA+sDPXnrZKaEfr/nI2JRBCKuKiTikHl+jOuKvl4SfT+BDXQDKm1maNwVuCHMs0xuzNkpSo29J6cMedSdvHfwcGfPiSnXhlKzxI99KGNjYywkOqDGH5ny7z9y5LEAb9w+UXVXMkqeixwsYyWku+J/mTCoNEpqmYNRORA3qIaCynItIhcSxWiB3Nh1f3Y4zsiQb5ce2Hma7rzTVJ8nF0bGC1W31QAVR9K909UobRcvsLrQNRslU8ObBi3QSfzakcPdSVKI07Qh46n7C/oJxYUse6AhyfweAy0XCJtKye/20rVqHgDkRueg+dH1vRgaBcdx4hmlOsQuCW7RIJK0KXJSSnljHNM0k1T3SeElIV963rMyxyHwNAPT/VYP4p1T,iv:wkh7LPLD9QUgofjKywe2NmIRE6Trl4GJucF6NZjMwsw=,tag:X1D4Xi7ne+sflQAg5oVq7Q==,type:str]
+    deploy: ENC[AES256_GCM,data:+qHQx9nwXEHiJRh9jWSnD8p/kuR0WBjFVoBGTVnd4ZiYZIjz51AC0jPrAxUZ8V1xKsAf2LxJy1Ffr8CldodhrEGaEwt4/2HWgwoPG82vm21lq16heWDytsch4nE+i+IJwRHhqNaaM5QQkadrMeFbd+uSo0qo0ds0ttdybT/7Lyr60CjvE05VS4T8P/x/QgWb7gV7C+1lFRfPjO7YdIZEIpYmiGbuACPxPhAA90utX+7EbktQ2tfvJGdJ78Mzlp9nUCvnYHB3K9fphFASSAUlRgP84JKkTOAXlMCdO6Ef4SLT1aW9FC5M/QDNNIlyjsrWFn6xRzA/+hmH9qn8c5TX03V2ESEyiuGq/efwQb1JgShNS0dd+tAr9jBFAT3ESIPJuocOdNHw0pwphyBETt1YZXxxQNgFLk5DcVkEGQ94XZkFo7wYClCH/O3F6CSi4XOdOxf7gJGw7uuSlGyOuDX0AQ20i1lR+VP/d5TMuxqEYZY6Wg98WEg2ddxutRTpetydrL5Q0slsvuXgJkdHCEKA,iv:pRygmo33l/IsDJmB4UYBFvbG4QSUUHKlYU1APAuk5Z0=,tag:aJhC95v6q8MBkvDkxKJw1g==,type:str]
 cachix:
     auth-token: ENC[AES256_GCM,data:WH4Orx9IVU4u41iYs/ZB7Ut7x9T9roXeLic03ciPepRxFbWaVwUuOEQ7WVd5iaNJ4J/1E4LN+Q12TXRLIAOrIHdIfB/cB/faLZGsESDpSQUy/0tRawNn8hDuA/k+BqWXA3/QpCA0CIpZa4Qmaex1d7tcL2Gf3x8pPY7yG8b2USYx+FT1E0Fk3kHKMNgasMdHWZRdnZo=,iv:d75fC9Ue+ZewCgUWOc09vHcFP0WRal/8Cw9Fj1uX2BI=,tag:ON89NcGI+XEfPFNWF7uQFg==,type:str]
     public-key: ENC[AES256_GCM,data:7SxjLpUzrKtH40SAdN7Nkm3XE6WFuC4KmnzQOHHS1IzkiWfqm/WmjwKe+47nHtNPuc+qGP9dAgy76g+UBViC72HEs/RPr2tC2SlKaNV5p0g=,iv:XpgwkvjCj765ONGZvqOX8SfNU/5S30ltnaaw9m4uY2I=,tag:l0/pps7aFRd7qkVG14vY9Q==,type:str]
@@ -48,7 +49,7 @@ sops:
             xSMXy+Kj73Di/So/tdv3saE4a5QQLW4TwfVJyWhTOJgW5dgWW+yH4Q==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1emdtpejkq68k5zpp09fy6ak4wrkjmhuz4yxx9pmkk7r4h56tgppsqf9tuh
-    lastmodified: "2026-08-29T08:38:18Z"
-    mac: ENC[AES256_GCM,data:Inmpc1srs+nNRklZgfIDAq+VUhvO8RYowjUySbpslTITanwbuY5sfaRdbAKvfTum2DbsogQSCl+YwqCeBLp+m0kn24QWlZxB7CLXbVFRYXY48u9PjwEnUuh3wMxLBBvsP0kL02OLPCBEGfruGMSR4XtL1M/B6t7wJVciIqpBs3A=,iv:3sdSm+mMWR1kaaBKf+EHXTGz0nzELBPwvXGhtGY17Ng=,tag:pw2sZJyovAVlVnAlKI1+fw==,type:str]
+    lastmodified: "2026-08-31T15:19:50Z"
+    mac: ENC[AES256_GCM,data:ct7e5nQJnx7vMJfe34BCOw6Doz1h2Clc9OJ9f46cykLK30bV+JEDyhyOxgs7RkusO7iUGOAzlESR31ygnJTHeWY7Eb+E+bL1yn1NtQAzapTgM2D0qYKDonAgiSzigsB7VMb5eTiD2wbNa9V9ZxyUa56NECGfCwjTNBlW3ErkPyU=,iv:D7LBsNGn9/srwrb0/mObFc5pt16CWoU/I+9SUNtvQO4=,tag:ovsIuLz+r13N+dNVPA1Y1w==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3

--- a/secrets/shared.yaml
+++ b/secrets/shared.yaml
@@ -20,7 +20,6 @@ monitoring:
     proton_smtp_token: ENC[AES256_GCM,data:CO206ap4Z3l/wTzFPM7W6g==,iv:Fqufh3x+VIWdPzXZcyNKKgaN9kflPl10kuvpx+i0lTI=,tag:kcy3awO7zJZetPe8MeA/hw==,type:str]
 users:
     coryg: ENC[AES256_GCM,data:TvIF+j/X76/x90iJhDobSIsGTV894mdGTLpDRiIdWCip21dC4SRCl0XmA2vrete7q9QMhUT3rYyPmTx+b4Cac3Nb1gAZssd6oRqaO0UEAJFFwlFxfLVDcrCogIyVLPpMzkqUlIoCDgTMHg==,iv:UFP4xfuVJv5tK1EMv82UJtBSPVsQd4fhg6vmbU1yn+Q=,tag:org7tTiH6PF1+xlCQxnYDA==,type:str]
-    deploy: ENC[AES256_GCM,data:50x2NTkcAjnbqHEYbH/zyR2wFC7xGKmWR2IMYeegJFq5oXR0Lls/WgWHknCIxeVAJuAvv1GWOi5lU/tdjR0iB3LNJDiHoXP/Jw/foCtwLrFrZ+pClwZsnWx2YjbXjOcQGYiTfw2TTB6YRg==,iv:HqT7oRj5h5wG/n8vqSvD7sB07GizbNFxSOpaeJ7sFG0=,tag:C319hFgHDnE6FyvAM7qDeA==,type:str]
 sops:
     age:
         - enc: |
@@ -50,7 +49,7 @@ sops:
             4ldX/6eyvm5JkKiQBi+WAf4Tsc/SbD+B3sdRp5kbjdWal2LisfVwjQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age15h2tcfx9dw5qeyx4cgg358wlzr489vvq272s6wm7gud6mrkmregsp9s6x6
-    lastmodified: "2026-08-30T03:29:24Z"
-    mac: ENC[AES256_GCM,data:YsYxODzB1MBOZ+E6gqidL7PSScywLKzDgOEZY+COpBCwoawH/kbraDzukIAkZqiv/nX6bE4cC7OdKoyDhiPGFN3ZP2RgnINTT3bF7g4YQMrUW642kdJl6KRXF9qk7NDBEIaH+pEl0hB0+Jdp71SpSiqTRarjJMl4xouPuttLK54=,iv:9NImkDxwGsVGQ9UUVjw61xlyCkbrvq9aRblWwHMun8Y=,tag:jVbn7htvkAd9RGeGG51v7A==,type:str]
+    lastmodified: "2026-08-31T14:21:10Z"
+    mac: ENC[AES256_GCM,data:G2Rq4ufpETugFeHhYhMnygWw6Lam2txKliiKBrJt3scKHlzvy8TUWvrPaQMpkLBI2Pp11iwi0t/07MZz7E12C7WMBUnnib5PlBwAiiVTCHRgb37WHyHo/LmZj5MJe5RIMoBjhDYcBKzsVaquQz/OnZ9wtFUzSsH0++q7Y34+QxM=,iv:ViWKH6Qcy+HyO1xwxyBbsvnSD2Ip2fEHVbveUsLej6k=,tag:+xhwATf0u7ig4visusMsWw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
Implements **item 10** of `docs/plans/deployment-hardening.md` — *Deploy-account sudo on SSH keys instead of a hashed password*.

## What changed

- **`modules/nixos/deploy-rs.nix`** — the deploy user loses `wheel` and its sops password. Its only sudo is the deploy-rs activation path, passwordless, via two scoped `NOPASSWD` rules:
  - `/nix/store/*/activate-rs` (covers `activate`/`wait`/`revoke`; the closure path changes every build)
  - `/run/current-system/sw/bin/rm ^/tmp/deploy-rs-canary-[a-z0-9]*$` (magicRollback's confirmation)
- **Wheel membership replaced where it was load-bearing** (not silently dropped):
  - `nix.settings.trusted-users` — keeps the unsigned-closure copy step working over `ssh-ng`
  - sudo wrapper group (`security.sudo.execWheelOnly`) — now the deploy group, with `coryg` added, so exactly the two SSH accounts can execute sudo
- **`flake.nix`** — `interactiveSudo` removed from both `deploy.nodes`
- **Secrets** — `users/deploy` retired from `secrets/shared.yaml`; the deploy key's private half stored as `private_keys/deploy` in `secrets/operator.yaml` (user-key-only), declared in `modules/home/security/sops-nix.nix` to restore it to `~/.ssh/deploy`
- **Hosts** — the deploy account now authorizes a dedicated `deploy@xps15` key instead of the human's `coryg@xps15`
- **`modules/home/development/ssh.nix`** — a `Host deploy@homelab01 deploy@homelab02` block offers only the deploy key
- **`checks/deploy-sudo.nix`** (new) — VM test modelling `execWheelOnly` that drives the real deploy-rs command shapes; wired into the CI matrix

## Notes for review

- The plan's original sketch used `${config.system.build.activate}/bin/activate-rs`, which does not exist; the real escalation is `<deploy-rs closure>/activate-rs` plus the confirm `rm`. Verified against the pinned deploy-rs and sudo source.
- Dropping `wheel` breaks the deploy in **two** places, not one: sudo exec (via `execWheelOnly`) and the trusted-user copy step. Both are replaced explicitly.
- Plan document updated with a "What landed" section recording these findings.

## Checks run

- `nix fmt -- --ci` clean
- `checks.deploy-sudo` (VM test, passes), `checks.deploy-schema`, `checks.deploy-activate`, `checks.secrets` (47 declarations, incl. the new `private_keys/deploy`)
- CI matrix / flake checks agreement (20 checks)
- All three host toplevels build

Residual: the two live `deploy .#homelab01` / `.#homelab02` runs against the promoted revision remain (per the plan's "done when"). Reviewers with host access can confirm `sudo -u deploy sudo -l` shows only the two rules.