### PR TITLE
build(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1788364057,
-        "narHash": "sha256-bd0u33vaHEUE09rt10Qb8p6xXltuee3z+kZBi3z7y9A=",
+        "lastModified": 1788395115,
+        "narHash": "sha256-7sprixDLchHgjQt1yNoc91d0L0lnbd1VUb3OPZpsIJk=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "c03082a563c010c03a5c3d5e1507ccd9dd53d341",
+        "rev": "a591d4600e8ada8b22489093ebf50337f4d98065",
         "type": "github"
       },
       "original": {
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788355065,
-        "narHash": "sha256-gAz5oTI7ur34CfuakQduiQd/2ZhO62Bn2XXg08nZYYQ=",
+        "lastModified": 1788458226,
+        "narHash": "sha256-UZTAlg8iKVEmyEXakzKmukrzFIKrXezYsRy9vajDrGw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d9d750e4fc11c10cab2da677bdd31e427f3a3a71",
+        "rev": "aa308770461dcf22c333a5e8a31c8bddbde5bee9",
         "type": "github"
       },
       "original": {
@@ -267,11 +267,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1788329703,
-        "narHash": "sha256-fHvRW4JUchuw6QNzQ50BfzeYe0TnjKml1V8PVRjntSI=",
+        "lastModified": 1788422941,
+        "narHash": "sha256-JkX1/UHjz5U0zEsTRCG3sxJ9GCk7imvrXG/1+JuMAZA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "090e478bd64824e2122328df47a7efb74fdaf0c1",
+        "rev": "a718ac06264a6eb180294b577aa9067c3f69e7e8",
         "type": "github"
       },
       "original": {
@@ -283,11 +283,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1788179007,
-        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
+        "lastModified": 1788316716,
+        "narHash": "sha256-bc7rSpXIdn9QWGNqfWcPZWOhEVF8NoeAZkWq0XWnf/k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
+        "rev": "3ed67ec0a4d3c7ab4ae1f04f8ee8df07bfa506a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `flake.lock` update.

The per-host deltas below are recorded in the commit body so they
land in `git log` on merge (ADR 0001).

Each host was built at the current lock and at the updated one, and
the closures compared. All three builds passing is a precondition of
this PR existing at all — but the `nixos ci` gate still has to pass
before it can merge, and merging is what promotes `deploy`.

### homelab01

age: 1.3.1 → 1.3.2, -15.5 KiB
golangci-lint: 2.13.1 → 2.13.2
nixos-manual: 10.9 KiB
nixos-system-homelab01: 26.11.20260831.34ab990 → 26.11.20260902.3ed67ec
source: 26.3 KiB

### homelab02

age: 1.3.1 → 1.3.2, -15.5 KiB
golangci-lint: 2.13.1 → 2.13.2
nixos-manual: 10.9 KiB
nixos-system-homelab02: 26.11.20260831.34ab990 → 26.11.20260902.3ed67ec
source: 26.3 KiB

### xps15

age: 1.3.1 → 1.3.2, -15.5 KiB
claude-code: 2.1.245 → 2.1.257, -168.3 MiB
exiv2: 0.28.8 → 0.28.9, 17.3 KiB
firefox: 154.0.1 → 155.0
firefox-unwrapped: 154.0.1 → 155.0, 948.4 KiB
golangci-lint: 2.13.1 → 2.13.2
google-chrome: 152.0.7977.64 → 152.0.7977.75, -88.2 KiB
nixos-manual: 10.9 KiB
nixos-system-xps15: 26.11.20260831.34ab990 → 26.11.20260902.3ed67ec
nvidia-vaapi-driver: 0.0.17 → 0.0.18, 52.3 KiB
openvino: 2026.3.0 → 2026.3.1, 64.5 KiB
source: 26.3 KiB
yazi: 26.8.15 → 26.9.1, 483.3 KiB