### PR TITLE
feat(digital-garden): make one masthead, and eight corrections around it

### DIFF
--- a/checks/digital-garden.nix
+++ b/checks/digital-garden.nix
@@ -686,6 +686,16 @@
         # whole trick, so that is what is pinned.
         assert re.search(r'\.table-container\s*{[^}]*\blocal\b', css), \
             "the scroll shadow on a table container is gone"
+        # And room around it. The container had no margin at all, so a table
+        # took whatever the block after it happened to have above it - and a
+        # callout's is 1rem, the same 1rem that separates two paragraphs of one
+        # argument. A table and the callout under it therefore sat at the
+        # spacing of two sentences and read as ONE object with a tinted foot.
+        # The vault makes that adjacency common rather than rare: the markdown
+        # formatter these notes are written with closes the blank line around
+        # a table, so the two arrive with no authored separation to inherit.
+        assert re.search(r'\.table-container\s*{[^}]*\bmargin:', css), \
+            "a table has no room around it, so it merges with whatever follows"
         # And paper, which cannot scroll: the box must stop clipping there, or a
         # wide table prints with its right-hand columns cut off.
         assert re.search(r'@media print\s*{.*\.table-container\s*{[^}]*overflow-x:\s*visible',
@@ -2019,30 +2029,53 @@
         # computed stages instead of published ones would read zero here.
         assert int(counted.group(2)) >= 1, "the hand-written evergreen is not counted"
 
-    with subtest("the composition belongs to the home page alone"):
-        # Item 19: one site title per page. The home page carries it in a bar
-        # of its own - larger, and with the site's links beside it - and
-        # baseof.html drops the small one there; every interior page is the
-        # masthead it has always been, and carries no composition.
+    with subtest("one masthead, on every page, and the tree on the home page alone"):
+        # Item 21. The site had two headers - this bar on the interior pages
+        # and a composition of its own on the landing page, carrying the same
+        # name at twice the size - so the row at the top of the window changed
+        # height on the commonest journey the site has. There is now one bar,
+        # rendered by baseof.html for every page, and what is left on the home
+        # page is the picture.
+        #
+        # Still one site title per page. On the home page the name is that
+        # page's <h1>: the landing page's own title was removed with the
+        # composition, and the site's name is what the page is about, so it
+        # takes the heading rather than the page having none.
         home = served("/")
-        assert '<p class="nameplate-title">' in home, home[:400]
-        assert 'class="masthead-title"' not in home, (
+        assert '<h1 class="masthead-title">' in home, home[:400]
+        assert home.count("masthead-title") == 1, (
             "the home page carries the site title twice"
         )
-        # And the composition is outside the indexed article, for the reason
-        # the bonsai's caption store is: a search for the site would otherwise
+        assert not re.search(r'<article[^>]*>\s*<h1', home), (
+            "the landing page still opens with a title of its own"
+        )
+        # And the tree is outside the indexed article, for the reason the
+        # bonsai's caption store is: a search for the site would otherwise
         # return the home page for the words "notes evergreen growing".
-        assert home.index('class="nameplate"') < home.index("data-pagefind-body"), (
-            "the composition is inside the indexed article"
+        assert home.index('class="garden"') < home.index("data-pagefind-body"), (
+            "the tree is inside the indexed article"
         )
 
-        # The header's link list, and the placeholder rule. An entry with no
+        # The masthead's link list, and the placeholder rule. An entry with no
         # URL renders as muted text and not as a link, so a section can show
         # its shape before every destination exists - the alternative being a
         # 404 shipped on purpose. GitHub has a URL; Projects and Resume do not
         # yet.
-        links = re.search(r'<ul class="nameplate-links">(.*?)</ul>', home, re.S)
+        links = re.search(r'<ul class="masthead-links">(.*?)</ul>', home, re.S)
         assert links, "the header has no link list"
+        # THE LINKS DROP, THEY DO NOT WRAP. On the old landing page the list
+        # was allowed to fold onto a second line, which turned the bar into a
+        # block on a phone - at the one width where the header should cost
+        # least. The row is now fixed at one line and the links leave it one at
+        # a time, from the left, as the bar narrows. The question is asked of
+        # the BAR rather than of the viewport, because the bar is capped at the
+        # measure and it is the bar that runs out of room.
+        assert re.search(r'\.masthead\s*{[^}]*container-type:\s*inline-size', css), \
+            "the masthead is not a container, so the link steps cannot be measured on it"
+        assert re.search(r'@container[^{]*{\s*\.masthead-links', css), \
+            "nothing drops a link when the bar runs out of room"
+        assert not re.search(r'\.masthead-links\s*{[^}]*flex-wrap:\s*wrap', css), \
+            "the masthead's links can wrap onto a second line again"
         assert re.search(
             r'<a href="https://github\.com/[^"]+">GitHub</a>', links.group(1)
         ), links.group(1)
@@ -2062,33 +2095,39 @@
         )
 
         essay = served("/on-gates/")
-        assert 'class="masthead-title"' in essay, essay[:400]
+        # The same bar, with the name as a link rather than as a heading - an
+        # interior page's <h1> is the note's own title - and with the same
+        # links beside it, which is the half of item 21's blend that the
+        # interior pages gained.
+        assert '<a class="masthead-title"' in essay, essay[:400]
+        assert '<h1 class="masthead-title">' not in essay, (
+            "an interior page took the site's name as its heading"
+        )
+        assert re.search(r'<ul class="masthead-links">.*?GitHub', essay, re.S), (
+            "an interior page's masthead carries no links"
+        )
         # The bonsai is matched on its element rather than on the word: the
         # script that grows it is inlined on every page and names the plate it
         # looks for, and finding nothing is how it stays off an essay.
-        for stray in ['class="nameplate"', 'class="colophon"', 'class="bonsai-plate"']:
+        for stray in ['class="garden"', 'class="colophon"', 'class="bonsai-plate"']:
             assert stray not in essay, f"an interior page rendered {stray}"
 
-    with subtest("the home page's header is anchored to the page's own grid"):
-        # The header used to share a CENTRE with the page and not a single
-        # EDGE: at 1440px every interior masthead's rule ran from 400px to
-        # 1040px, exactly the article column, and the nameplate ran from 305px
-        # to 1135px. Nothing on the page lined up with either of its ends, and
-        # a band that lines up with nothing reads as floating over the page
-        # rather than as part of it. That is a geometry fault, invisible to a
-        # grep and obvious in a screenshot, so it is measured here.
+    with subtest("the home page's header and tree are anchored to the page's own grid"):
+        # The home page's header used to share a CENTRE with the page and not a
+        # single EDGE: at 1440px every interior masthead's rule ran from 400px
+        # to 1040px, exactly the article column, and the landing page's ran
+        # from 305px to 1135px. Nothing on the page lined up with either of its
+        # ends, and a band that lines up with nothing reads as floating over
+        # the page rather than as part of it. That is a geometry fault,
+        # invisible to a grep and obvious in a screenshot, so it is measured
+        # here.
         #
-        # The first fix anchored the left end to the prose and the right end
-        # to the wide grid's right edge, and it was half right. The home page
-        # carries no sidenotes, so nothing on it ever reaches that edge: the
-        # header closed 288px past the last character of every paragraph
-        # below it, on a line the page never draws. Anchored to an empty
-        # column it read as hanging off the page instead of floating over it.
-        #
-        # So: BOTH ends on the article column, which is the span every
-        # interior page's masthead rule already has. The name sits directly
-        # above the first line of prose and the rule under the header closes
-        # where every line of prose closes.
+        # It is now the same masthead every page carries (item 21), which no
+        # longer needs a rule of its own to reach those edges: `max-width:
+        # var(--measure); margin-inline: auto` reduces to the article column's
+        # own offset out here. That is arithmetic rather than a coincidence,
+        # and this is what pins it - along with the tree beneath, which is held
+        # to the same two lines by the same declaration.
         machine.succeed(
             "mkdir -p /tmp/np && "
             "cp /var/lib/digital-garden/public/index.html /tmp/np/page.html && "
@@ -2104,8 +2143,8 @@
             "}\n"
             'var marker = document.createElement("div");\n'
             'marker.id = "NP-MEAS";\n'
-            'marker.textContent = "@@" + [box(".nameplate"), box(".layout > article"),\n'
-            '  box(".layout")].join("|") + "@@";\n'
+            'marker.textContent = "@@" + [box(".masthead"), box(".layout > article"),\n'
+            '  box(".layout"), box(".garden")].join("|") + "@@";\n'
             'document.body.appendChild(marker);\n'
             "PROBE"
         )
@@ -2129,10 +2168,10 @@
             "--dump-dom file:///tmp/np/page.html 2>/dev/null"
         )
         m = re.search(r'id="NP-MEAS">@@(.*?)@@', dom, re.S)
-        assert m, "the nameplate probe never ran"
+        assert m, "the masthead probe never ran"
         parts = m.group(1).split("|")
         assert "MISSING" not in parts, f"the probe could not find a box: {parts}"
-        header, article, grid = [
+        header, article, grid, tree = [
             tuple(int(n) for n in part.split(",")) for part in parts
         ]
         # A pixel of slack, because a fractional layout rounds.
@@ -2142,11 +2181,113 @@
         assert abs(header[1] - article[1]) <= 1, (
             f"the header does not end on the prose's right edge: {header} vs {article}"
         )
-        # And the page is genuinely in its wide layout, so that the two
+        # The tree under it spans the same column, so the picture begins and
+        # ends where every line of prose begins and ends.
+        assert abs(tree[0] - article[0]) <= 1 and abs(tree[1] - article[1]) <= 1, (
+            f"the tree does not span the prose column: {tree} vs {article}"
+        )
+        # And the page is genuinely in its wide layout, so that the three
         # assertions above are about the anchored header and not about a
         # narrow page where everything is one centred column anyway.
         assert grid[1] - article[1] > 100, (
             f"the page is not in its wide layout: article {article}, grid {grid}"
+        )
+
+    with subtest("the masthead drops a link before it cuts the site's name"):
+        # The name is the one item in the bar that can be squeezed, so the
+        # order the bar gives way in is a property with a wrong answer: a
+        # reader at 430px saw "Cory Gyarma..." with three links beside it,
+        # which is the site's identity cut to keep its chrome. That shipped,
+        # from container steps measured off a screenshot rather than off the
+        # bar - the row needs 396.5px to hold two links and the second step
+        # was set at 384.
+        #
+        # A screenshot cannot hold this still: it is true or false at every
+        # width, and the failure lives in a forty-pixel window between two
+        # steps. So the bar is swept in a real browser instead. One page load
+        # measures a clone of the masthead inside a box of each width from
+        # 280 to 720px - the clone carries `.masthead`, so it is its own
+        # container and the @container steps resolve against the box - and
+        # reports, for each width, whether the name's text is wider than the
+        # box the name was given and whether the row overflows the bar.
+        #
+        # Both must be no, everywhere. Never cut says the links go first;
+        # never overflow says the answer to "no room" is not a bar hanging off
+        # the page, which is what a name that could not shrink at all would
+        # do. The step widths are reported so a failure says which one moved.
+        machine.succeed(
+            "mkdir -p /tmp/bar && "
+            "cp /var/lib/digital-garden/public/index.html /tmp/bar/page.html && "
+            "cp /var/lib/digital-garden/public/main.*.css /tmp/bar/"
+        )
+        machine.succeed(
+            "cat > /tmp/bar/sweep.js <<'SWEEP'\n"
+            'var bar = document.querySelector(".masthead");\n'
+            'var host = document.createElement("div");\n'
+            'host.style.cssText = "position:absolute;left:-9999px;top:0";\n'
+            "document.body.appendChild(host);\n"
+            "var rows = [];\n"
+            "for (var w = 280; w <= 720; w += 2) {\n"
+            '  var box = document.createElement("div");\n'
+            '  box.style.cssText = "width:" + w + "px";\n'
+            "  var clone = bar.cloneNode(true);\n"
+            "  clone.querySelectorAll('[id]').forEach(function (el) {\n"
+            '    el.removeAttribute("id");\n'
+            "  });\n"
+            "  box.appendChild(clone);\n"
+            "  host.appendChild(box);\n"
+            '  var t = clone.querySelector(".masthead-title");\n'
+            "  var links = Array.prototype.filter.call(\n"
+            "    clone.querySelectorAll('.masthead-links > li'),\n"
+            "    function (li) { return li.offsetParent !== null; }\n"
+            "  );\n"
+            "  rows.push([w, links.length, t.scrollWidth - t.clientWidth,\n"
+            '    clone.scrollWidth - clone.clientWidth].join(","));\n'
+            "  host.removeChild(box);\n"
+            "}\n"
+            'var marker = document.createElement("div");\n'
+            'marker.id = "BAR-SWEEP";\n'
+            'marker.textContent = "@@" + rows.join(";") + "@@";\n'
+            "document.body.appendChild(marker);\n"
+            "SWEEP"
+        )
+        machine.succeed(
+            "python3 - <<'PY'\n"
+            "import re\n"
+            'p = "/tmp/bar/page.html"\n'
+            "s = open(p).read()\n"
+            'sweep = open("/tmp/bar/sweep.js").read()\n'
+            'css = re.search(r"main\\.[0-9a-f]+\\.css", s)\n'
+            'assert css, "no fingerprinted stylesheet on the home page"\n'
+            's = re.sub(r\'href="/main\\.[0-9a-f]+\\.css"\', \'href="\' + css.group(0) + \'"\', s)\n'
+            's = s.replace("</body>", "<script>" + sweep + "</" + "script>" + "</body>", 1)\n'
+            'open(p, "w").write(s)\n'
+            "PY"
+        )
+        dom = machine.succeed(
+            "chromium --headless=new --no-sandbox --disable-gpu "
+            "--disable-dev-shm-usage --allow-file-access-from-files "
+            "--virtual-time-budget=30000 --window-size=1600,1200 "
+            "--dump-dom file:///tmp/bar/page.html 2>/dev/null"
+        )
+        m = re.search(r'id="BAR-SWEEP">@@(.*?)@@', dom, re.S)
+        assert m, "the masthead sweep never ran"
+        cut, overflow, steps, previous = [], [], [], None
+        for row in m.group(1).split(";"):
+            width, shown, clipped, over = (int(n) for n in row.split(","))
+            if clipped > 0:
+                cut.append((width, shown, clipped))
+            if over > 0:
+                overflow.append((width, shown, over))
+            if previous is not None and shown != previous:
+                steps.append((width, previous, shown))
+            previous = shown
+        assert steps, "no width in the sweep changes how many links are shown"
+        assert not cut, (
+            f"the name is cut while links are still shown: {cut[:5]}; steps {steps}"
+        )
+        assert not overflow, (
+            f"the bar overflows rather than dropping a link: {overflow[:5]}; steps {steps}"
         )
 
     with subtest("a renamed note keeps its publication date"):
@@ -2192,5 +2333,27 @@
         assert "on-gates" not in ledger, "the old key lingered after the rename"
         page = served("/on-gates-renamed")
         assert 'datetime="2001-01-01"' in page, page[-400:]
+
+        # ONE DATE ON A NOTE, at the narrow width (item 21). The seeding above
+        # makes this the fixture's only note whose edit date differs from its
+        # publication date, so it is the only place the rule can be seen: the
+        # line under the title carries the EDIT and drops the publication,
+        # because four facts and two dates are wider than a phone and the
+        # wrapped second line pushed the essay down by a whole row at exactly
+        # the width where vertical space is scarcest. The margin has a column
+        # to spend and still carries both.
+        line = re.search(r'<p class="dateline">(.*?)</p>', page, re.S)
+        assert line, "the renamed note has no dateline"
+        line = line.group(1)
+        assert "updated" in line, (
+            f"the note's dateline dropped the edit rather than the publication:\n{line}"
+        )
+        assert 'datetime="2001-01-01"' not in line, (
+            f"the note's dateline carries both dates and so can wrap:\n{line}"
+        )
+        facts = re.search(r'<dl class="margin-facts">(.*?)</dl>', page, re.S)
+        assert facts and 'datetime="2001-01-01"' in facts.group(1), (
+            "the margin lost the publication date"
+        )
   '';
 }

--- a/docs/plans/digital-garden-design.md
+++ b/docs/plans/digital-garden-design.md
@@ -402,6 +402,8 @@ Three ways out, and the choice is a taste decision rather than a measurement:
 
 The first is the recommendation. Nothing is blocked on it.
 
+**Settled, 2026-09-03, by item 21 and not on purpose.** The masthead's name went to 1.25rem because one bar now carries the site's identity on every page and 1.1rem was sized to be ignorable. 20px at weight 600 is past the 18.66px where the large-text allowance starts, so the floor that applies is 3:1 and Lotus's `--brand` clears it at 3.73:1. The hue is unchanged and the decision that chose it stands; what moved was the size, which is the way out this section recommended.
+
 ### Deliberately not changed
 
 The Chroma comment rule keeps fujiGray at 3.67:1 against sumiInk0. That one is genuinely a comment, on code the stylesheet already sets at lower contrast on purpose — the syntax block says so in as many words — and changing it would cost more editor parity than it buys.
@@ -887,6 +889,68 @@ One thing the build made obvious that the plan did not say: on a bounded grid th
 
 Both pauses are behaviour, so the VM check runs the page in headless Chromium rather than grepping for it: the script writes its running state and population back to the canvas as data-attributes, and the check reads those to assert it runs, that it pauses under `prefers-reduced-motion`, and that it pauses out of view — plus the plan's own "not on the home page" pinned as a negative, and the centred-beneath-the-message placement pinned as a positive. No cost over the estimate; the Chromium machinery was already in the test.
 
+## 21. One masthead, and eight things found by reading the site
+
+### The problem
+
+Reported 2026-09-03, after the site had been read rather than looked at. Eight complaints. Two of them are about the header and they resolve together, so they are taken as one:
+
+- **The top row changes height between the home page and a note.** Item 19 gave the landing page a composition of its own, so the site had two headers: a 1.1rem name in a bar on every interior page, and a 2rem name in a bar of its own on the home page. Navigating between them moved the name, the icons and the rule under them. That is the commonest journey the site has, and it was the one that flinched.
+- **The two headers should be one, and it should be the interior one.** Keep the bar's format — one line, a rule under it — take the home page's links into it, and set the type slightly larger so the row is legible rather than ignorable.
+- **The links must not fold onto a second line on a phone.** On the landing page they wrapped, which turned a bar into a block at the one width where a header should cost least. They should drop instead, from the left, since the list is ordered least-important-first.
+
+Then, on the home page:
+
+- **The caption and the colophon read as one thing.** _"Point at any foliage to see the note it grew from"_ and _"18 notes · 1 evergreen · 11 growing · 6 seedlings"_ sat one line apart at the same size in the same grey. They are not one thing: the first is whatever the pointer is on right now, empty until the reader moves it, and the second is a standing fact about the whole garden.
+- **The rule under the tree should go**, and **the landing page's `<h1>` should go** — _"another thing the reader has to get through before they reach the page's content"_.
+
+And on a note:
+
+- **The facts push the prose down when the margin collapses**, which makes crossing the breakpoint feel harsh.
+- **They wrap onto a second line on a phone** whenever a note has been edited, because a publication date, an edit date, a reading time and a maturity are wider than 390px. Show the edit date and cut the publication date.
+
+And everywhere:
+
+- **A table merges with whatever follows it.** Reported against a real note, where a table and the callout under it read as one object with a tinted foot.
+
+### Approach
+
+**One bar, rendered by `baseof.html` for every page, home included.** The name at 1.25rem — between the two sizes it replaces — with the links from `footerLinks` and the two controls to the right of them, and the rule under it. `home.html` keeps the tree and nothing else; the second header is gone rather than reconciled, which is what makes the heights equal by construction instead of by two numbers kept in step.
+
+The name is a link on every page and the `<h1>` on the home page. Removing the landing page's own title would otherwise leave that page with no heading at all, and the site's name is what the page is about, so it takes the heading it should always have had. A link pointing at the page it is on is not written.
+
+**The links drop from the left, and the question is asked of the bar.** `container-type: inline-size` on `.masthead` and three `@container` steps, at 30, 24 and 19.5rem, measured off the rendered bar: with this name and these three links it needs 468px for all of them, 382px for two and 308px for one. The viewport is the wrong thing to ask — the bar is capped at the measure and padded, so it is the bar that runs out of room — and the widths are specific to the words in it, which is why the title is the one item in the row allowed to shrink: a longer name in the host's configuration meets an ellipsis rather than pushing the links off the page.
+
+**The colophon takes `--text` and the caption keeps `--muted`,** with a wider gap between them. That is the right way round: the transient line is the quieter one and the standing fact is set in the ink the page's prose is set in. In Wave the two are a warm cream against a violet grey, in Lotus a blue-black against a warm grey, and in both the difference is a hue rather than only a value.
+
+**One date on a note, at the narrow width.** `dateline.html` drops the publication date when the note has been edited and the line is carrying the whole margin. Which of the two to cut is not a close call: a reader arriving at a note wants to know how current it is, and the edit date answers that. The margin still carries both at the wide width, where there is a column to carry them in. The `/notes/` index keeps both — its rows have two facts rather than four, and there the publication date is what orders the page.
+
+That also settles the harsh transition, and it settles it by making the thing that appears smaller rather than by reserving space for it. Reserving space was the alternative and it was rejected: it costs a permanent blank row between the title and the first paragraph on every desktop note page, which is a fixed price paid on every read to smooth an event that happens while dragging a window.
+
+**A table gets 1.5rem above and below it.** It had none at all — the rule set `overflow-x` and nothing else — so a table took whatever the block after it happened to have above it, and a callout's is 1rem, the same 1rem that separates two paragraphs of one argument. The vault makes that adjacency common rather than rare: the markdown formatter these notes are written with closes the blank line around a table, so a table and what follows it arrive with no authored separation for the page to inherit. The fixture grew the case — a table butted directly against a callout — because it is now a thing the spacing has to survive.
+
+### Shipped, 2026-09-03
+
+The rule under the masthead sits at the same pixel row on the home page, a note and `/notes/` — measured at 1440px, row 104 on all three.
+
+Assertions were added to the VM check and two rewritten, all of them for properties a screenshot cannot hold still: that the home page carries the site's name exactly once and as an `<h1>`, that an interior page carries it as a link and carries the same link list, that the masthead is a container and that something drops a link when it runs out of room, that `.masthead-links` cannot wrap, that a table container has a margin, that a note whose edit date differs from its publication date shows the edit on the dateline and both in the margin, and — added by the correction below — that the bar never cuts the name while a link is still shown. The geometry probe that pinned the old header to the article column now pins the masthead and the tree to it, and the arithmetic it was testing is no longer a rule of its own: `max-width: var(--measure); margin-inline: auto` reduces to the article column's offset out past 80rem, so one declaration holds the bar, the picture and the prose to the same two vertical lines.
+
+The masthead's links do not print. They are three words naming places that cannot be reached from paper, and the rule that prints a URL after a link is scoped to the article on purpose.
+
+### The links went second, 2026-09-03
+
+Reported on the first pass and fixed on the same day: at about 430px the name came out as _"Cory Gyarma…"_ with three links still beside it. The name is the one item in the bar that can be squeezed, so if a step fires late that is what the reader loses — the site's identity cut to keep its chrome, which is exactly backwards.
+
+The cause was arithmetic, not architecture. The steps were estimated off a screenshot, and the estimates were low: the bar needs **396.5px** to hold two links and the second step was set at 384, so there was a forty-pixel window where two links were still asked for and the name paid for them. The widths are now measured in the browser — the title's own text width from a `Range` over its contents, each link's `offsetWidth`, the tools, and the row gap between them — giving 478.5 / 396.5 / 319.5px for three, two and one link, and each step sits about a rem above its number at 31 / 26 / 21rem. The slack is what carries the numbers off this machine: `system-ui` is a different face on every platform, and measuring on the widest of them and rounding up is what makes the order hold everywhere.
+
+The name can still shrink, as the last thing that happens rather than the first. Past the final step there are no links left to give, and a name that could not shrink at all would answer "no room" with a bar hanging off the page — which is a worse failure than an ellipsis, and a failure this site has already met once with tables.
+
+**And the order is now a test rather than a screenshot**, because it is true or false at every width and the fault lived in a forty-pixel window between two steps. `checks/digital-garden.nix` sweeps the bar from 280 to 720px in one page load — a clone of the masthead in a box of each width, which works because the clone carries `.masthead` and so is its own container — and asserts at every one of them that the name's text is never wider than the box it was given and that the row never overflows the bar. Never cut says the links go first; never overflow says the answer to "no room" is not a bar off the edge of the page.
+
+### Cost and risk
+
+One session, plus the correction above. The risk is the three container steps, which are measured against one site title and three link names and will be wrong for a fourth link or a much longer name — wrong in the direction of an ellipsis on the name rather than of a broken bar, which is why the shrink is there. `@container` needs Chrome 105, Safari 16 or Firefox 110; the tree's plate has depended on container queries since item 19, so this adds no floor the site did not already have.
+
 ## Rejected: a graph view
 
 The canonical Quartz feature, and it should not be built here. Nineteen nodes with six edges is not a graph, it is a list with extra steps — the rendered picture would be five connected Lighting notes and thirteen dots. It needs a rendering library, which means either a build-time network fetch or vendoring a canvas library into a site that currently ships zero bytes of framework, and it works badly on the phones that most of this site's readers will use. Items 3 and 4 deliver what a reader actually wants from a graph view, which is "what else is near this", at a fraction of the cost. Revisit at a hundred notes if the link density has gone up with them.
@@ -924,6 +988,8 @@ The order is fixed by dependencies for the first two and by taste after that.
 7. **Item 18b, the bonsai taste pass.** Unestimated by design. Generate many, look at them, tune the three levers. Done 2026-08-31; the three levers were the wrong three, and the trunk was the one that mattered.
 8. **Item 19, the home page.** Last, because it wants the tree finished. Done 2026-08-31; the tree being finished is what decided the composition's width, so the sequencing earned its keep.
 9. **Item 20, the 404.** Any time; it depends on nothing and blocks nothing.
+
+Item 21 was not sequenced either, for item 11's reason: every part of it came from reading the finished site, and eight corrections that all land on the header and on the spacing around it are one session rather than eight PRs.
 
 Item 7 is the only optional item still outstanding — item 8 shipped on 2026-08-28 and the table has been corrected. It is less urgent after item 15 — the maturity sprout on an internal link already answers most of "is this worth following", which was the value the hover preview was reaching for — so if it is ever taken it should be taken as the `title` version first, and judged against a site that already has the marks.
 

--- a/modules/services/digital-garden/digital-garden.nix
+++ b/modules/services/digital-garden/digital-garden.nix
@@ -435,11 +435,16 @@ in
         Resume = "";
       };
       description = ''
-        Links shown in the site footer, and in the home page's header, as a
-        name -> URL map. Empty by default, which renders no list at all rather
-        than an empty one. One list rather than two so that "where else to
-        find me" cannot say different things at the top and the bottom of the
-        same page.
+        Links shown in the site footer, and in the masthead at the top of
+        every page, as a name -> URL map. Empty by default, which renders no
+        list at all rather than an empty one. One list rather than two so that
+        "where else to find me" cannot say different things at the top and the
+        bottom of the same page.
+
+        The masthead drops them from the LEFT as it runs out of room, rather
+        than wrapping them onto a second line, so the order here is an order
+        of increasing importance: whatever sorts first is the first thing a
+        narrow window loses. Hugo ranges the map in key order.
 
         An entry whose URL is the empty string renders as muted text instead
         of a link, so a destination that does not exist yet can still take its

--- a/modules/services/digital-garden/lib/hugo/assets/main.css
+++ b/modules/services/digital-garden/lib/hugo/assets/main.css
@@ -84,10 +84,8 @@
   --gutter: 3rem;
   /* One line of the bonsai's caption: its own size times its own leading. The
    * caption holds two of these open so that a long note's name does not move
-   * the page, and the colophon across the composition from it is lifted by
-   * one, so the two small grey lines that close the header sit on the same
-   * line as each other. Three rules have to agree about that number, so it is
-   * written once. */
+   * the page as the pointer crosses the foliage. Two rules have to agree about
+   * that number, so it is written once. */
   --caption-line: calc(0.85rem * 1.3);
   color-scheme: light;
 }
@@ -182,26 +180,156 @@ footer {
 
 /* ── masthead ───────────────────────────────────────────────────────────── */
 
+/* ONE bar, on every page (item 21). The site's name, where else to find me,
+ * and the two controls, with a rule under them.
+ *
+ * It replaces a pair: this bar on the interior pages and a composition of its
+ * own on the landing page, which carried the same name at 2rem with the same
+ * links and the same two icons. Two headers is two heights - 1.1rem of name
+ * against 2rem of it - so the row at the top of the window changed size, and
+ * the name, the icons and the rule under them all moved, every time a reader
+ * went from the landing page to a note or back. That is the commonest journey
+ * on the site and it was the one that flinched.
+ *
+ * The blend keeps this bar's FORMAT - one line, one rule - and takes the
+ * landing page's LINKS, at a size between the two. 1.25rem rather than
+ * 1.1rem: this row is now the whole of the site's identity on every page,
+ * where the old one was a small label under an assumption that the landing
+ * page carried the identity elsewhere.
+ *
+ * `container-type: inline-size` makes the bar the containment context the
+ * link rules below query. The bar's width is min(measure, viewport - padding)
+ * rather than the viewport's, and it is the bar running out of room that
+ * decides how many links fit - so the question is asked of the box that has
+ * the answer. */
 .masthead {
+  container-type: inline-size;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  /* Between the GROUPS - the name, the links, the tools. Each group sets its
+   * own internal gap, which is tighter. */
+  gap: 1.25rem;
   padding-bottom: 0.75rem;
   margin-bottom: 2rem;
   border-bottom: 1px solid var(--border);
 }
 
+/* An <a> on every page and the <h1> on the home page, which is why the
+ * heading's own margin is reset here: the landing page's title used to be an
+ * h1 over the prose and is now this, so the page keeps a heading without
+ * carrying the site's name twice. See baseof.html. */
 .masthead-title {
+  /* Grows to push the links and the tools to the right edge, and is the one
+   * item in the row allowed to SHRINK: `min-width: 0` releases the flex
+   * item's automatic minimum so that a name too long for the bar is cut with
+   * an ellipsis rather than shouldering the links off the page. Everything
+   * else in the row is nowrap and holds its size. */
   flex-grow: 1;
-  font-size: 1.1rem;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0;
+  font-size: 1.25rem;
   font-weight: 600;
+  line-height: 1.2;
   color: var(--brand);
   text-decoration: none;
   white-space: nowrap;
 }
 
-.masthead-title:hover {
+a.masthead-title:hover {
   text-decoration: underline;
+}
+
+/* Where else to find me, from the same `footerLinks` the footer renders. A
+ * list, not a paragraph of links: these are a set of destinations and the
+ * markup should say so, for the same reason the footer's does.
+ *
+ * THEY DROP, THEY DO NOT WRAP. On the old landing page this list was allowed
+ * to fold onto a second line, which turned the bar into a block on a phone -
+ * the one width where the header should cost least. Here the row is fixed at
+ * one line and the links leave it one at a time as the bar narrows.
+ *
+ * From the LEFT, because the list is ordered least-important first (the
+ * footer reads in the same direction), so the first thing to go is the first
+ * thing named. Which link that is belongs to the host's configuration and not
+ * to this file - `footerLinks` is a map and Hugo ranges it in key order - so
+ * these rules name POSITIONS and never names.
+ *
+ * THE LINKS GO BEFORE THE NAME DOES. The name is the one item in the bar that
+ * can be squeezed, so if a step fires late the reader sees "Cory Gyarma..."
+ * with three links still beside it - the site's identity cut to keep its
+ * chrome, which is exactly backwards. That shipped once, from steps measured
+ * off a screenshot: the bar needs 396.5px to hold two links and the second
+ * step was set at 384.
+ *
+ * The widths are now measured in the browser, off the rendered bar - the
+ * title's own text width from a Range over its contents, each link's
+ * offsetWidth, the tools, and the row's gap between them:
+ *
+ *   3 links  158.5 + 20 + (62 + 20 + 57 + 20 + 57) + 20 + 64  =  478.5px
+ *   2 links  158.5 + 20 +           (57 + 20 + 57) + 20 + 64  =  396.5px
+ *   1 link   158.5 + 20 +                      57  + 20 + 64  =  319.5px
+ *
+ * and each step sits about a rem above its number: 31, 26 and 21rem. The slack
+ * is what carries the numbers off this machine - `system-ui` is a different
+ * face on every platform, and the same fourteen characters are a few per cent
+ * wider here (DejaVu) than in SF or Segoe UI, so measuring on the widest of
+ * them and rounding up is what makes the order hold everywhere.
+ *
+ * The title can still shrink, as the last thing that happens rather than the
+ * first: past the final step there are no links left to give, and a site name
+ * longer than a bar has to end somewhere. An ellipsis is a better failure than
+ * a bar that overflows the page, which is what a name that cannot shrink at
+ * all would do. checks/digital-garden.nix sweeps the bar from 280 to 720px in
+ * a live browser and asserts the name is never the thing that gives way. */
+.masthead-links {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.95rem;
+  white-space: nowrap;
+}
+
+@container (max-width: 31rem) {
+  .masthead-links > li:nth-child(-n + 1) {
+    display: none;
+  }
+}
+
+@container (max-width: 26rem) {
+  .masthead-links > li:nth-child(-n + 2) {
+    display: none;
+  }
+}
+
+@container (max-width: 21rem) {
+  .masthead-links {
+    display: none;
+  }
+}
+
+/* A destination that does not exist yet: the same list, in the muted grey the
+ * rest of the site uses for text that is there to be read rather than acted
+ * on. It has to be legible - it is naming a real thing that is coming - and it
+ * has to be plainly not a link, which is the whole reason it is not one.
+ *
+ * No underline, no cursor change, no hover: everything a link does, it does
+ * not do. See _partials/site-link.html for why an empty URL renders this and
+ * not a link to a page that would 404. */
+.link-placeholder {
+  color: var(--muted);
+}
+
+/* The two controls travel as one group, with the tight gap two icons want
+ * rather than the row's gap between groups. */
+.masthead-tools {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 /* The controls are buttons, not boxes. A bordered field containing the word
@@ -239,232 +367,83 @@ footer {
 
 /* ── the home page ──────────────────────────────────────────────────────── */
 
-/* One composition: the name at scale, the garden counted under it, and the
- * tree beside the pair — docs/plans/digital-garden-design.md, item 19. The
- * landing page used to be an h1 and a list with a large tree above them,
- * which was two unrelated things sharing a screen.
+/* What is left of the landing page's composition once the masthead above
+ * became the site's only header (item 21): the tree, and the garden counted
+ * under it. The name, the links and the tools are in that bar with every
+ * other page's, and the page's <h1> is the name in it.
  *
- * This is where the 2026-08-31 decision spends its one purely visual change:
- * the stylesheet has nothing above 1.75rem anywhere else, so the site has no
- * scale contrast, and it is bought here and nowhere else. It does not reopen
- * item 6 — the face is still the system stack, and a name at 4.25rem is a
- * size rather than a change of voice. */
-
-/* The header is a masthead BAR and a picture under it.
+ * The same span as the masthead and as the prose - the measure, centred - so
+ * the picture begins and ends on the two lines everything else on the page
+ * begins and ends on. Past 80rem those are the article column's edges (see
+ * the grid below: the arithmetic makes `max-width: measure; margin: auto` land
+ * exactly there), which is what the old header needed a rule of its own to
+ * reach.
  *
- * The composition this replaces set the name beside the tree, and the fault it
- * had was geometric rather than decorative: the band ran from the article
- * column's left edge to the wide grid's RIGHT edge, 18rem past where every
- * line of prose below it stops. The reasoning for that right-hand anchor was
- * that it ends "where the page's widest element ends" - but the home page
- * carries no sidenotes, so nothing else on it ever reaches that edge, and the
- * rule under the header closed on a line that is never drawn. A band anchored
- * to an empty column reads as hanging off the page, which is what it was.
- *
- * The header is now exactly the article column, at every width. That is the
- * same span as the masthead rule on every interior page, so the home page
- * stops being the one page whose header is a different width from its body,
- * and nothing can hang off it because there is nothing to its right.
- *
- * Inside it, the two parts stop competing. The words are a BAR - the row the
- * tools already had, with the name and the links moved into it - and the tree
- * has the whole measure under it. The name giving up its column is the trade
- * this composition makes and the one the old one would not: the tree is the
- * page's subject, the name is its label, and sizing them as peers is what
- * left one column full and the other half empty.
- *
- * Three text blocks became one. The blurb is gone (see home.html), and the
- * count moved under the tree, where it captions the picture it counts. */
-.nameplate {
-  display: grid;
-  /* The bar: name hard left, links and tools together on the right, and the
-   * measure's worth of space between them. The tree and the count then span
-   * the whole of it. */
-  grid-template-columns: auto minmax(0, 1fr) auto auto;
-  grid-template-areas:
-    "title .     links tools"
-    "tree  tree  tree  tree"
-    "count count count count";
-  /* Centre, not baseline. Baseline sets the name, the links and the icons on
-   * one line - but an icon has no letterforms, so its box BOTTOM lands on the
-   * text baseline and it rides half a line above the words beside it. What
-   * the eye compares here is the optical middle of a 2rem name, a 1rem link
-   * and an 18px glyph, which is what centring aligns. It is also what
-   * `.masthead` does on every interior page. */
-  align-items: center;
-  /* Stretch, not centre. `.bonsai-plate` is an inline-size container, so its
-   * own contents cannot size it: under `justify-items: center` the track
-   * shrinks to fit a box whose width depends on the track, the whole thing
-   * resolves to zero and the tree disappears. */
-  justify-items: stretch;
-  column-gap: 1.25rem;
-  width: auto;
+ * AND NO RULE UNDER IT. There was one, and it was the old header's - the line
+ * that closed the composition the name and the tree were both inside. With
+ * the header out of it, a rule here separates the picture from the sentences
+ * that introduce it, which is the one pair on this page that belongs
+ * together. */
+.garden {
   max-width: var(--measure);
-  /* And the rule an interior page draws under its masthead, drawn here under
-   * the whole composition. */
-  padding-bottom: 1.25rem;
-  border-bottom: 1px solid var(--border);
   margin: 0 auto 3rem;
 }
 
-/* The wrapper stops being a box so the name and the links can join the bar as
- * grid items of the header itself, without the template having to un-group
- * what it groups for good reasons. Inherited properties still pass THROUGH
- * `display: contents`, which is why the alignment below is set here rather
- * than on each child. */
-.nameplate-id {
-  display: contents;
-  text-align: left;
-}
-
-.nameplate-title {
-  grid-area: title;
-  /* Held on one line: the bar's middle column is what gives way first, and a
-   * name that wraps inside a bar turns the row into a block. Released again
-   * at the phone width below, where the bar breaks up anyway. */
-  white-space: nowrap;
-}
-
-.nameplate-links {
-  grid-area: links;
-  justify-content: flex-end;
-}
-
-.nameplate-tools {
-  grid-area: tools;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  justify-self: end;
-  /* The old composition gave the tools a band of their own and a rag of space
-   * under it. In a bar that margin is part of what is being centred, so it
-   * lifts the icons off the line the words sit on. */
-  margin-bottom: 0;
-}
-
-/* Below this the bar cannot hold the name and three links on one line. It
- * breaks into name-and-tools over links, which is the same reading order at
- * the same left edge - not a different composition. Nothing centres. */
-@media (max-width: 34rem) {
-  .nameplate {
-    grid-template-columns: minmax(0, 1fr) auto;
-    grid-template-areas:
-      "title tools"
-      "links links"
-      "tree  tree"
-      "count count";
-    row-gap: 0.75rem;
-  }
-
-  .nameplate-title {
-    white-space: normal;
-  }
-
-  .nameplate-links {
-    justify-content: flex-start;
-  }
-}
-
-.nameplate-title {
-  margin: 0;
-  /* The interior masthead's title is 1.1rem, so this is the same words at
-   * about twice the size: enough that the landing page is plainly the landing
-   * page, not so much that it competes with the picture under it. It was
-   * 4.25rem, which is what the name costs when it is a column of its own
-   * rather than a line in a bar.
-   *
-   * `break-word` is for the title this file cannot see - a single very long
-   * word would otherwise push the bar past the measure. */
-  font-size: clamp(1.5rem, 4vw, 2rem);
-  overflow-wrap: break-word;
-  line-height: 1.1;
-  font-weight: 600;
-  /* Type set this large looks loose at the tracking that suits a 1.1rem
-   * masthead; a name is one word-group and should read as one. */
-  letter-spacing: -0.02em;
-  color: var(--brand);
-}
-
-/* Where else to find me: the same links the footer carries, at the top of the
- * one page that is about the site rather than about a note. One list in the
- * configuration, so the two cannot drift apart.
- *
- * A list, not a paragraph of links: these are a set of destinations, and the
- * markup should say so for the same reason the footer's does. */
-.nameplate-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem 1.25rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  font-size: 0.95rem;
-}
-
-/* A destination that does not exist yet: the same list, in the muted grey the
- * rest of the site uses for text that is there to be read rather than acted
- * on. It has to be legible - it is naming a real thing that is coming - and it
- * has to be plainly not a link, which is the whole reason it is not one.
- *
- * No underline, no cursor change, no hover: everything a link does, it does
- * not do. See _partials/site-link.html for why an empty URL renders this and
- * not a link to a page that would 404. */
-.link-placeholder {
-  color: var(--muted);
-}
-
-/* The count sits under the tree, on the caption's own line, because it is the
- * one line of text on this page that describes the PICTURE: eighteen notes is
- * exactly what the eighteen clumps of foliage are. Beside the name it was a
- * fourth block of masthead copy; under the tree it is a plate's label, and
- * the caption and the count read as one two-line note about the picture.
- *
- * Centred here and nowhere else. The bar above it is set to the two edges of
- * the measure and the tree fills that measure; a picture's caption centres on
- * the picture. */
-.nameplate .colophon {
-  grid-area: count;
-  margin: 0;
-  text-align: center;
-}
-
-/* The garden counted, from item 14's model — see _partials/colophon.html for
- * where the numbers come from. Small, quiet and spaced: it is a caption to
- * the name above it and to the tree beside it, and the two are the same
- * count seen twice. Tabular figures so the digits sit in a row rather than
- * shuffling with the vault. */
-.colophon {
-  margin: 0.9rem 0 0;
-  font-size: 0.8rem;
-  line-height: 1.5;
-  color: var(--muted);
-  letter-spacing: 0.04em;
-  font-variant-numeric: tabular-nums;
-}
-
-/* In the composition the tree is not a centred block with a page of its own:
- * the grid places it and the space around it is the composition's.
- *
- * `container-type: inline-size` is the whole of the fix for "the tree does not
- * fill its column". The plate's width now comes from the grid track, and the
- * TYPE is sized from the plate below - so the picture's right edge and the
- * header's right edge are the same line at every viewport and for every
- * vault. Before this the band was sized by the layout and the tree by the
- * viewport, and nothing made the two agree: at 1440px the picture stopped
- * 74px short of its own rule.
+/* `container-type: inline-size` is the whole of the fix for "the tree does not
+ * fill its column". The plate's width comes from this box, and the TYPE is
+ * sized from the plate - so the picture's right edge and the prose's right
+ * edge are the same line at every viewport and for every vault. Before this
+ * the band was sized by the layout and the tree by the viewport, and nothing
+ * made the two agree: at 1440px the picture stopped 74px short of its own
+ * rule.
  *
  * The top margin is bigger than it looks. The crown's first row has ink in it
  * from the very top of the box, so the gap the reader sees above the tree is
  * this number almost exactly; the gap BELOW is padded by an empty line box -
  * see .bonsai's margin-block-end. */
-.nameplate .bonsai-plate {
-  grid-area: tree;
+.garden .bonsai-plate {
   container-type: inline-size;
   width: auto;
   min-width: 0;
   max-width: none;
   overflow: visible;
-  margin: 2.5rem 0 0;
+  margin: 1.5rem 0 0;
+}
+
+/* The count sits under the tree, on the caption's own line, because it is the
+ * one line of text on this page that describes the PICTURE: eighteen notes is
+ * exactly what the eighteen clumps of foliage are.
+ *
+ * Centred here and nowhere else. The tree fills the measure; a picture's
+ * caption centres on the picture. */
+.garden .colophon {
+  text-align: center;
+}
+
+/* The garden counted, from item 14's model — see _partials/colophon.html for
+ * where the numbers come from. Tabular figures so the digits sit in a row
+ * rather than shuffling with the vault.
+ *
+ * IT IS NOT THE CAPTION, AND IT MUST NOT LOOK LIKE IT. Directly above it sits
+ * `.bonsai-caption`, which is the same size and was the same grey, so the two
+ * read as one four-line block - and they are not one thing: the caption is
+ * what the pointer is on right now, empty until the reader moves it, and this
+ * is a standing fact about the whole garden. Same colour, same size, one
+ * line apart, and nothing on the page said which was which.
+ *
+ * So the count takes --text and the caption keeps --muted. That is the right
+ * way round: the transient thing is the quieter one, and the fact that is
+ * always true is the one set in the colour the page's own prose is set in.
+ * The extra space above is the second half of the separation - a gap wider
+ * than the leading inside either of them, so that the two never read as
+ * consecutive lines of one paragraph. */
+.colophon {
+  margin: 1.4rem 0 0;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--text);
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
 }
 
 /* ── prose ──────────────────────────────────────────────────────────────── */
@@ -1003,6 +982,23 @@ mark {
  * right at every width without anything having to measure the table. */
 .table-container {
   overflow-x: auto;
+  /* Room above and below, and more of it than the paragraph rhythm gives.
+   *
+   * A table had none at all: the rule set `overflow-x` and nothing else, so
+   * the box took whatever margin its neighbour happened to have below it - and
+   * a callout's is 1rem, the same 1rem that separates two paragraphs of one
+   * argument. A table and the callout under it therefore sat at the spacing of
+   * two sentences and read as ONE object with a tinted foot, which is
+   * precisely what they are not. The vault makes this common rather than rare:
+   * the markdown formatter used on these notes closes the blank line around a
+   * table, so a table and whatever follows it arrive as adjacent blocks with
+   * no authored separation for the page to inherit.
+   *
+   * 1.5rem, not more: a table is part of the argument around it and should not
+   * read as an interlude. It is enough to be plainly a gap rather than a line
+   * of leading, which is the whole job. Margins collapse, so a table between
+   * two paragraphs takes 1.5rem at each end rather than 1.5 plus their 1. */
+  margin: 1.5rem 0;
   background:
     linear-gradient(to right, var(--bg) 60%, transparent) left / 2rem 100% no-repeat
       local,
@@ -1366,49 +1362,25 @@ h4:hover > .heading-anchor,
     align-items: baseline;
   }
 
-  /* The home page's header, anchored to the grid above.
+  /* The home page's header used to need a rule here, anchoring it to this
+   * grid, and it does not any more: it is not a header of its own, it is the
+   * masthead every page carries (item 21).
    *
-   * This is the fix for "the header feels disconnected from the page", and
-   * the cause turned out not to be its width. At 1440px every interior page's
-   * masthead rule runs from 400px to 1040px - exactly the article column, so
-   * it begins and ends on the prose beneath it. The nameplate ran from 305px
-   * to 1135px: it shared a CENTRE with the page and not a single EDGE, so
-   * there was nothing on the page for either end of it to land on, and a band
-   * that lines up with nothing reads as floating over the page rather than as
-   * part of it.
+   * That header's fault is worth keeping, because it is what the arithmetic
+   * below avoids. At 1440px every interior masthead ran from 400px to 1040px
+   * - exactly the article column, so it began and ended on the prose beneath
+   * it. The landing page's ran from 305px to 1135px: it shared a CENTRE with
+   * the page and not a single EDGE, so there was nothing on the page for
+   * either end of it to land on, and a band that lines up with nothing reads
+   * as floating over the page.
    *
-   * The first fix for that anchored the left end to the prose and the right
-   * end to the grid's right edge. It was half right, and the half it got
-   * wrong is why this reads differently now: the home page carries no
-   * sidenotes, so nothing on it ever reaches that right edge. The header's
-   * right end - and the rule under it - closed 288px past the last character
-   * of every paragraph below, on a line the page never draws. Anchored to an
-   * empty column, it read as hanging off the page rather than as floating
-   * over it, which is a different fault at the same address.
-   *
-   * It now begins AND ends on the article column: the same two lines every
-   * interior page's masthead rule uses, and the only two this layout has that
-   * anything is ever set against. `max-width: var(--measure)` on the base
-   * rule already fixes the width, so all this does is stop the header
-   * centring itself in the page and set its left edge on the prose.
-   *
-   * The arithmetic is the grid's own, written out rather than inherited,
-   * because the header is not inside .layout: the offset is where the grid's
-   * left edge falls in this container, plus one margin column and one gutter.
-   * Both terms are the same tokens .layout is built from, so the two cannot
-   * drift.
-   *
-   * Only out here. Below this breakpoint the page is a single centred column
-   * with no margins and so no vertical lines to anchor to, and the header
-   * centres with the prose it sits over - which is the same relationship, on
-   * a page that has only one edge to have it with. */
-  .nameplate {
-    margin-left: calc(
-      (100% - (var(--measure) + 2 * (var(--margin-col) + var(--gutter)))) / 2 +
-        var(--margin-col) + var(--gutter)
-    );
-    margin-right: 0;
-  }
+   * `max-width: var(--measure); margin-inline: auto` lands on the article
+   * column by itself out here, and not by luck. The masthead's left edge is
+   * (W - measure)/2; the article's is (W - (measure + 2*(margin + gutter)))/2
+   * + margin + gutter, and the two reduce to the same expression. So the one
+   * declaration on the base rule holds the masthead, the tree and the prose to
+   * the same two vertical lines at every width past this breakpoint, with no
+   * second copy of the grid's arithmetic to keep in step. */
 
   .layout > article {
     grid-column: 2;
@@ -2133,8 +2105,15 @@ pagefind-modal {
    * nothing; the heading anchors are a hover affordance for a hover that
    * cannot happen; and the arrow back to a footnote's reference is a jump on a
    * page that is already in the reader's hand. The 404's Game of Life is
-   * decoration that reports nothing, so it does not print either. */
+   * decoration that reports nothing, so it does not print either.
+   *
+   * The masthead's links go with them. They are three words naming places
+   * that cannot be reached from paper, and the rule that prints a URL after a
+   * link is scoped to the article on purpose - so printing them would put
+   * three dead words above every essay. The name stays: it says whose sheet
+   * this is. */
   .icon-button,
+  .masthead-links,
   .heading-anchor,
   .footnote-backref,
   .life {

--- a/modules/services/digital-garden/lib/hugo/fixture/_Slip_Box/Every Element.md
+++ b/modules/services/digital-garden/lib/hugo/fixture/_Slip_Box/Every Element.md
@@ -150,6 +150,19 @@ rather than be cut into stacked fragments:
 | -------------------------------------------------------------------- | ----------- |
 | `https://example.invalid/a/very/long/path/that/never/breaks/anywhere` | It is long. |
 
+And a table with nothing between it and what follows, because the markdown
+formatter these notes are written with closes the blank line around a table.
+This is the case the spacing has to survive: the vault ships it, and with no
+margin of its own the table sat at paragraph distance from the callout under
+it and the two read as one object.
+
+| Supplier    | Unit   | Minimum |
+| ----------- | ------ | ------- |
+| Direct      | $18.40 | 500     |
+| Distributor | $24.10 | 1       |
+> [!warning] Read the minimum before the price
+> The direct price is the better one only at a volume this project does not have.
+
 ## An image
 
 Diagrams in the vault are frequently light-background scans and exports, which is the case worth looking at on a dark page:

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/colophon.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/colophon.html
@@ -1,7 +1,15 @@
 {{/*
-  The garden, counted. Item 19's line under the site title, and every number
-  in it is item 14's model read back off the frontmatter the filter already
-  wrote — nothing here computes a stage, it only counts the ones published.
+  The garden, counted. The line under the tree on the home page, and every
+  number in it is item 14's model read back off the frontmatter the filter
+  already wrote — nothing here computes a stage, it only counts the ones
+  published.
+
+  It is set in the page's own ink rather than in the muted grey, which is not
+  a decoration: directly above it sits the bonsai's caption, the same size and
+  once the same colour, and the two read as one four-line block. They are not
+  one thing — the caption is whatever the pointer is on right now and this is
+  a standing fact about the whole garden — so the standing fact takes the
+  louder colour. See `.colophon` in the stylesheet.
 
   `site.RegularPages` is exactly the published notes: the landing page is the
   home kind and /notes/ is a section list, so neither is in it. That is the

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/dateline.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/dateline.html
@@ -25,15 +25,33 @@
 
   The last edit shows only when it is a different day — "published and
   modified on the same date" is noise on an essay.
+
+  ONE DATE ON A NOTE, NOT TWO. Where this line is a note's whole margin
+  (`facts`) and the note has been edited since it was published, the
+  publication date is dropped and only the edit is shown. That is item 21's
+  narrow-width rule and it is about the line fitting: four facts and two dates
+  are wider than a phone, so the line wrapped, and a wrapped second line under
+  the title pushes the essay down by a whole row at exactly the width where
+  vertical space is scarcest. Which of the two dates to cut is not a close
+  call — a reader arriving at a note wants to know how current it is, and the
+  edit date answers that while the publication date answers a question about
+  the note's history. The margin still carries both at the wide width, where
+  there is a column to carry them in.
+
+  The index keeps both. Its rows have two facts rather than four, so they fit,
+  and there the publication date is what orders the page.
 */}}
 {{ $page := .page }}
 {{ $facts := .facts }}
+{{ $updated := and (not $page.Lastmod.IsZero) (ne ($page.Lastmod.Format "2006-01-02") ($page.Date.Format "2006-01-02")) }}
 {{ if not $page.Date.IsZero }}
   <p class="dateline">
-    <span>
-      <time datetime="{{ $page.Date.Format "2006-01-02" }}">{{ $page.Date.Format "2 Jan 2006" }}</time>
-    </span>
-    {{ if and (not $page.Lastmod.IsZero) (ne ($page.Lastmod.Format "2006-01-02") ($page.Date.Format "2006-01-02")) }}
+    {{ if not (and $facts $updated) }}
+      <span>
+        <time datetime="{{ $page.Date.Format "2006-01-02" }}">{{ $page.Date.Format "2 Jan 2006" }}</time>
+      </span>
+    {{ end }}
+    {{ if $updated }}
       <span>
         updated
         <time datetime="{{ $page.Lastmod.Format "2006-01-02" }}">{{ $page.Lastmod.Format "2 Jan 2006" }}</time>

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/masthead-tools.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/masthead-tools.html
@@ -1,14 +1,19 @@
 {{/*
-  Search and theme, the site's two controls. A partial because they appear in
-  two places that are not the same element: the masthead on every interior
-  page, and the home page's composition, which is that page's masthead and is
-  laid out as one grid (see home.html, item 19). Duplicating the markup would
-  duplicate the ids the scripts in baseof.html bind to, so there is one copy
-  and only one of the two places renders per page.
+  Search and theme, the site's two controls, in the one masthead every page
+  now carries (item 21). It was a partial because the markup appeared in two
+  templates and the ids the scripts in baseof.html bind to must exist exactly
+  once per page; the home page's second header is gone, so it is now simply
+  where these two are written.
+
+  They are wrapped in a box of their own so that the pair travels together as
+  one item of the masthead's row, with its own tight gap between the glyphs.
+  Loose in the row they took the row's gap, which is the distance between the
+  name and the links and much too far apart for two icons that are one group.
 
   The controls are buttons, not boxes: a bordered field containing the word
   "Search" reads as an input you can type into, and this one opens a dialog.
 */}}
+<div class="masthead-tools">
 <button
   class="icon-button"
   id="search-open"
@@ -24,3 +29,4 @@
 <button class="icon-button" id="theme-toggle" aria-label="Change theme">
   {{ partial "icon-theme.html" . }}
 </button>
+</div>

--- a/modules/services/digital-garden/lib/hugo/layouts/_partials/site-link.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/_partials/site-link.html
@@ -1,5 +1,6 @@
 {{- /*
-  One entry of `footerLinks`, in the footer and in the home page's nameplate.
+  One entry of `footerLinks`, in the footer and in the masthead every page
+  carries.
 
   An entry whose URL is empty renders as MUTED TEXT rather than as a link. That
   is what lets the header show the shape of the section - GitHub, Projects,

--- a/modules/services/digital-garden/lib/hugo/layouts/baseof.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/baseof.html
@@ -99,19 +99,56 @@
   <body>
     <div class="page">
       {{/*
-        Every page but the home page. The home page's masthead IS its
-        composition - the same bar as this one, carrying the site's links as
-        well, with the tree under it - so it renders its own in home.html
-        (item 19) rather than taking a title here and another below, which
-        would be two mastheads on one page. The tools themselves are shared,
-        so the ids the scripts below bind to exist exactly once either way.
+        ONE masthead, on every page including the home page (item 21). It used
+        to be two: this bar on the interior pages, and a composition of its own
+        in home.html that carried the same name at twice the size along with
+        the site's links. Two headers meant two heights, and the difference was
+        visible as movement in the name, the icons and the rule under them
+        every time a reader crossed between the landing page and a note - which
+        is the commonest navigation this site has.
+
+        So the bar is the blend the two asked for. It keeps the interior
+        page's format - one line, the rule under it - and takes the home
+        page's links, at a size between the two: 1.25rem rather than 1.1rem,
+        because this row is now the whole of the site's identity on every page
+        and the old one was set to be ignorable.
+
+        The home page's remaining composition is the tree, which home.html
+        renders under this. The tools are still a partial rather than markup
+        here, but the reason has changed: they used to appear in one of two
+        places and now they appear in one, so the partial is simply where they
+        are written.
+
+        The name is a LINK on every page but the home one, where it is the
+        page's <h1>. That is not a flourish: the landing page's own title had
+        been an h1 over the prose under the tree, and removing it (item 21)
+        would have left the page with no heading at all. The site's name is
+        what that page is about, so it takes the heading it always should
+        have had, and a link pointing at the page it is on is not written.
       */}}
-      {{ if not .IsHome }}
-        <header class="masthead">
+      <header class="masthead">
+        {{ if .IsHome }}
+          <h1 class="masthead-title">{{ site.Title }}</h1>
+        {{ else }}
           <a class="masthead-title" href="{{ "/" | relURL }}">{{ site.Title }}</a>
-          {{ partial "masthead-tools.html" . }}
-        </header>
-      {{ end }}
+        {{ end }}
+        {{/*
+          Where else to find me, from the same `footerLinks` the footer
+          renders, so that the answer is one list in the host's configuration
+          and not two that drift. Nothing renders when none are configured.
+
+          They drop from the LEFT as the bar runs out of room, rather than
+          wrapping onto a second line - see `.masthead-links` in the
+          stylesheet for why, and for why the order is the configuration's
+          business.
+        */}}
+        {{ with site.Params.footerLinks }}
+          <ul class="masthead-links">
+            {{ range . }}<li>{{ partial "site-link.html" . }}</li>{{ end }}
+          </ul>
+        {{ end }}
+        {{ partial "masthead-tools.html" . }}
+      </header>
 
       <main>{{ block "main" . }}{{ end }}</main>
 

--- a/modules/services/digital-garden/lib/hugo/layouts/home.html
+++ b/modules/services/digital-garden/lib/hugo/layouts/home.html
@@ -1,66 +1,41 @@
 {{ define "main" }}
   {{/*
-    The landing page, composed once (docs/plans/digital-garden-design.md,
-    item 19, and recomposed by its second pass). A masthead bar — the name,
-    the links and the tools on one line — and the tree under it, filling the
-    article column, with the garden counted beneath as the picture's label.
+    The landing page: the masthead every page carries (baseof.html), the tree
+    under it, and the hand-written table of contents under that.
 
-    The bar rather than a band with the name beside the tree: that version
-    gave the two equal columns, and only the tree filled one. Here the tree
-    has the whole measure and the name is a label on it, which is the order
-    the page's subject actually has.
-
-    This IS the page's masthead: baseof.html renders none here, because a site
-    title in two sizes on one page is two mastheads. Every interior page keeps
-    the masthead it has, and the tools are shared between the two so that the
-    ids their scripts bind to exist exactly once per page.
+    What used to be here was a composition of its own - the name at 2rem, the
+    links and the tools on a bar of its own, a rule under the whole thing - and
+    it is gone (item 21). It was the second of two headers on this site, and
+    the price of the second was that the row at the top of the page changed
+    height depending on which page you were on. The blend the two became is in
+    baseof.html; what is left here is the part that was never a header, which
+    is the picture.
 
     The tree (item 18) is grown by publish-filter.py and left in the staging
     tree as ready markup, which lib/hugo.nix moves into assets; all this
     template does is inline it. That is the whole reason the page ships no
-    generator and no library — the characters are already in the HTML by the
+    generator and no library - the characters are already in the HTML by the
     time it is served, and the only script involved reveals ones that are
     already there.
 
     `resources.Get` returns nothing when there is no tree, so a content tree
-    that came from somewhere other than the filter still renders a home page —
-    with the name and the colophon, which are read off the pages themselves.
+    that came from somewhere other than the filter still renders a home page -
+    with the masthead and the colophon, which are read off the pages
+    themselves.
 
     Outside <article>, deliberately. The article is what carries
     data-pagefind-body, and the tree's caption store holds the title of every
     note on the site - indexing it here would put the whole garden into the
     search results for the home page.
-  */}}
-  <header class="nameplate">
-    <div class="nameplate-tools">{{ partial "masthead-tools.html" . }}</div>
-    <div class="nameplate-id">
-      <p class="nameplate-title">{{ site.Title }}</p>
-      {{/*
-        The site's own sentence used to sit here, under the name. It is gone,
-        and nothing is lost: `description.html` still resolves it for <meta
-        name="description">, for the social card and for the feed, so the page
-        says the same thing to a reader's machine as it ever did. What it was
-        NOT is prose written for this composition - the comment that used to
-        sit here said as much - and the first paragraph of the body below says
-        the same thing properly, in the site's own voice.
 
-        What it cost was a line: the bar holds the name, the links and the
-        tools, and a sentence is not a thing a bar can hold.
-      */}}
-      {{/*
-        The site's links, from the same `footerLinks` the footer renders, so
-        that "where else to find me" is one list in the host's configuration
-        and not two that drift. Nothing is rendered when none are configured.
-      */}}
-      {{ with site.Params.footerLinks }}
-        <ul class="nameplate-links">
-          {{ range . }}<li>{{ partial "site-link.html" . }}</li>{{ end }}
-        </ul>
-      {{ end }}
-      {{ partial "colophon.html" . }}
-    </div>
+    No rule under it. There was one, closing the old header, and with the
+    header gone it was a line drawn between a picture and the prose that
+    describes it - which is exactly the pair a rule should not separate.
+  */}}
+  <div class="garden">
     {{ with resources.Get "bonsai.html" }}{{ .Content | safeHTML }}{{ end }}
-  </header>
+    {{ partial "colophon.html" . }}
+  </div>
 
   {{/*
     The landing page is a hand-written table of contents, not a generated list:
@@ -70,12 +45,15 @@
   {{/* Same wrapper as a note, with nothing in the margins to put there. The
        wide grid builds either way and the article is always its centre
        column, so the landing page's prose lands exactly where every note's
-       prose lands - which is the point of using the same wrapper. The
-       composition above is the one thing on this site that is wider than the
-       measure, and the prose beneath it is not. */}}
+       prose lands - which is the point of using the same wrapper. The tree
+       above is the one thing on this site that is wider than the measure, and
+       the prose beneath it is not.
+
+       No <h1>: the site's name in the masthead is this page's heading (item
+       20). The title that was here was a second name for the same page, and a
+       reader met it between the picture and the first sentence about it. */}}
   <div class="layout">
     <article data-pagefind-body>
-      <h1>{{ .Title }}</h1>
       {{ .Content }}
     </article>
   </div>


### PR DESCRIPTION
Eight things reported from reading the site rather than looking at it. Recorded as item 21 in `docs/plans/digital-garden-design.md`.

## One masthead

The site had two headers — a 1.1rem name in a bar on every interior page, and a 2rem name in a bar of its own on the home page — so the row at the top of the window changed height on the commonest journey the site has. They are now one bar, rendered by `baseof.html` for every page: the interior page's format, the landing page's links, at 1.25rem. The rule under it lands on the same pixel row on the home page, on a note and on `/notes/`, measured at 1440px.

Past 80rem it needs no anchoring rule either. `max-width: var(--measure); margin-inline: auto` reduces to the article column's own offset, so one declaration holds the bar, the tree and the prose to the same two vertical lines.

The size settles the open contrast question from item 2 as a side effect: 20px at weight 600 is past the 18.66px where the large-text allowance starts, so the floor for Lotus's `--brand` is 3:1 and it clears it at 3.73:1. The hue is unchanged.

## The links drop, they do not wrap

On the landing page the list folded onto a second line, which turned a bar into a block at the one width where a header should cost least. `container-type: inline-size` on the masthead and three `@container` steps take them out one at a time from the left, which is the order the configuration gives them. The question is asked of the bar rather than of the viewport, because the bar is capped at the measure and it is the bar that runs out of room.

The first cut of this got the order wrong — at ~430px the name came out as *"Cory Gyarma…"* with three links still beside it, because the steps were estimated off a screenshot and the bar actually needs 396.5px to hold two links. The widths are now measured in the browser and each step sits about a rem above its number.

## The home page

The rule under the tree is gone — it was the old header's closing line, and with the header out of it a rule there separates the picture from the sentences that introduce it. The landing page's `<h1>` is gone with it, and the site's name in the masthead is that page's heading instead, so the page still has one.

The colophon takes `--text` where the hover caption keeps `--muted`. They sat one line apart, the same size in the same grey, and read as one block — but the caption is whatever the pointer is on right now and the count is a standing fact about the whole garden.

## A note

One date at the narrow width. Four facts and two dates are wider than a phone, so the line wrapped, and a wrapped second line under the title pushes the essay down by a row where vertical space is scarcest. The publication date is the one that goes; the margin carries both at the wide width, and `/notes/` keeps both.

## Tables

`margin: 1.5rem 0`. A table had none at all, so it took whatever the block after it happened to have above it — a callout's is 1rem, the same gap that separates two paragraphs of one argument, and the two read as one object with a tinted foot. The markdown formatter used on these notes closes the blank line around a table, so the adjacency is routine rather than rare; the fixture grew the case.

## Gate

`nix build .#checks.x86_64-linux.digital-garden` passes. Assertions added for the properties a screenshot cannot hold still:

- the site's name is an `<h1>` on the home page and a link everywhere else, and appears once per page;
- the masthead is a container, something drops a link when it runs out of room, and the link list cannot wrap;
- **the bar is swept from 280 to 720px in a live browser** — a clone of the masthead in a box of each width — asserting the name is never cut while a link is still shown, and the row never overflows instead of dropping one;
- a table container has a margin;
- a note edited since publication shows the edit on its dateline and both dates in its margin.

The geometry probe that pinned the old header to the article column now pins the masthead and the tree to it.

Judged by rendering at 390 / 434 / 530 / 1279 / 1281 / 1440px, in both themes, against the fixture and the real vault.
