### PR TITLE
build(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788458226,
-        "narHash": "sha256-UZTAlg8iKVEmyEXakzKmukrzFIKrXezYsRy9vajDrGw=",
+        "lastModified": 1788487777,
+        "narHash": "sha256-Ro/e1N4ZR8/XaFF+sF9SgfPK79HM5YNEppzFj8p+0Ak=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "aa308770461dcf22c333a5e8a31c8bddbde5bee9",
+        "rev": "693e8ce0fb240a73c116a03cfd7b19269c87af88",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1788297115,
-        "narHash": "sha256-Z+vUNbfd2FIKkWOTkcT7RYlh3oFCnig/d2eXD1SWf2E=",
+        "lastModified": 1788405554,
+        "narHash": "sha256-r2f1oUwixlgq9zOdYLqJLfS/lWBT60/IITjhTKI59JU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a3116115851d68b8952a2a4221cc25a84e56b532",
+        "rev": "a5cc6f2c37bf518436dc8d1c288ccd0c43c2f4c4",
         "type": "github"
       },
       "original": {
@@ -267,11 +267,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1788422941,
-        "narHash": "sha256-JkX1/UHjz5U0zEsTRCG3sxJ9GCk7imvrXG/1+JuMAZA=",
+        "lastModified": 1788523300,
+        "narHash": "sha256-HRlfCPLSKAHOnbn+QxuEvWvug0yqU8oHZHLbO5snJQE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a718ac06264a6eb180294b577aa9067c3f69e7e8",
+        "rev": "074b06a122e9f3e245e17fdc1199c3481c8b70b5",
         "type": "github"
       },
       "original": {
@@ -283,11 +283,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1788316716,
-        "narHash": "sha256-bc7rSpXIdn9QWGNqfWcPZWOhEVF8NoeAZkWq0XWnf/k=",
+        "lastModified": 1788404924,
+        "narHash": "sha256-lhEhY8X5EgkQ/eg6IFz4cc8jRuSYSvnxx1al7d1dvZ0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3ed67ec0a4d3c7ab4ae1f04f8ee8df07bfa506a2",
+        "rev": "0968519e14f7aa7d3e9b389682bd74d2b51c8ce8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `flake.lock` update.

The per-host deltas below are recorded in the commit body so they
land in `git log` on merge (ADR 0001).

Each host was built at the current lock and at the updated one, and
the closures compared. All three builds passing is a precondition of
this PR existing at all — but the `nixos ci` gate still has to pass
before it can merge, and merging is what promotes `deploy`.

### homelab01

gh: 2.98.0 → 2.99.0, 146.3 KiB
initrd-linux: 6.18.48 → 6.18.49
linux: 6.18.48 → 6.18.49, -24.5 KiB
mesa: 26.2.1 → 26.2.2, 24.8 KiB
nixos-system-homelab01: 26.11.20260902.3ed67ec → 26.11.20260903.0968519
ruff: 0.16.4 → 0.16.5, 90.3 KiB
source: 33.1 KiB

### homelab02

gh: 2.98.0 → 2.99.0, 146.3 KiB
initrd-linux: 6.18.48 → 6.18.49, 100.2 KiB
linux: 6.18.48 → 6.18.49, -24.5 KiB
mesa: 26.2.1 → 26.2.2, 24.8 KiB
nixos-system-homelab02: 26.11.20260902.3ed67ec → 26.11.20260903.0968519
ruff: 0.16.4 → 0.16.5, 90.3 KiB
source: 33.1 KiB
zfs-kernel: 2.4.4-6.18.48 → 2.4.4-6.18.49

### xps15

audacity: 3.7.8 → 3.7.9, -345.8 KiB
claude-code: 2.1.257 → 2.1.258
discord: 1.0.155, 1.0.155-fhsenv → 1.0.156, 1.0.156-fhsenv
discord-unwrapped: 1.0.155 → 1.0.156, -3.8 MiB
faugus-launcher: 2.1.0 → 2.2.1, 99.5 KiB
ffmpeg: 8.1.2 removed, -33.7 MiB
firefox-unwrapped: 52.8 KiB
gh: 2.98.0 → 2.99.0, 146.3 KiB
initrd-linux: 7.2.2 → 7.2.3, 42.1 KiB
linux: 7.2.2 → 7.2.3, 17.2 KiB
mesa: 26.2.1 → 26.2.2, 54.1 KiB
nixos-system-xps15: 26.11.20260902.3ed67ec → 26.11.20260903.0968519
noto-fonts: 2026.08.01 → 2026.09.01
nvidia-open: 595.99.02-7.2.2 → 595.99.02-7.2.3
python3.14-sip: 6.15.1 → 6.16.1, 2.0 MiB
ruff: 0.16.4 → 0.16.5, 90.3 KiB
source: 33.1 KiB
wireplumber: 0.5.15 → 0.5.17, 1.2 MiB
x86_energy_perf_policy: 6.18.48 → 6.18.49
zotero: 9.8 KiB