### PR TITLE
fix(digital-garden): keep garden-preview re-rendering from dotted checkouts

### DIFF
--- a/modules/services/digital-garden/lib/preview.nix
+++ b/modules/services/digital-garden/lib/preview.nix
@@ -211,12 +211,16 @@ pkgs.writeShellApplication {
     # the old inode into oblivion and never fires again, so the first save
     # after startup would be the last one the preview ever noticed.
     #
-    # Dotfiles are excluded to match the filter, which ignores
-    # .obsidian/.git/.sync.lock. Without this, Obsidian's own churn in
-    # .obsidian re-renders the site continuously.
+    # Exclude the paths whose churn would re-render for no reason - Obsidian's
+    # own writes to .obsidian, git's to .git, and the .sync.lock marker -
+    # rather than every dotted path. An earlier version excluded all of them
+    # with '/\.', which also silenced a checkout under a dotted directory like
+    # .claude/worktrees/: the watched stylesheet there never re-rendered, and
+    # the loop this command exists to run silently stopped. The filter ignores
+    # all of these, so rendering for them would report work that did not happen.
     cssdir=$(dirname "$css")
     inotifywait -q -m -r -e modify,create,delete,move,close_write \
-      --exclude '/\.' --format '%w%f' "$vault/" "$cssdir/" \
+      --exclude '/(\.obsidian|\.git)(/|$)|\.sync\.lock$' --format '%w%f' "$vault/" "$cssdir/" \
       | while read -r changed; do
         # The watch is on the stylesheet's directory rather than the file (see
         # above), so it also fires for the editor's own scratch files - swap


### PR DESCRIPTION
Problem: garden-preview's watcher excluded events with --exclude '/\.'. Inotifywait matches that against the absolute event path, so a checkout under a dotted directory (like .claude/worktrees/) had its stylesheet events silently dropped and the preview never re-rendered.

Change: narrow the exclusion in modules/services/digital-garden/lib/preview.nix from every dotted path to the paths whose churn would re-render for no reason and that publish-filter.py already ignores (.obsidian, .git, .sync.lock). The server-side digital-garden-watch keeps its '/\.' rule because its vault lives under a non-dotted path.

Verified: reproduced the bug with the old regex; with the new regex inotifywait reports the dotted-checkout stylesheet while excluding .obsidian/.git/.sync.lock; ran the built app from a .claude/worktrees/ checkout and a stylesheet save re-rendered while .obsidian/.git churn did not; nix eval of the app program and nix fmt -- --ci both clean.