### PR TITLE
fix(nvim): use snacks.picker to satisfy obsidian.nvim validation

### DIFF
--- a/configs/nvim/lua/plugins/obsidian-nvim.lua
+++ b/configs/nvim/lua/plugins/obsidian-nvim.lua
@@ -72,7 +72,7 @@ return {
 		---@type obsidian.config
 		opts = {
 			workspaces = { { name = "personal", path = "~/git/personal-notes" } },
-			picker = { name = "snacks.pick" },
+			picker = { name = "snacks.picker" },
 			attachments = { folder = "Files" },
 			ui = { enable = false },
 			legacy_commands = false, -- Just to suppress the annoying warning every startup


### PR DESCRIPTION
obsidian.nvim v3.16.7 (pinned commit 7a2b7caf) added strict startup validation of `picker.name` in commit 96d4806. The only accepted snacks value is `snacks.picker`; the old `snacks.pick` survives only as a backwards-compat shim and fails validation, so the plugin aborted setup with an error about the picker.

- Change `picker.name` from `snacks.pick` to `snacks.picker` in `configs/nvim/lua/plugins/obsidian-nvim.lua`.
- Verified against the plugin source at the pinned commit that `snacks.picker` passes validation and resolves to `obsidian.picker.snacks`.
- Confirmed by user that the startup error no longer occurs.