### PR TITLE
fix(hypridle): use correct dpms dispatcher in after_sleep_cmd

### DIFF
--- a/modules/home/desktop/hyprlock.nix
+++ b/modules/home/desktop/hyprlock.nix
@@ -91,7 +91,7 @@ in
         general = {
           lock_cmd = "pidof hyprlock || hyprlock"; # avoid starting multiple hyprlock instances.
           before_sleep_cmd = "loginctl lock-session"; # lock before suspend.
-          after_sleep_cmd = "hyprctl dispatch 'hl.disp.dpms({ action = \" enable \" })'"; # to avoid having to press a key twice to turn on the display.
+          after_sleep_cmd = "hyprctl dispatch 'hl.dsp.dpms({ action = \"enable\" })'"; # to avoid having to press a key twice to turn on the display.
         };
 
         listener = [


### PR DESCRIPTION
## What

The hypridle `after_sleep_cmd` dispatches to `hl.disp.dpms`, but the `disp` field does not exist in the Hyprland 0.56 Lua dispatch API — it is `hl.dsp.dpms`. Every resume failed the dispatch with:

```
error: [string "return hl.dispatch(hl.disp.dpms({ action = " ..."]:1: attempt to index a nil value (field 'disp')
```

so the display was never explicitly re-enabled after sleep (it relies on the key press to turn the screen back on). The other dpms dispatch in the same file (`hl.dsp.dpms` on the 5-minute idle timeout) already uses the correct name, and the misnamed one did not error at write time because it only executes at runtime.

- Change `after_sleep_cmd` from `hl.disp.dpms` to `hl.dsp.dpms` and drop stray whitespace inside the action string.
- Verified the home-manager value evaluates to `hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })'` for the xps15 host.
- Confirmed against a live session that `hl.dsp.dpms` dispatches without error while `hl.disp.dpms` fails.

## Context

Found while troubleshooting a frozen ultrawide after resume (DP-2 wedged at `0x0` because the kernel rejects all atomic modesets on that connector post-resume). This fix corrects the broken resume path but does not by itself prevent the kernel-side modeset failure — see the pre-existing `FIXME: waking from suspend failing` in the same file.

## Verification

- `nix eval` of the affected home-manager option for `xps15` succeeds and shows the corrected command.
- `nixos ci` gate will build all hosts and run `nix flake check` before this can merge.