### PR TITLE
fix(boot): cap xps15 systemd-boot generations at 6

### DIFF
--- a/hosts/xps15/default.nix
+++ b/hosts/xps15/default.nix
@@ -101,6 +101,12 @@
     extraModprobeConfig = ''
       options iwlwifi power_save=1
     '';
+    # The fleet default (profiles/common.nix) keeps 10 generations, but this
+    # machine's ESP is 511M and each generation's initrd is ~48M, so 10 leaves
+    # /boot at ~83% used and close enough to overflow that it already did once
+    # (Sep 2026). 6 keeps the same rollback depth boot-counting and
+    # upgrade-verify actually reach back for while leaving comfortable headroom.
+    loader.systemd-boot.configurationLimit = lib.mkForce 6;
   };
 
   # ============================================================================


### PR DESCRIPTION
## What

Caps `boot.loader.systemd-boot.configurationLimit` at **6** for xps15 only, overriding the fleet-wide default of 10 set in `profiles/common.nix`.

## Why

xps15's ESP is 511M and each generation's initrd is ~48M, so 10 generations leave `/boot` at ~83% used. It already overflowed once (Sep 2026): `/boot` hit 100%, `nixos-upgrade-apply.service` failed at the systemd-boot install step with `ENOSPC`, and the fix that would have stopped it couldn't apply because the disk was full.

6 generations (~290M) keeps more rollback depth than `boot-counting` or `upgrade-verify` ever reach back for while leaving comfortable headroom on the 511M ESP. Servers keep 10.

## Verification

- `nix eval` shows xps15=6, homelab01=10, homelab02=10
- `nix build ".#nixosConfigurations.xps15.config.system.build.toplevel"` succeeds
- CI runs `nix flake check` on this PR