### PR TITLE
fix(desktop): the bar would not start, and was the wrong shape when it did

### DIFF
--- a/configs/waybar/config.jsonc
+++ b/configs/waybar/config.jsonc
@@ -79,6 +79,12 @@
   "custom/media": {
     "exec": "waybar-media",
     "max-length": 35,
+    // Track titles are somebody else's text, and waybar renders a custom
+    // module's output as Pango markup. An unescaped "&" in a title is not a
+    // stray character, it is a markup error - the label refuses to update and
+    // keeps whatever it said before, which reads as a media module that has
+    // stopped following the player.
+    "escape": true,
     "format": "󰎈 {}",
     "on-click": "playerctl play-pause",
     "on-click-right": "playerctl next",

--- a/configs/waybar/ddc.css
+++ b/configs/waybar/ddc.css
@@ -1,16 +1,11 @@
 /* DDC Module Styles
  * @import "./ddc.css";
+ *
+ * States only. The module's box - background, padding, margin, border and
+ * radius - is style.css's, along with every other module's, because a bar
+ * whose modules are boxed in four different files is a bar whose height
+ * cannot be changed in one place.
  */
-
-#custom-ddc-brightness {
-  background: @bg-base;
-  opacity: 0.9;
-  padding: 8px 16px;
-  margin: 8px 0px;
-  border: 2px solid @border;
-  border-radius: 8px 8px 8px 8px;
-  margin-right: 8px;
-}
 
 #custom-ddc-brightness.auto {
   color: @fg-primary;

--- a/configs/waybar/kanagawa-wave.css
+++ b/configs/waybar/kanagawa-wave.css
@@ -20,7 +20,7 @@
 /* sumiInk0: darkest surface - module backgrounds, tooltips */
 @define-color bg-base        #16161D;
 /* sumiInk0: the same, translucent - rofi's window behind its own chrome */
-@define-color bg-backdrop    #16161DCC;
+@define-color bg-backdrop    alpha(#16161D, 0.8);
 /* sumiInk1: default background - the layer most things sit on */
 @define-color bg-surface     #1F1F28;
 /* sumiInk2: raised chrome - tooltip borders, rofi's input bar */

--- a/configs/waybar/nixos-upgrade.css
+++ b/configs/waybar/nixos-upgrade.css
@@ -1,16 +1,9 @@
 /* NixOS Upgrade Waybar Module Styles
  * @import "./nixos-upgrade.css";
+ *
+ * States only - which colour means "updates available", which means "reboot
+ * needed". The module's box is style.css's, with every other module's.
  */
-
-#custom-nixos-upgrade {
-  padding: 8px 16px;
-  margin: 8px 0px;
-  border: 2px solid @border;
-  background: @bg-base;
-  opacity: 0.9;
-  border-radius: 8px 8px 8px 8px;
-  margin-right: 8px;
-}
 
 /* Hidden state - no updates, system up to date */
 #custom-nixos-upgrade.hidden {

--- a/configs/waybar/style.css
+++ b/configs/waybar/style.css
@@ -45,7 +45,7 @@ tooltip {
  * ============================================================================== */
 
 #workspaces button {
-  padding: 8px;
+  padding: 0px 8px;
   color: @fg-disabled;
   margin-right: 8px;
 }
@@ -79,6 +79,8 @@ tooltip {
 #custom-project,
 #custom-power_profile,
 #custom-media,
+#custom-nixos-upgrade,
+#custom-ddc-brightness,
 #window,
 #clock,
 #battery,
@@ -98,8 +100,23 @@ tooltip {
 #backlight {
   background: @bg-surface;
   opacity: 0.9;
-  padding: 8px 16px;
-  margin: 8px 0px;
+  /* The half-step, on the axis the unit is too coarse for. A module's content
+   * is one 19px line, so 8px of vertical padding more than doubles the chip -
+   * that is what put the bar at 55px - and 0 makes it exactly as tall as its
+   * own text. 4 is the scale's answer to that; see lib/geometry.nix.
+   *
+   * The bottom margin is 0 on purpose, and it is not an asymmetry. Hyprland
+   * puts gaps_out (8) between the bar and the window below it, so a bottom
+   * margin of 8 here is the second half of a gap that already exists: it drew
+   * 8px above the chip and 16 below. Above the chip there is no window to gap
+   * against and the margin is the whole story. 8 and 0 here is what renders
+   * as 8 and 8 on screen - which is the thing being kept even, rather than
+   * the two numbers in this rule.
+   *
+   * Item 21 turns the bar on its side. These two lines swap axis with it, and
+   * the gaps_out reasoning above swaps with them. */
+  padding: 4px 16px;
+  margin: 8px 0px 0px 0px;
   border: 2px solid @border;
 }
 
@@ -141,6 +158,24 @@ tooltip {
   color: @fg-primary;
   border-radius: 0px 8px 8px 0px;
   margin-right: 16px;
+}
+
+/* nixos-upgrade.css and ddc.css own these two modules' states - which colour
+ * means "updates available", which means "override". They used to own the box
+ * as well, and restated it: the same padding, margin, border and radius
+ * written a third and a fourth time. Nothing noticed, because nothing was
+ * checking that the module box is one box - so changing it in style.css moved
+ * some of the bar and not the rest.
+ *
+ * Their backgrounds came out of that duplication too. Both said @bg-base
+ * where every other module says @bg-surface, which drew two chips a shade
+ * darker than the rest of the bar for no reason anyone chose - a difference
+ * that reads as a rendering fault rather than as meaning. They take the
+ * shared background now; what is left here is the placement. */
+#custom-nixos-upgrade,
+#custom-ddc-brightness {
+  border-radius: 8px;
+  margin-right: 8px;
 }
 
 #tray {

--- a/docs/plans/desktop-design.md
+++ b/docs/plans/desktop-design.md
@@ -339,6 +339,16 @@ Its scope is deliberately narrow — the properties that carry geometry, listed 
 
 What actually moved: window rounding 16 → 12 and gaps 5 → 8 in `settings.lua`, window borders 1 → 2, dunst's radius 10 → 12, rofi's window 16 → 12 and its rows 10 → 8. And in `style.css`, the bar's own asymmetry finally went: every module carried `margin: 3px 0` with a `margin-top: 15px` overriding it, which is why the modules sat low. They are now `padding: 8px 16px; margin: 8px 0`, which is the plan's number and which **makes the bar roughly fourteen pixels taller**. That is the one change here worth looking at before accepting — item 21 owns the bar's final shape, and dunst's `offset` is the number that has to move with it.
 
+### Amended, 2026-09-06
+
+It was looked at, and it was not accepted. Three things came out of that.
+
+`padding: 8px 16px` was the wrong number for the bar's cross axis, and the scale had no right one: a module's content is a single 19px line, so 8px of vertical padding more than doubles the chip while 0 leaves it exactly as tall as its own text. `space.half = 4` is the answer — deliberately a half-step and not a second unit, so 4 is on the scale and 12 and 20 still are not. The bar is 39px with a 31px chip, against 55 and 39 as built and 41 and 23 before the item.
+
+The bottom margin was being spent twice. Hyprland puts `gaps_out` between the bar and the window below it, so `margin: 8px 0` drew 8px above the chip and 16 below — the asymmetry the item set out to remove, reintroduced from the other side. It is `margin: 8px 0 0 0` now, which is what renders as 8 and 8.
+
+And the reason none of that could be fixed in one place: **the module box was written out in four files.** `style.css` had it, and so did `nixos-upgrade.css`, `ddc.css` and `modifiers.css` — the same padding, margin, border and radius, restated. Changing `style.css` moved some of the bar and left the rest, which is how the height survived the first attempt to change it. The box is `style.css`'s now and the module sheets carry states only. This is item 5's principle — a value is named in exactly one file — and the geometry gate could not see the violation, because 8 is on the scale in all four files. Worth remembering when item 21 swaps the axis: the swap is now one rule rather than four.
+
 ## 7. Rofi is the menu system
 
 ### The problem

--- a/lib/geometry.nix
+++ b/lib/geometry.nix
@@ -40,5 +40,21 @@
     # The two that get used by name often enough to deserve one.
     tight = 8;
     loose = 16;
+
+    # And one half-step, for the cross axis of something the unit is too
+    # coarse for.
+    #
+    # It was added by waybar. A bar module's content is a single 19px line, so
+    # the only vertical paddings the unit could offer were 0 - a chip exactly
+    # as tall as its text - and 8, which more than doubles the chip and cost
+    # the bar fourteen rows of a 1440-row panel. Neither is the right answer
+    # and the scale had no third one. 4 is: the chip reads as a chip, and the
+    # bar stays the height it is with no padding at all, because the space
+    # comes out of a margin that was being spent twice (see style.css).
+    #
+    # Deliberately a half-step and not a second unit: 4 is allowed, 12 and 20
+    # are not, so this buys the one value the bar needed without turning the
+    # scale into "any multiple of four".
+    half = 4;
   };
 }

--- a/lib/kanagawa-wave.nix
+++ b/lib/kanagawa-wave.nix
@@ -211,6 +211,31 @@ let
     }
   ];
 
+  # ── The one role two formats spell differently ─────────────────────────────
+  #
+  # `bg-backdrop` is a colour with an opacity, and rasi and GTK 3 CSS disagree
+  # about how to write one. rofi takes the eight-digit `#RRGGBBAA` that the
+  # palette carries; GTK has no such notation, and `#16161DCC` there is not a
+  # colour it renders opaque but a parse error - which aborts the rest of the
+  # stylesheet and stops waybar from starting at all. So a role that only rofi
+  # reads was enough to take the bar down with it.
+  #
+  # GTK's `alpha()` takes the opacity as a fraction, so the byte is divided
+  # here and the pigment is still written out as the same hex as every other
+  # line in the file. Nix prints a float to six places; the match trims the
+  # zeros back off, and `removeSuffix` catches the "1." a fully opaque byte
+  # would leave behind.
+  fraction =
+    hex:
+    lib.removeSuffix "." (lib.head (lib.match "(.*[^0])0*" (toString (lib.fromHexString hex / 255.0))));
+
+  cssValue =
+    role:
+    if role ? alpha then
+      "alpha(${colours.${role.colour}}, ${fraction role.alpha})"
+    else
+      colours.${role.colour};
+
   flatRoles = lib.listToAttrs (
     lib.concatMap (
       group:
@@ -312,7 +337,7 @@ rec {
             map (
               role:
               "/* ${role.colour}: ${role.note} */\n"
-              + "@define-color ${role.name}${pad 15 role.name}${flatRoles.${role.name}};"
+              + "@define-color ${role.name}${pad 15 role.name}${cssValue role};"
             ) group.roles
           )
         }'') groups

--- a/modules/home/desktop/geometry-scale.py
+++ b/modules/home/desktop/geometry-scale.py
@@ -13,7 +13,7 @@ somebody else's decision and are not looked at - a check that policed every
 number in a stylesheet would be refused within a week, which is the same as not
 having one.
 
-Usage: geometry-scale.py <radius,...> <border,...> <space-unit> <file> [file...]
+Usage: geometry-scale.py <radius,...> <border,...> <space-unit>[,<half>] <file> [file...]
 """
 
 import re
@@ -108,9 +108,11 @@ def check(path, scale):
             if length == 0:
                 continue
             if part == "space":
-                if length % scale["space"] == 0:
+                if length % scale["space"] == 0 or length in scale["space_extra"]:
                     continue
                 why = "not a multiple of %d" % scale["space"]
+                if scale["space_extra"]:
+                    why += " (or %s)" % ", ".join(str(v) for v in sorted(scale["space_extra"]))
             else:
                 if length in scale[part]:
                     continue
@@ -121,10 +123,14 @@ def check(path, scale):
 
 
 def main(argv):
+    # Space is a unit plus any half-steps the scale allows by name, so that
+    # "a multiple of 8, and also 4" stays one argument and one idea.
+    space = [int(v) for v in argv[3].split(",")]
     scale = {
         "radius": {int(v) for v in argv[1].split(",")},
         "border": {int(v) for v in argv[2].split(",")},
-        "space": int(argv[3]),
+        "space": space[0],
+        "space_extra": set(space[1:]),
     }
 
     failures = [(path, failure) for path in argv[4:] for failure in check(path, scale)]

--- a/modules/home/desktop/gtk-css-parse.py
+++ b/modules/home/desktop/gtk-css-parse.py
@@ -1,0 +1,83 @@
+"""Ask GTK whether it can parse waybar's stylesheets.
+
+waybar hands its CSS to GTK 3 and exits 1 if GTK complains, so a stylesheet
+that does not parse is not a bar with the wrong colours - it is no bar at all.
+GTK's parser is also narrower than CSS on the web: `#RRGGBBAA` is not a
+translucent colour there, it is "Missing semicolon at end of color definition",
+and the error aborts the rest of the file.
+
+Nothing else in the build was in a position to notice. The generated-file gate
+checks the stylesheet is byte-for-byte what lib/kanagawa-wave.nix produces,
+which it was; the geometry gate reads it with a regex, which does not care
+whether GTK agrees. Both pass on a file GTK rejects. So this one does the only
+thing that settles it and hands the file to GTK.
+
+Every error is reported rather than just the first, because GTK keeps parsing
+after one and a second mistake would otherwise take a second round trip. They
+are reported by basename, in `style.css:15:24` form, so that what this prints
+and what waybar prints when it gives up are the same string.
+"""
+
+import os
+import sys
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+
+from gi.repository import GLib, Gtk  # noqa: E402  (must follow require_version)
+
+
+def errors_in(path):
+    """Return GTK's complaints about one stylesheet, as printable lines."""
+    found = []
+
+    def on_error(_provider, section, error):
+        # The section names the file the error is *in*, which is not `path`
+        # when the mistake is inside an @import. Only the basename is useful:
+        # these are copies in a build sandbox, and the name is what waybar
+        # would print anyway.
+        where = section.get_file()
+        name = os.path.basename(where.get_path() if where is not None else path)
+        # GTK counts lines and columns from zero; editors and waybar's own
+        # log do not.
+        found.append(
+            f"{name}:{section.get_start_line() + 1}:"
+            f"{section.get_start_position() + 1}: {error.message}"
+        )
+
+    provider = Gtk.CssProvider()
+    provider.connect("parsing-error", on_error)
+    try:
+        provider.load_from_path(path)
+    except GLib.Error as exc:
+        # load_from_path raises on the first error as well as signalling it.
+        # The signal is the better report; this is the fallback for the case
+        # where it somehow did not fire.
+        if not found:
+            found.append(f"{os.path.basename(path)}: {exc.message}")
+
+    return found
+
+
+def main(paths):
+    # A stylesheet named here is usually also reached through style.css's
+    # @import, and GTK reports the same mistake once down each route.
+    # dict.fromkeys is the order-preserving way to say "once each".
+    failures = list(dict.fromkeys(line for path in paths for line in errors_in(path)))
+    if not failures:
+        return 0
+
+    print("GTK cannot parse these stylesheets, so waybar would not start:", file=sys.stderr)
+    print(file=sys.stderr)
+    for line in failures:
+        print(f"    {line}", file=sys.stderr)
+    print(file=sys.stderr)
+    print("GTK 3 CSS is narrower than CSS on the web. In particular it has no", file=sys.stderr)
+    print("eight-digit hex: write an opacity as alpha(#RRGGBB, 0.8) instead.", file=sys.stderr)
+    print(file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/modules/home/desktop/lib/gtk-css.nix
+++ b/modules/home/desktop/lib/gtk-css.nix
@@ -1,0 +1,63 @@
+# The build gate for waybar's stylesheets.
+#
+# The fourth gate on the bar, and the one the other three left room for. Item
+# 1's check asks whether the commands the bar names exist; item 5's asks
+# whether the colour file still matches the palette; item 6's asks whether the
+# lengths honour the scale. None of them asks the question waybar actually
+# asks at startup, which is whether GTK can parse the file at all - and a
+# stylesheet GTK rejects is not a bar that looks wrong, it is a bar that does
+# not appear.
+#
+# So this hands the stylesheets to GTK itself, at build time, and a file GTK
+# will not parse fails `nixos-rebuild switch` and fails CI. See
+# ../gtk-css-parse.py for what it reports.
+{ pkgs }:
+let
+  # Parsing CSS needs no display, but it does need the GTK typelib and every
+  # other typelib GTK's introspection data refers to. Having the libraries on
+  # PATH is not enough - pygobject finds typelibs by this variable alone.
+  typelibs = pkgs.lib.makeSearchPathOutput "out" "lib/girepository-1.0" (
+    with pkgs;
+    [
+      gtk3
+      glib
+      pango
+      gdk-pixbuf
+      atk
+      harfbuzz
+      at-spi2-core
+      gobject-introspection
+    ]
+  );
+in
+pkgs.writeShellApplication {
+  name = "gtk-css-parse";
+  runtimeInputs = [ (pkgs.python3.withPackages (ps: [ ps.pygobject3 ])) ];
+  text = ''
+    export GI_TYPELIB_PATH=${typelibs}
+    # GTK pulls in pango, which looks for fontconfig's configuration whether
+    # or not anything is going to be drawn, and grumbles to stderr when the
+    # sandbox has none. Nothing here renders text; this just keeps the build
+    # log about the stylesheets.
+    export FONTCONFIG_FILE=${pkgs.fontconfig.out}/etc/fonts/fonts.conf
+
+    # GTK resolves @import against the importing file's directory, and
+    # style.css imports one stylesheet this module does not own: modifiers.css
+    # is written by waybar-modifiers.nix at activation time and is not in
+    # configs/. Checking a copy lets an empty stand-in sit beside it, so the
+    # import resolves and the check is about syntax rather than about which
+    # module supplies which file.
+    work=$(mktemp -d)
+    trap 'rm -rf "$work"' EXIT
+    cp "$@" "$work"/
+    : > "$work"/modifiers.css
+
+    names=()
+    for file in "$@"; do
+      names+=("$work/$(basename "$file")")
+    done
+
+    # HOME so fontconfig has somewhere to write its cache.
+    HOME=$work exec python3 ${../gtk-css-parse.py} "''${names[@]}"
+  '';
+}

--- a/modules/home/desktop/lib/scale.nix
+++ b/modules/home/desktop/lib/scale.nix
@@ -31,7 +31,12 @@ pkgs.writeShellApplication {
         ]
       } \
       ${list [ geometry.border ]} \
-      ${toString geometry.space.unit} \
+      ${
+        list [
+          geometry.space.unit
+          geometry.space.half
+        ]
+      } \
       "$@"
   '';
 }

--- a/modules/home/desktop/stylix.nix
+++ b/modules/home/desktop/stylix.nix
@@ -21,11 +21,26 @@ in
       starship.enable = false; # Custom config
     };
 
-    # NOTE: rose-pine-gtk-theme was removed from nixpkgs (depended on the
-    # dropped gtk-engine-murrine/GTK 2). Stylix generates the GTK theme from
-    # base16Scheme anyway, so no replacement is needed.
-    home.packages = with pkgs; [
-      rose-pine-icon-theme
-    ];
+    # An icon theme that is actually installed, and actually selected.
+    #
+    # Before this, `home.packages` carried rose-pine-icon-theme and nothing
+    # ever pointed GTK at it, so the icon theme in force was gsettings'
+    # default of Adwaita - which is not installed either. GTK fell back to
+    # hicolor, which has almost nothing in it, and the failure surfaced two
+    # layers away: udiskie asks for `drive-removable-media`, does not find it,
+    # and returns the literal string "not-available" (udiskie/tray.py), which
+    # waybar's tray then cannot find either and logs as its own error. The
+    # tray icon was simply missing.
+    #
+    # Papirus rather than Adwaita because stylix recolours Papirus to the
+    # base16 scheme, so the icons arrive on the same palette as everything
+    # else lib/kanagawa-wave.nix feeds - and because it carries the full
+    # freedesktop names, which is what a tray asks for by convention.
+    stylix.icons = {
+      enable = true;
+      package = pkgs.papirus-icon-theme;
+      dark = "Papirus-Dark";
+      light = "Papirus-Light";
+    };
   };
 }

--- a/modules/home/desktop/waybar.nix
+++ b/modules/home/desktop/waybar.nix
@@ -14,6 +14,7 @@ let
   palette = import ../../../lib/kanagawa-wave.nix { inherit lib; };
   inherit (import ./lib/generated.nix { inherit pkgs; }) assertGenerated;
   geometryScale = import ./lib/scale.nix { inherit pkgs; };
+  gtkCssParse = import ./lib/gtk-css.nix { inherit pkgs; };
 
   # Where the bar will actually look for the commands it names. waybar runs as
   # a systemd user service inside the graphical session, so its PATH is the
@@ -41,12 +42,18 @@ let
   #
   # See ./waybar-commands.py for what it does and does not look at.
   #
-  # It gates three things now. The second is item 5's half of the same
+  # It gates four things now. The second is item 5's half of the same
   # bargain: the colour file and the calendar's four hexes are generated from
   # lib/kanagawa-wave.nix and checked in, and this is what stops the copy from
   # drifting away from the palette. The third is item 6's: the stylesheets are
   # hand-written and cannot read the geometry scale, so they are checked
-  # against it instead. See ./lib/generated.nix and ./lib/scale.nix.
+  # against it instead.
+  #
+  # The fourth exists because the first three all passed on a stylesheet GTK
+  # could not parse, and the bar spent a night refusing to start: they check
+  # what the CSS *says*, and none of them checks that it is CSS GTK accepts.
+  # That one asks GTK. See ./lib/generated.nix, ./lib/scale.nix and
+  # ./lib/gtk-css.nix.
   checkedConfigs =
     pkgs.runCommand "waybar-config"
       {
@@ -70,6 +77,12 @@ let
 
         ${geometryScale}/bin/geometry-scale \
           ${configs}/style.css \
+          ${configs}/nixos-upgrade.css \
+          ${configs}/ddc.css
+
+        ${gtkCssParse}/bin/gtk-css-parse \
+          ${configs}/style.css \
+          ${configs}/kanagawa-wave.css \
           ${configs}/nixos-upgrade.css \
           ${configs}/ddc.css
 


### PR DESCRIPTION
Item 5 shipped a colour the bar could not read, and item 6 shipped a module box the bar could not change. Both are fixed here, and both left a gate behind.

## waybar would not start

`bg-backdrop` is the one role in the palette carrying an opacity, and it was written as eight-digit hex. rasi takes `#RRGGBBAA`; **GTK 3 CSS has no such notation**, so `#16161DCC` is not a colour rendered opaque, it is a parse error that aborts the rest of the stylesheet — and waybar exits 1 rather than starting unstyled.

```
#16161DCC             exit=1   style.css:1:23 Missing semicolon at end of color definition
alpha(#16161D, 0.8)   exit=124 (still running)
```

The sting is that the role is read **only by rofi** — `style.css` never references it. A colour for the launcher stopped the bar.

`toCss` renders an opacity as `alpha(#RRGGBB, 0.8)` now, dividing the alpha byte so the pigment is still written as the same hex as every other line. `toRasi` is unchanged and `palette.rasi` is byte-identical.

### The gate that should have caught it

All three existing gates passed on that file. They check what the CSS *says* — that it matches the palette, that its lengths are on the scale — and none of them checks that it is CSS GTK will accept.

So there is a fourth: `lib/gtk-css.nix` hands `style.css` and the three sheets it imports to a real `Gtk.CssProvider` at build time. Parsing needs no display, only the typelibs. Errors report as `ddc.css:27:1` — the string waybar prints when it gives up — deduplicated across the direct and `@import` routes. Proven by putting the eight-digit hex back.

## The module box was written in four files

`style.css`, `nixos-upgrade.css`, `ddc.css` and `modifiers.css` each restated the same padding, margin, border and radius. Changing the box in `style.css` moved some of the bar and left the rest — which is how the height survived the first attempt to change it.

This is item 5's principle violated for lengths instead of colour, and the geometry gate could not see it: **8 is on the scale in all four files.** The box is `style.css`'s now; the module sheets carry states only. Worth remembering when item 21 swaps the axis — that swap is one rule rather than four.

Their backgrounds came out of the same duplication: `nixos-upgrade` and `ddc` said `@bg-base` where every other module says `@bg-surface`, drawing two chips a shade darker for no reason anyone chose.

## The bar was the wrong shape

Two numbers, and the scale was short of a third.

A module's content is a single 19px line, so the only vertical paddings the unit offered were `0` — a chip exactly as tall as its text — and `8`, which more than doubles it and is what took the bar from 41px to 55px. `space.half = 4` is the missing one, deliberately a half-step rather than a second unit: **4 is on the scale, 12 and 20 are not**, verified by injecting 12 and watching the build name it.

And the bottom margin was being spent twice. Hyprland puts `gaps_out` (8) between the bar and the window below it, so `margin: 8px 0` drew 8px above the chip and **16 below** — the asymmetry item 6 set out to remove, reintroduced from the other side. `margin: 8px 0 0 0` is what renders as 8 and 8.

| | bar | chip | above / below |
|---|---|---|---|
| before item 6 | 41 | 23 | 15 / 11 |
| as built | 55 | 39 | 8 / 16 |
| **here** | **39** | **31** | **8 / 8** |

Measured from the Hyprland layer surface, by diffing the layer set across each launch rather than assuming one bar.

## Two things found while the bar was on screen

**Track titles are somebody else's text**, and waybar renders a custom module's output as Pango markup, so an unescaped `&` was a markup error: the label refused to update and kept whatever it said before, which reads as a media module that has stopped following the player. `"escape": true` is waybar's own answer — four markup errors to zero.

**The tray icon was missing** because the icon theme in force was gsettings' default of Adwaita, which is not installed; `rose-pine-icon-theme` sat in `home.packages` with nothing pointing GTK at it. GTK fell back to `hicolor`, udiskie did not find `drive-removable-media` and returned the literal string `not-available` (`udiskie/tray.py:93`), which waybar's tray could not find either and logged as its own error. `stylix.icons` with `papirus-icon-theme`, which stylix recolours to the base16 scheme.

## Checks

`nix fmt --ci`, `nixos-rebuild build` for all three hosts, and each new gate proven by breaking it — the eight-digit hex, and a 12px padding.
