### PR TITLE
build(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787797243,
-        "narHash": "sha256-8+Q7NOB7RPajRjA4pbCDLzqH+MTjnG9x6LUPLfL2joA=",
+        "lastModified": 1788199093,
+        "narHash": "sha256-gh09zTgEsbnoWwrNPzIDajc/HoE446Sc3yKDCPFa7Xs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "99c9ec63390f1d8c14d95d9e8b17cc29cfbd4e11",
+        "rev": "f772b7f968365e7b2b70a860c509d214639556fe",
         "type": "github"
       },
       "original": {
@@ -267,11 +267,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1788127064,
-        "narHash": "sha256-fC4A4mde4WeGSynrHUkLZtV/lmValH6Idw/QJn0MUDs=",
+        "lastModified": 1788194298,
+        "narHash": "sha256-Zt7o5H5OUfdXS2wcGlzeoPPQmX7OmbGJ83jZX/9BCfc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3633f4ab859cd646d244802286d916f107ffeda7",
+        "rev": "c5688f72f465acd2dc53167e410f19fd599a9533",
         "type": "github"
       },
       "original": {
@@ -283,11 +283,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1788039129,
-        "narHash": "sha256-pa4Q0qErvCvzCaaUph7Sm37RhR4xvPrYI8Lgz6k85+A=",
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d2f67949798825fe853f7c5d0492b8bf016d3f88",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `flake.lock` update.

The per-host deltas below are recorded in the commit body so they
land in `git log` on merge (ADR 0001).

Each host was built at the current lock and at the updated one, and
the closures compared. All three builds passing is a precondition of
this PR existing at all — but the `nixos ci` gate still has to pass
before it can merge, and merging is what promotes `deploy`.

### homelab01

fuse-overlayfs: 1.17 → 1.18
nixos-manual: 129.9 KiB
nixos-system-homelab01: 26.11.20260829.d2f6794 → 26.11.20260831.34ab990
source: 91.4 KiB

### homelab02

fuse-overlayfs: 1.17 → 1.18
nixos-manual: 129.9 KiB
nixos-system-homelab02: 26.11.20260829.d2f6794 → 26.11.20260831.34ab990
source: 91.4 KiB
unit-script-nfs-mountd-pre: (no version) removed
unit-script-nfs-server-pre: (no version) removed

### xps15

apr-util: 1.6.3 → 1.6.5
aquamarine: 0.14.0 → 0.15.0, 158.9 KiB
calibre: 9.13.0 → 9.14.0, 304.7 KiB
fuse-overlayfs: 1.17 → 1.18
gamescope: 3.16.25 → 3.16.28, 91.5 KiB
initrd-linux: -56.2 KiB
nixos-manual: 129.9 KiB
nixos-system-xps15: 26.11.20260829.d2f6794 → 26.11.20260831.34ab990
nvidia-open: 595.91.07-7.2.2 → 595.99.02-7.2.2
nvidia-settings: 595.91.07 → 595.99.02
nvidia-x11: 595.91.07 → 595.99.02, 10.6 KiB
source: 91.4 KiB
zellij: 0.45.0 → 0.45.1
zellij-unwrapped: 0.45.0 → 0.45.1, 95.7 KiB