### PR TITLE
fix(monitoring): mute Cloudflare tunnel criticals during the maintenance window

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ sops secrets/homelab01.yaml                 # edit
 
 Prometheus evaluates the rules in `modules/services/monitoring/alert-rules.yml` on both servers; a two-node Alertmanager cluster deduplicates them. Notifications leave through two deliberately unequal lanes:
 
-- **Push (ntfy, self-hosted on homelab01).** Critical alerts arrive with urgent priority and buzz. Warnings arrive silently, repeat no more often than daily, and are muted between 22:00 and 07:00 (Australia/Perth) — read them at breakfast. Resolutions follow their alert's lane: a resolved critical lands as an ordinary-priority all-clear.
+- **Push (ntfy, self-hosted on homelab01).** Critical alerts arrive with urgent priority and buzz. Warnings arrive silently, repeat no more often than daily, and are muted between 22:00 and 07:00 (Australia/Perth) — read them at breakfast. The one carve-out from "criticals always buzz": Cloudflare tunnel criticals are muted between 04:00 and 05:00, because the nightly auto-upgrade reboots the host that owns the tunnel inside that window — a tunnel still down when it ends pages then. Resolutions follow their alert's lane: a resolved critical lands as an ordinary-priority all-clear.
 - **Email (the archive lane).** Everything reaches it regardless of severity, grouped by alert name so a fan-out of related alerts is one message.
 
 Inhibition rules keep one root cause from fanning out into many notifications: an unreachable host suppresses every alert sourced from its exporters, a downed tunnel suppresses the probe failures it would otherwise cause, and a degraded ZFS pool supersedes the per-symptom alerts describing the same disks.

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -108,13 +108,35 @@ in
     in
     pkgs.runCommand "check-alertmanager-config"
       {
-        nativeBuildInputs = [ pkgs.prometheus-alertmanager ];
+        nativeBuildInputs = [
+          pkgs.prometheus-alertmanager
+          pkgs.jq
+        ];
         passAsFile = [ "amConfig" ];
         amConfig = builtins.toJSON eval.config.services.prometheus.alertmanager.configuration;
       }
       ''
         amtool check-config "$amConfigPath" | tee amtool.out
         grep -q SUCCESS amtool.out
+
+        # The nightly auto-upgrade reboots the tunnel host inside the 04:00-05:00
+        # maintenance window, so CloudflareTunnel criticals fire there by design
+        # (see monitoring.nix). They must be muted - but only during that window,
+        # only on the push lane, and only for tunnel alerts: a mute that covered
+        # the wrong window, every critical, or no longer existed would either
+        # page for planned maintenance or swallow a real outage at 04:30.
+        jq -e '
+          any(.mute_time_intervals[]?;
+              .name == "maintenance-window" and
+              any(.time_intervals[]?;
+                  any(.times[]?;
+                      .start_time == "04:00" and .end_time == "05:00")))
+          and
+          any(.route.routes[]?;
+              any(.matchers[]?; contains("CloudflareTunnel"))
+              and (.mute_time_intervals? | index("maintenance-window") != null))
+        ' "$amConfigPath" >/dev/null
+
         mkdir $out
       '';
 

--- a/docs/runbooks/tunnel-and-probes.md
+++ b/docs/runbooks/tunnel-and-probes.md
@@ -15,6 +15,13 @@ is *not* inhibited: the away-host beacon is what still pages when the tunnel
 owner itself is gone, since this alert's metric lives on that host and may
 never reach an operator.
 
+Push notifications for these two alerts are muted between 04:00 and 05:00
+(Australia/Perth): that is the nightly auto-upgrade reboot window
+(`system.autoUpgrade.rebootWindow` in `hosts/*/default.nix`), and the reboot
+takes the tunnel down with the host that owns it. A tunnel still down when the
+window ends pages then, and email is never muted. Any tunnel-down outside that
+window is a genuine incident.
+
 ### Do now
 
 - `ssh homelab01 systemctl status cloudflared-tunnel`

--- a/modules/services/monitoring/monitoring.nix
+++ b/modules/services/monitoring/monitoring.nix
@@ -14,6 +14,15 @@ let
   # `attrNames` is, which keeps the generated scrape config stable.
   servers = lib.attrNames (lib.filterAttrs (_: host: host.kind == "server") fleet.hosts);
 
+  # Timezone both wall-clock mute intervals are evaluated in. Quiet hours and
+  # the maintenance window are statements about the hosts' local time, not
+  # UTC, so they share the host timezone (Australia/Perth for this fleet).
+  muteLocation =
+    if cfg.alertmanager.quietHours.timeZone != null then
+      cfg.alertmanager.quietHours.timeZone
+    else
+      "UTC";
+
   # ZFS health metrics script for textfile collector
   # Outputs Prometheus metrics for ZFS pool health
   zfsHealthScript = pkgs.writeShellScript "zfs-health-exporter" ''
@@ -786,6 +795,29 @@ in
               repeat_interval = "24h";
 
               routes = lib.optionals cfg.alertmanager.ntfy.enable [
+                # Tunnel outages inside the nightly maintenance window are the
+                # upgrade rebooting the host that owns the tunnel - expected,
+                # not an incident. Criticals normally ignore quiet hours by
+                # design, so this route is the carve-out: only tunnel alerts
+                # are muted during it, a ZFS pool fault or failed verification
+                # at 04:30 still pages, and a tunnel still down when the
+                # window ends notifies then. See the maintenance-window
+                # interval below.
+                {
+                  receiver = "push";
+                  continue = true; # email still archives it
+                  matchers = [
+                    "severity = \"critical\""
+                    "alertname =~ \"CloudflareTunnel.*\""
+                  ];
+                  group_by = [
+                    "alertname"
+                    "instance"
+                  ];
+                  group_wait = "30s";
+                  repeat_interval = "4h";
+                  mute_time_intervals = [ "maintenance-window" ];
+                }
                 {
                   receiver = "push";
                   continue = true; # email still archives it
@@ -815,31 +847,50 @@ in
             };
 
             mute_time_intervals =
-              lib.optionals (cfg.alertmanager.ntfy.enable && cfg.alertmanager.quietHours.enable)
-                [
-                  {
-                    name = "overnight";
-                    time_intervals = [
-                      {
-                        times = [
-                          {
-                            start_time = cfg.alertmanager.quietHours.start;
-                            end_time = "23:59";
-                          }
-                          {
-                            start_time = "00:00";
-                            end_time = cfg.alertmanager.quietHours.end;
-                          }
-                        ];
-                        location =
-                          if cfg.alertmanager.quietHours.timeZone != null then
-                            cfg.alertmanager.quietHours.timeZone
-                          else
-                            "UTC";
-                      }
-                    ];
-                  }
-                ];
+              (lib.optionals (cfg.alertmanager.ntfy.enable && cfg.alertmanager.quietHours.enable) [
+                {
+                  name = "overnight";
+                  time_intervals = [
+                    {
+                      times = [
+                        {
+                          start_time = cfg.alertmanager.quietHours.start;
+                          end_time = "23:59";
+                        }
+                        {
+                          start_time = "00:00";
+                          end_time = cfg.alertmanager.quietHours.end;
+                        }
+                      ];
+                      location = muteLocation;
+                    }
+                  ];
+                }
+              ])
+              ++ lib.optionals cfg.alertmanager.ntfy.enable [
+                # The servers' nightly auto-upgrade window: homelab01 starts
+                # at 04:00 and homelab02 at 04:15, each with up to 10m of
+                # randomized delay, and both reboot inside it
+                # (system.autoUpgrade.rebootWindow, hosts/*/default.nix).
+                # The tunnel lives on homelab01, so its reboots take the
+                # CloudflareTunnel* criticals down with it - a mute that did
+                # not exist left those buzzing at 04:15. Kept in step with
+                # the UnexpectedReboot alert's 04:00-05:00 exclusion.
+                {
+                  name = "maintenance-window";
+                  time_intervals = [
+                    {
+                      times = [
+                        {
+                          start_time = "04:00";
+                          end_time = "05:00";
+                        }
+                      ];
+                      location = muteLocation;
+                    }
+                  ];
+                }
+              ];
 
             inhibit_rules =
               let


### PR DESCRIPTION
## Problem

The nightly auto-upgrade reboots `homelab01` inside the 04:00–05:00 reboot window, taking the Cloudflare tunnel it owns down with it. The tunnel alerts that fire then — `CloudflareTunnelDown`, `CloudflareTunnelNoConnections`, `CloudflareTunnelServiceFailed` — are all **critical** severity, and criticals deliberately ignore the `overnight` quiet-hours mute. So a planned reboot buzzed the phone at ~04:15.

## Change

- `modules/services/monitoring/monitoring.nix`: a timezone-aware `maintenance-window` mute interval (04:00–05:00, `Australia/Perth` — matching `system.autoUpgrade.rebootWindow` and the `UnexpectedReboot` alert's exclusion) plus a dedicated tunnel-critical push route that references it.
- Scoped deliberately: only `CloudflareTunnel.*` criticals are muted during the window. A ZFS pool fault or failed verification at 04:30 still pages, a tunnel still down when the window ends notifies then, and email (the archive lane) is never muted.
- `checks/default.nix`: the `alertmanager-config` check now asserts structurally (jq) that the mute exists with exactly 04:00–05:00 and is attached to the tunnel route, so a refactor can't silently drop or widen it.
- Docs: README alerting section and `tunnel-and-probes.md` runbook updated.

## Verification

- `nix flake check` — all checks pass (includes the monitoring VM test exercising routing/inhibition/push, the amtool config check with the new jq assertions, and both hosts building).