### PR TITLE
Desktop items 1-4: the bar's dead click actions, and a check that keeps them dead

### DIFF
--- a/configs/hypr/autostart.lua
+++ b/configs/hypr/autostart.lua
@@ -5,11 +5,13 @@
 -- hyprland-session.target is what pulls those units in; a daemon launched here
 -- as well is launched twice. hyprpaper (services.hyprpaper, enabled by stylix)
 -- and dunst (services.dunst) were both in that state - dunst refused its second
--- instance, hyprpaper raced its first over the same IPC socket.
+-- instance, hyprpaper raced its first over the same IPC socket. kdeconnect-
+-- indicator had no unit at all, so it was given one
+-- (modules/home/desktop/kdeconnect.nix) rather than kept here.
 --
--- So: add a daemon here only if it has no unit, and prefer giving it one.
+-- That leaves one line, and it should stay the only one: add a daemon here
+-- only if it has no unit, and prefer giving it one.
 
 hl.on("hyprland.start", function()
 	hl.exec_cmd("systemctl --user start hyprland-session.target")
-	hl.exec_cmd("kdeconnect-indicator")
 end)

--- a/configs/waybar/config.jsonc
+++ b/configs/waybar/config.jsonc
@@ -103,7 +103,8 @@
   },
 
   "hyprland/workspaces": {
-    "on-click": "activate",
+    // Clicking a workspace switches to it natively; there is no "on-click"
+    // option on this module, so a value here would be run as a command.
     "all-outputs": false,
   },
 
@@ -113,24 +114,25 @@
   "disk": {
     "interval": 120,
     "format": "{percentage_used}% ",
-    // Left = open file manager, Right = show details, Middle = open terminal at /
+    // Left = open file manager, Right = show details
+    // Middle was a `dust` tree in a terminal; item 14 of the desktop plan owns
+    // "what is using this disk" and gives it a menu instead.
     "on-click": "xdg-open ~",
     "on-click-right": "notify-send 'Disk' \"$(df -h / --output=source,size,used,avail,pcent | tail -1)\"",
-    "on-click-middle": "foot -e bash -c 'dust / | head -30; read'",
   },
 
   "cpu": {
     "format": "{usage}% ",
     "tooltip": true,
     // Left = open btop, Right = show top processes, Middle = (reserved)
-    "on-click": "foot -e btop",
+    "on-click": "term-run btop",
     "on-click-right": "notify-send 'Top CPU' \"$(ps -eo comm,%cpu --sort=-%cpu | head -6)\"",
   },
 
   "memory": {
     "format": "{}% ",
     // Left = open btop, Right = show top memory consumers
-    "on-click": "foot -e btop",
+    "on-click": "term-run btop",
     "on-click-right": "notify-send 'Top Memory' \"$(ps -eo comm,%mem --sort=-%mem | head -6)\"",
   },
 
@@ -139,9 +141,12 @@
     "critical-threshold": 80,
     "format": "{temperatureC}°C {icon}",
     "format-icons": ["", "", ""],
-    // Left = open btop (sensors), Right = show all thermal zones
-    "on-click": "foot -e btop",
-    "on-click-right": "notify-send 'Temperatures' \"$(sensors 2>/dev/null | grep -E '°C' | head -10)\"",
+    // Left = open btop (sensors)
+    // Right was a `sensors` notification with no `sensors` to run, so it fired
+    // an empty body - which reads as "nothing to report" rather than "broken".
+    // waybar's own tooltip already answers this module's question at hover
+    // depth; per-zone detail belongs to item 14 of the desktop plan.
+    "on-click": "term-run btop",
   },
 
   // ===========================================================================
@@ -157,9 +162,12 @@
       "critical": 15,
       "warning": 30,
     },
-    // Left = toggle format (capacity vs time), Right = show power details
-    // (format-alt handles left click natively)
-    "on-click-right": "notify-send 'Battery' \"$(upower -i $(upower -e | grep battery) | grep -E 'state|percentage|time|energy-rate')\"",
+    // Left = toggle format (capacity vs time; format-alt handles it natively)
+    // Right was a `upower` notification, and upower is not enabled - so it
+    // fired an empty body. Everything it meant to report waybar can render
+    // itself, at hover depth, which is where information the user asked for
+    // belongs.
+    "tooltip-format": "{timeTo}\nDraw: {power} W\nHealth: {health}%",
   },
 
   // ===========================================================================
@@ -174,7 +182,6 @@
       "mode": "month",
       "weeks-pos": "right",
       "mode-mon-col": 3,
-      "on-click-right": "mode",
       "format": {
         "month": "<span color='#E6C384'><b>{}</b></span>",
         "weekdays": "<span color='#FFA066'><b>{}</b></span>",
@@ -183,6 +190,12 @@
       },
     },
     // Left = toggle format (format-alt handles natively)
+    // Right = switch the calendar between month and year. That is a module
+    // action rather than a command, so it belongs in "actions"; inside
+    // "calendar" it was never read.
+    "actions": {
+      "on-click-right": "mode",
+    },
   },
 
   // ===========================================================================
@@ -195,8 +208,9 @@
     "format-ethernet": "{ifname}: {ipaddr}/{cidr}   up: {bandwidthUpBits} down: {bandwidthDownBits}",
     "format-linked": "{ifname} (No IP) ",
     "format-wifi": "{signalStrength}% ",
-    // Left = toggle format (format-alt handles natively), Middle = open nm settings
-    "on-click-middle": "nm-connection-editor",
+    // Left = toggle format (format-alt handles natively)
+    // Middle was nm-connection-editor, which is not installed; item 9 of the
+    // desktop plan gives the network a rofi menu instead.
   },
 
   // ===========================================================================
@@ -218,10 +232,11 @@
     "format-muted": " {format_source}",
     "format-source": "{volume}% ",
     "format-source-muted": "",
-    // Left = open pavucontrol, Right = toggle mute, Middle = open pulsemixer
+    // Left = open pavucontrol, Right = toggle mute
+    // Middle was a pulsemixer TUI; item 9 of the desktop plan replaces it with
+    // a sink picker in rofi.
     "on-click": "pavucontrol",
     "on-click-right": "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle",
-    "on-click-middle": "foot -e pulsemixer",
     "on-scroll-up": "wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+",
     "on-scroll-down": "wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-",
   },

--- a/docs/plans/desktop-design.md
+++ b/docs/plans/desktop-design.md
@@ -1,6 +1,6 @@
 # Plan: the desktop, as a designed system
 
-Status: proposed 2026-09-05; the four open questions were answered on 2026-09-06 and two requirements were added that change the shape of the bar and remove motion from the desktop entirely — see _Decisions, 2026-09-06_ below. Nothing is built yet. This is the spine document for a series of sessions — it decides what the desktop is _for_, names the rules a change can be checked against, records what is actually there today, and sequences the work. The per-tool sessions (waybar, rofi, the lock screen) come after, and their brief is this document rather than a fresh opinion.
+Status: proposed 2026-09-05; the four open questions were answered on 2026-09-06 and two requirements were added that change the shape of the bar and remove motion from the desktop entirely — see _Decisions, 2026-09-06_ below. Items 22 and 1–4 were built on 2026-09-06; everything from 5 on is still proposed. This is the spine document for a series of sessions — it decides what the desktop is _for_, names the rules a change can be checked against, records what is actually there today, and sequences the work. The per-tool sessions (waybar, rofi, the lock screen) come after, and their brief is this document rather than a fresh opinion.
 
 Scope is the `xps15` host: `modules/home/desktop/`, `modules/nixos/hyprland.nix`, `modules/nixos/stylix.nix` and the eleven files under `configs/` that they deploy. The servers are out of scope and have no desktop.
 
@@ -104,10 +104,10 @@ These are the load-bearing ones. Each is argued in its item below; they are coll
 
 | # | Item | Size | Depends on | Status |
 | - | ---- | ---- | ---------- | ------ |
-| 1 | A check that the bar's commands exist | small | – | proposed |
-| 2 | A polkit authentication agent | small | – | proposed |
-| 3 | The eight dead click actions | small | 1 | proposed |
-| 4 | Autostart stops owning what systemd owns | small | – | proposed |
+| 1 | A check that the bar's commands exist | small | – | **done 2026-09-06** |
+| 2 | A polkit authentication agent | small | – | **done 2026-09-06** |
+| 3 | The eight dead click actions | small | 1 | **done 2026-09-06** — ten, in the end |
+| 4 | Autostart stops owning what systemd owns | small | – | **done 2026-09-06** |
 | 5 | One palette, one source | medium | – | proposed |
 | 6 | A geometry scale | small | – | proposed; motion half withdrawn 2026-09-06 |
 | 7 | Rofi is the menu system | medium | 5 | proposed |
@@ -125,7 +125,7 @@ These are the load-bearing ones. Each is argued in its item below; they are coll
 | 19 | Waybar, re-laid-out | medium | 3, 5, 6 | **superseded by 21** |
 | 20 | Rofi, refined | small | 5, 6, 7 | proposed |
 | 21 | The bar is vertical | large | 3, 5, 6 | proposed 2026-09-06 |
-| 22 | Motion comes out | small | – | proposed 2026-09-06 |
+| 22 | Motion comes out | small | – | **done 2026-09-06** |
 
 Sequencing: **22 first**, out of order, because it is one line, it is free, and it changes how everything after it feels to work on — there is no sense tuning a desktop while a 400 ms fade sits in front of the launcher. Then **1–4**, because they are defects and cheap, and because item 1 is the harness that stops item 3 from recurring — the same reason the digital garden plan put its rendering fixture before its palette. **5–7 next**, because they are the spine every later item hangs from. **8–15** are the gaps, and each is a session-sized piece of work that can be taken independently once 7 exists. **16, 17, 18, 20 and 21** are tuning and taste, and want the rest in place first so that what is being looked at is the finished shape — item 21 especially, since it is the item that decides which of the modules from 9, 12, 13 and 14 earn a permanent place on a bar that no longer has room for all of them.
 
@@ -149,6 +149,14 @@ Reference resolution is the same question for `binds.lua` and for the hypridle a
 
 Half a session. The risk is over-reach: shell one-liners with pipes and `$(...)` are in the file already, and the check should look at the first token and stop, not try to parse shell.
 
+### Built, 2026-09-06
+
+`modules/home/desktop/waybar-commands.py`, run from `modules/home/desktop/waybar.nix`. It parses `config.jsonc` with `json5` (JSONC is a subset — comments and trailing commas both parse), walks every `exec`, `exec-if`, `on-update`, `on-click*` and `on-scroll*` string, takes the first whitespace-separated word, and asserts it resolves under `home.path/bin`, `system.path/bin` or `system.path/sbin` — the two closures that actually make up the bar's PATH, read from the evaluated configuration rather than restated.
+
+It is _not_ in `checks/`, and that is the point of item 1 rather than an omission: `xdg.configFile."waybar".source` is the check's own output, so there is no way to deploy a `config.jsonc` the check has not passed on. A dead button fails `nixos-rebuild switch` on the laptop and fails the host build in CI, instead of failing a test run somebody has to remember to look at. `/run/wrappers/bin` is deliberately not modelled — nothing on the bar is setuid, and a wrapper cannot be resolved from a build sandbox, so a command that needs one fails the check and forces the question.
+
+One deliberate exclusion: a module's `actions` object maps an event to a waybar-_internal_ action name, not to a command, so it is skipped. That distinction turned out to matter — see item 3.
+
 ## 2. A polkit authentication agent
 
 ### The problem
@@ -166,6 +174,10 @@ Its dialog is Qt and will not be themed by stylix's GTK target. That is acceptab
 ### Cost and risk
 
 Minutes. Verify by asking for something that needs it rather than by reading the option back.
+
+### Built, 2026-09-06
+
+`services.hyprpolkitagent.enable = true` in `modules/home/desktop/hyprland.nix`, next to the comment naming it as the other half of `security.polkit.enable`. Not behind its own toggle: a session with no way to authenticate is not a configuration anyone would choose. The Qt dialog stays an accepted exception. Still to be verified the way the item asks — by triggering something that needs it, not by reading the option back.
 
 ## 3. The eight dead click actions
 
@@ -202,6 +214,19 @@ That leaves the actual installs: `btop` for the system view, and — if the righ
 
 One session, mostly deciding rather than typing. Item 1 should land first so the result is verified by the check rather than by clicking eight things.
 
+### Built, 2026-09-06
+
+Item 1 landed first, as the item asks, and immediately found two more of the same defect that reading the file had missed — so the count was ten, not eight:
+
+- `hyprland/workspaces` had `"on-click": "activate"`. `activate` is a `sway/workspaces` action name; `hyprland/workspaces` has no `on-click` option at all, so waybar was handing `activate` to a shell. Clicking a workspace already switches to it natively (`Workspace::handleClicked` dispatches over the Hyprland socket), so the line is simply gone.
+- The clock's `"on-click-right": "mode"` sat _inside_ `"calendar"`, where waybar never reads it — module actions come from an `"actions"` object on the module. It was inert rather than broken, which is the same failure wearing a better disguise. Moved to `"actions"`, where it now works.
+
+The eight from the table: the three `foot -e btop` left-clicks became `term-run btop`; `dust`, `pulsemixer` and `nm-connection-editor` were dropped rather than installed, each with a comment naming the later item that replaces what it was reaching for (14, 9, 9); and the two `notify-send` right-clicks were moved rather than fixed, per the escalation-ladder rule.
+
+The battery's move is the clean case: `upower -i` reported state, percentage, time and energy rate, and waybar's own `tooltip-format` renders `{timeTo}`, `{power}` and `{health}` at hover depth with no process to fork. The temperature's is the honest one: the module's `tooltip-format` only accepts `{temperatureC/F/K}`, so "all thermal zones" cannot go there. The right-click is gone, the native tooltip answers the module's own question, and per-zone detail is left to item 14 — where a `pick`-depth surface exists to put it in.
+
+**The terminal is named once.** `term-run <command>` is a `writeShellApplication` in `modules/home/terminals/ghostty.nix` — the module that already decides which terminal this desktop uses, and therefore the right place to make that decision executable. `config.jsonc` names `term-run`, never `ghostty`. `btop` is installed by `modules/home/desktop/waybar.nix` rather than by the host's package list, so the bar carries its own click targets and the two cannot drift apart.
+
 ## 4. Autostart stops owning what systemd owns
 
 ### The problem
@@ -219,6 +244,12 @@ Delete the `hyprpaper` and `dunst` lines. The `systemctl --user start hyprland-s
 ### Cost and risk
 
 Small, and it is a strict simplification. The risk is that something depends on the ordering the exec gave it; UWSM plus `graphical-session.target` is the correct ordering mechanism and both services already declare `After=graphical-session.target`.
+
+### Built, 2026-09-06
+
+The `hyprpaper` and `dunst` lines are gone. `kdeconnect-indicator` got the unit it never had, in `modules/home/desktop/kdeconnect.nix` behind `cg.home.kdeconnect.enable` — the daemon and its firewall holes stay with `programs.kdeconnect.enable` on the host, and only the tray icon is the home-manager side's business. It is ordered `After=` and `Requires=tray.target` exactly as `udiskie.service` is, because a StatusNotifierItem with no host has nowhere to draw; under the old `exec_cmd` it raced the bar with nothing to order it at all.
+
+`autostart.lua` is kept rather than folded away, at one line. The file is now the written-down answer to "where does a daemon go", and the comment says the answer is _not here_ — which is worth more as a file than as a deleted file.
 
 ## 5. One palette, one source
 

--- a/hosts/xps15/home.nix
+++ b/hosts/xps15/home.nix
@@ -52,6 +52,7 @@
     # Desktop Services
     dunst.enable = true; # Notification daemon (extracted from hyprland)
     udiskie.enable = true; # USB automounting (extracted from hyprland)
+    kdeconnect.enable = true; # Tray indicator (the daemon is a NixOS option)
 
     # Upgrade indicator in waybar
     auto-upgrade-desktop.enable = true;

--- a/modules/home/desktop/kdeconnect.nix
+++ b/modules/home/desktop/kdeconnect.nix
@@ -1,0 +1,59 @@
+# KDE Connect tray indicator
+{
+  config,
+  osConfig,
+  lib,
+  ...
+}:
+let
+  cfg = config.cg.home.kdeconnect;
+in
+{
+  options.cg.home.kdeconnect.enable = lib.mkEnableOption "KDE Connect tray indicator" // {
+    description = ''
+      Run `kdeconnect-indicator` as a user service. The daemon itself and its
+      firewall holes come from `programs.kdeconnect.enable` on the host; this
+      is only the tray icon, which has no unit of its own.
+    '';
+  };
+
+  config = lib.mkIf cfg.enable {
+    # A tray icon for a daemon that is not running is a worse affordance than
+    # no tray icon, so say so at evaluation rather than at login.
+    assertions = [
+      {
+        assertion = osConfig.programs.kdeconnect.enable;
+        message = "cg.home.kdeconnect.enable needs programs.kdeconnect.enable on the host: the indicator is a front end for a daemon this does not start.";
+      }
+    ];
+
+    # Item 4 of docs/plans/desktop-design.md. This was an `hl.exec_cmd` line in
+    # configs/hypr/autostart.lua, which is the one thing in the session that
+    # starts daemons outside systemd: nothing supervises it, nothing orders it
+    # against graphical-session.target, and a crash is silent. Everything else
+    # on this desktop is a unit, so this is one too.
+    systemd.user.services.kdeconnect-indicator = {
+      Unit = {
+        Description = "KDE Connect tray indicator";
+        After = [
+          "graphical-session.target"
+          "tray.target"
+        ];
+        PartOf = [ "graphical-session.target" ];
+        # It is a StatusNotifierItem and has nowhere to draw without a host,
+        # which the bar provides. udiskie's unit orders itself the same way.
+        Requires = [ "tray.target" ];
+      };
+      Service = {
+        # The host's package, not a second reference to the same default: the
+        # indicator and the daemon it talks to have to be the same build.
+        ExecStart = "${osConfig.programs.kdeconnect.package}/bin/kdeconnect-indicator";
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+      Install = {
+        WantedBy = [ "graphical-session.target" ];
+      };
+    };
+  };
+}

--- a/modules/home/desktop/waybar-commands.py
+++ b/modules/home/desktop/waybar-commands.py
@@ -1,0 +1,97 @@
+"""Assert that every command waybar's config can run actually exists.
+
+Waybar parses config.jsonc happily whether or not the binaries it names are
+installed, so a package dropped from the closure or a script renamed shows up
+only as a click that does nothing - which is worse than no click at all,
+because the bar documents an interaction grammar it then fails to honour. This
+turns that into a build failure. See waybar.nix for why it runs at build time
+rather than as a flake check.
+
+Scope, deliberately narrow: the *head* of each command line, and nothing else.
+Shell one-liners with pipes and $(...) are already in the config, and a check
+that grew a shell parser to follow them would be a second, worse shell. The
+head alone caught every dead action this was written for except two, and those
+two hid their missing binary inside a $(...) - they were removed rather than
+parsed for.
+
+Usage: waybar-commands.py <config.jsonc> <bin-dir:bin-dir:...>
+"""
+
+import os
+import sys
+
+import json5
+
+
+def is_command_key(key):
+    """Is this a key whose value waybar hands to a shell?
+
+    `actions` is deliberately not one of them. That object maps an event to a
+    module-*internal* action name - clock's "mode", "shift_up" - which is not a
+    command and must not be looked for on PATH.
+    """
+    return key in ("exec", "exec-if", "on-update") or key.startswith(("on-click", "on-scroll"))
+
+
+def commands(node, path=()):
+    """Yield (where in the config, command line) for everything waybar runs."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "actions":
+                continue
+            here = path + (key,)
+            if is_command_key(key) and isinstance(value, str):
+                yield ".".join(here), value
+            else:
+                yield from commands(value, here)
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from commands(value, path + ("[%d]" % index,))
+
+
+def head(command):
+    """The binary a command line invokes: its first whitespace-separated word."""
+    words = command.split()
+    return words[0] if words else ""
+
+
+def resolve(name, bindirs):
+    return any(os.path.exists(os.path.join(d, name)) for d in bindirs)
+
+
+def main(argv):
+    config_path, search_path = argv[1], argv[2]
+    bindirs = [d for d in search_path.split(":") if d]
+
+    with open(config_path) as handle:
+        config = json5.load(handle)
+
+    failures = []
+    for where, command in commands(config):
+        name = head(command)
+        if not name:
+            failures.append((where, command, "the command is empty"))
+        elif "/" in name or "=" in name:
+            # Not a limitation worth lifting: a path or an inline assignment in
+            # the bar's config is a shell-out that has outgrown a config file
+            # and belongs in a script the closure can carry.
+            failures.append((where, command, "%s: not a bare command name" % name))
+        elif not resolve(name, bindirs):
+            failures.append((where, command, "%s: not found" % name))
+
+    if not failures:
+        return 0
+
+    print("%s names commands that are not installed:\n" % config_path, file=sys.stderr)
+    for where, command, why in failures:
+        print("  %s\n    %s\n    -> %s\n" % (where, command, why), file=sys.stderr)
+    print(
+        "Add the package that provides it to the closure, or remove the action.\n"
+        "A declared click that runs nothing is worse than no click.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/modules/home/desktop/waybar.nix
+++ b/modules/home/desktop/waybar.nix
@@ -1,12 +1,52 @@
 # Waybar status bar
 {
   config,
+  osConfig,
   lib,
   pkgs,
   ...
 }:
 let
   cfg = config.cg.home.waybar;
+
+  configs = ../../../configs/waybar;
+
+  # Where the bar will actually look for the commands it names. waybar runs as
+  # a systemd user service inside the graphical session, so its PATH is the
+  # user's own profile plus the system one - the same two closures, not a
+  # hand-written list that could disagree with them.
+  #
+  # `/run/wrappers/bin` is not modelled: nothing on the bar is setuid today,
+  # and a wrapper cannot be resolved from inside the build sandbox. A command
+  # that needs one will fail this check, which is the right moment to decide
+  # whether it belongs on the bar at all.
+  searchPath = lib.concatStringsSep ":" [
+    "${config.home.path}/bin"
+    "${osConfig.system.path}/bin"
+    "${osConfig.system.path}/sbin"
+  ];
+
+  # Item 1 of docs/plans/desktop-design.md.
+  #
+  # This is a check, but it is not in `checks/`: it gates the *build* rather
+  # than a test run, so a configuration whose bar has a dead button cannot be
+  # switched to in the first place - not on this laptop and not in CI, which
+  # builds every host. Making the deployed config file the check's output is
+  # what buys that: there is no way to ship config.jsonc without the check
+  # having passed on it.
+  #
+  # See ./waybar-commands.py for what it does and does not look at.
+  checkedConfigs =
+    pkgs.runCommand "waybar-config"
+      {
+        nativeBuildInputs = [ (pkgs.python3.withPackages (ps: [ ps.json5 ])) ];
+      }
+      ''
+        python3 ${./waybar-commands.py} ${configs}/config.jsonc ${lib.escapeShellArg searchPath}
+
+        cp -r ${configs} $out
+        chmod -R u+w $out
+      '';
 in
 {
   options.cg.home.waybar.enable = lib.mkEnableOption "Waybar status bar";
@@ -27,10 +67,17 @@ in
       Install.WantedBy = [ "graphical-session.target" ];
     };
 
+    # The bar's system modules open btop, so the bar is what has to carry it.
+    # Putting it in the host's package list instead would let the two drift,
+    # which is the failure the check above exists to stop.
+    home.packages = [ pkgs.btop ];
+
     # Source external config files for portability
-    # These files can be used standalone on non-NixOS systems
+    # These files can be used standalone on non-NixOS systems - what is
+    # deployed here is a verbatim copy of ../../../configs/waybar, produced by
+    # the derivation that checks it.
     xdg.configFile."waybar" = {
-      source = ../../../configs/waybar;
+      source = checkedConfigs;
       recursive = true;
     };
 

--- a/modules/home/terminals/ghostty.nix
+++ b/modules/home/terminals/ghostty.nix
@@ -7,12 +7,35 @@
 }:
 let
   cfg = config.cg.home.ghostty;
+
+  # `term-run <command> [args...]` - open a command in a terminal window.
+  #
+  # Item 3 of docs/plans/desktop-design.md: the terminal was named five times
+  # in configs/waybar/config.jsonc, and it was still named `foot`. Which
+  # terminal this desktop uses is decided here, so anything that needs to show
+  # a TUI can shell out without restating the answer - and changing the
+  # terminal is one edit rather than a search.
+  termRun = pkgs.writeShellApplication {
+    name = "term-run";
+    runtimeInputs = [ pkgs.ghostty ];
+    text = ''
+      if [ "$#" -eq 0 ]; then
+        echo "usage: term-run <command> [args...]" >&2
+        exit 64
+      fi
+
+      exec ghostty -e "$@"
+    '';
+  };
 in
 {
   options.cg.home.ghostty.enable = lib.mkEnableOption "Ghostty terminal";
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ pkgs.ghostty ];
+    home.packages = [
+      pkgs.ghostty
+      termRun
+    ];
 
     # Source portable config file
     # This file can be used standalone on non-NixOS systems


### PR DESCRIPTION
Items 1–4 of `docs/plans/desktop-design.md`. Item 2 (the polkit agent) already landed in 3936c2c; this is the rest.

## Item 1 — a check that the bar's commands exist

`config.jsonc` named twenty-six binaries and seven were not installed. Nothing caught it: the file is deployed verbatim, waybar parses it happily, and the failure only ever showed up as a click that did nothing.

`modules/home/desktop/waybar-commands.py` parses the config with `json5`, walks every `exec` / `exec-if` / `on-update` / `on-click*` / `on-scroll*` string, takes the first word, and asserts it resolves under `home.path` or `system.path` — the two closures that make up the bar's runtime PATH, read out of the evaluated configuration rather than restated somewhere that can drift.

**It is not in `checks/`, on purpose.** `xdg.configFile."waybar".source` *is* the check's output, so there is no way to ship a `config.jsonc` the check has not passed on. A dead button fails `nixos-rebuild switch` on the laptop and fails the host build in CI, rather than failing a test run someone has to remember to read — which is what item 1 meant by "fail the build rather than a test run".

It reads the head of a command line and stops. The file already contains pipes and `$(...)`, and following those means writing a second, worse shell.

## Item 3 — the dead click actions

Running the check against the old config found **ten**, not the eight found by reading:

- `hyprland/workspaces` had `"on-click": "activate"` — a `sway/workspaces` action name. `hyprland/workspaces` has no `on-click` option, so waybar was handing `activate` to a shell. Clicking a workspace already dispatches over the Hyprland socket; line removed.
- The clock's `"on-click-right": "mode"` sat inside `"calendar"`, where waybar never reads it — module actions come from an `"actions"` object on the module. Inert rather than broken, which is the same failure in better disguise. Moved to `"actions"`, where it now works.

Of the original eight: the three `foot -e btop` left-clicks became `term-run btop`; `dust`, `pulsemixer` and `nm-connection-editor` were dropped rather than installed, each commented with the later item that replaces what it was reaching for (14, 9, 9).

The two `notify-send` right-clicks were **moved rather than fixed** — both succeeded with an empty body, which reads as "nothing to report" rather than "broken", and information the user asked for does not belong in the same stream as a chat message. Battery is the clean case: `tooltip-format` renders `{timeTo}`, `{power}` and `{health}`, everything `upower -i` reported, with no process to fork. Temperature is not: its `tooltip-format` only accepts `{temperatureC/F/K}`, so all-thermal-zones cannot go there. The right-click is gone, the native tooltip answers the module's own question, and per-zone detail is left to item 14 rather than pretended into place.

**The terminal is named once.** `term-run` is a `writeShellApplication` in the ghostty module — the module that already decides which terminal this desktop uses, and therefore the right place to make that decision executable. `config.jsonc` names `term-run`, never `ghostty`. `btop` is installed by the waybar module rather than the host's package list, so the bar carries its own click targets.

## Item 4 — autostart stops owning what systemd owns

`kdeconnect-indicator` was the one line in `autostart.lua` that genuinely had no unit. It gets one: nothing supervised it, nothing ordered it, and a crash was silent. Ordered `After=` and `Requires=tray.target` exactly as `udiskie.service` is, because a StatusNotifierItem with no host has nowhere to draw.

`ExecStart` reads `osConfig.programs.kdeconnect.package` rather than naming the same default twice, so the indicator and its daemon are the same build, and an assertion says so out loud if the host has not enabled the daemon.

`autostart.lua` is kept at one line rather than folded away — it is now the written-down answer to "where does a daemon go", and the answer is: not here.

## Verification

- `nix build .#nixosConfigurations.xps15.config.system.build.toplevel` — passes at every commit on the branch, so `git bisect` stays useful.
- The validator against the pre-fix `config.jsonc` reports all eight findings above. The two `notify-send` cases are missed exactly as item 1 predicted they would be (the missing binary sits inside a `$(...)`, so the head resolves) — and both are now gone.
- The deployed `~/.config/waybar` diffs byte-identical against `configs/waybar`; the check derivation copies verbatim, so portability is unchanged.
- `nix fmt -- --ci` clean. `nix flake check` → `all checks passed!`.

## Not done

Item 2 is verified only by reading the generated unit back. The item asks for it to be verified by triggering something that actually needs a polkit prompt, which is a login-time check — worth doing on the next switch.
