### PR TITLE
feat(desktop): items 8-15 of the desktop plan - the missing surfaces

### DIFF
--- a/configs/hypr/binds.lua
+++ b/configs/hypr/binds.lua
@@ -17,6 +17,23 @@ hl.bind(mod .. " + P", hl.dsp.exec_cmd("project-launcher pick"))
 hl.bind(mod .. " + Q", hl.dsp.exec_cmd("project-launcher close"))
 
 ---------------------------------------------------------------------------
+-- Menus and system actions
+---------------------------------------------------------------------------
+-- Every menu is keybound *and* reachable from the bar (principle 2 in one
+-- sentence). These are the keyboard half of items 8, 9, 10, 11 and 13 of
+-- docs/plans/desktop-design.md; the pointer half lives on the bar modules.
+-- Item 9's three menus take SHIFT + the first letter of the domain, which
+-- keeps the plain letters for their applications (B = vivaldi, W = window
+-- picker, A = togglesplit).
+hl.bind(mod .. " + escape", hl.dsp.exec_cmd("power-menu"))
+hl.bind(mod .. " + SHIFT + V", hl.dsp.exec_cmd("clipboard-menu"))
+hl.bind(mod .. " + slash", hl.dsp.exec_cmd("keybind-sheet"))
+hl.bind(mod .. " + N", hl.dsp.exec_cmd("dunstctl set-paused toggle"))
+hl.bind(mod .. " + SHIFT + W", hl.dsp.exec_cmd("network-menu"))
+hl.bind(mod .. " + SHIFT + B", hl.dsp.exec_cmd("bluetooth-menu"))
+hl.bind(mod .. " + SHIFT + A", hl.dsp.exec_cmd("audio-menu"))
+
+---------------------------------------------------------------------------
 -- Window management
 ---------------------------------------------------------------------------
 hl.bind(mod .. " + C", hl.dsp.window.close())
@@ -102,29 +119,41 @@ hl.bind(mod .. " + ALT + mouse:272", hl.dsp.window.resize(), { mouse = true })
 ---------------------------------------------------------------------------
 -- Screenshot
 ---------------------------------------------------------------------------
-hl.bind("Print", hl.dsp.exec_cmd("grimblast copy area"))
+-- Item 15 of docs/plans/desktop-design.md. Print stays the common case -
+-- region to clipboard, unchanged. The other three capture to a file and
+-- offer satty as an optional annotation step; SUPER+SHIFT+C picks a colour.
+hl.bind("Print", hl.dsp.exec_cmd("screenshot area-copy"))
+hl.bind(mod .. " + Print", hl.dsp.exec_cmd("screenshot area-save"))
+hl.bind(mod .. " + SHIFT + Print", hl.dsp.exec_cmd("screenshot window"))
+hl.bind(mod .. " + CTRL + Print", hl.dsp.exec_cmd("screenshot monitor"))
+hl.bind(mod .. " + SHIFT + C", hl.dsp.exec_cmd("hyprpicker -a"))
 
 ---------------------------------------------------------------------------
 -- Media keys
----------------------------------------------------------------------------
+--------------------------------------------------------------------------
 hl.bind("XF86AudioPlay", hl.dsp.exec_cmd("playerctl play-pause"), { locked = true })
 hl.bind("XF86AudioPrev", hl.dsp.exec_cmd("playerctl previous"), { locked = true })
 hl.bind("XF86AudioNext", hl.dsp.exec_cmd("playerctl next"), { locked = true })
-hl.bind("XF86AudioMute", hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"), { locked = true })
-hl.bind("XF86AudioMicMute", hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"), { locked = true })
+
+-- Volume and brightness now go through swayosd-client (item 12): it performs
+-- the change *and* shows the OSD, so the key has immediate confirmation.
+-- That replaces wpctl here and brillo on the brightness keys - brightnessctl
+-- was already the tool everywhere else, and now it is the tool here too.
+hl.bind("XF86AudioMute", hl.dsp.exec_cmd("swayosd-client --output-volume mute-toggle"), { locked = true })
+hl.bind("XF86AudioMicMute", hl.dsp.exec_cmd("swayosd-client --input-volume mute-toggle"), { locked = true })
 
 -- Volume (repeating)
 hl.bind(
 	"XF86AudioRaiseVolume",
-	hl.dsp.exec_cmd("wpctl set-volume -l '1.0' @DEFAULT_AUDIO_SINK@ 6%+"),
+	hl.dsp.exec_cmd("swayosd-client --output-volume +5"),
 	{ locked = true, repeating = true }
 )
 hl.bind(
 	"XF86AudioLowerVolume",
-	hl.dsp.exec_cmd("wpctl set-volume -l '1.0' @DEFAULT_AUDIO_SINK@ 6%-"),
+	hl.dsp.exec_cmd("swayosd-client --output-volume -5"),
 	{ locked = true, repeating = true }
 )
 
 -- Brightness (repeating)
-hl.bind("XF86MonBrightnessUp", hl.dsp.exec_cmd("brillo -q -u 300000 -A 5"), { locked = true, repeating = true })
-hl.bind("XF86MonBrightnessDown", hl.dsp.exec_cmd("brillo -q -u 300000 -U 5"), { locked = true, repeating = true })
+hl.bind("XF86MonBrightnessUp", hl.dsp.exec_cmd("swayosd-client --brightness +5"), { locked = true, repeating = true })
+hl.bind("XF86MonBrightnessDown", hl.dsp.exec_cmd("swayosd-client --brightness -5"), { locked = true, repeating = true })

--- a/configs/swayosd/style.css
+++ b/configs/swayosd/style.css
@@ -1,0 +1,118 @@
+/*
+ * SwayOSD colours: Kanagawa Wave
+ *
+ * Generated from lib/kanagawa-wave.nix. Do not edit.
+ *
+ * A copy is checked in so that swayosd works on a machine without Nix, the
+ * way everything under configs/ does. The build asserts the two agree, so an
+ * edit here fails `nixos-rebuild switch` and fails CI rather than drifting
+ * quietly. To change a colour, change the palette and run:
+ *
+ *     nix run .#write-palette
+ *
+ * The OSD is overlay-sized, so it takes the surface radius (12) and the
+ * border (2) from lib/geometry.nix like every other surface. Item 12 of
+ * docs/plans/desktop-design.md; the same two gates the bar and the
+ * launcher sit behind.
+ */
+
+/* ── Backgrounds ─────────────────────────────────────────────────── */
+/* Layered darkest to lightest. */
+/* sumiInk0: darkest surface - module backgrounds, tooltips */
+@define-color bg-base        #16161D;
+/* sumiInk0: the same, translucent - rofi's window behind its own chrome */
+@define-color bg-backdrop    alpha(#16161D, 0.8);
+/* sumiInk1: default background - the layer most things sit on */
+@define-color bg-surface     #1F1F28;
+/* sumiInk2: raised chrome - tooltip borders, rofi's input bar */
+@define-color bg-overlay     #2A2A37;
+/* sumiInk3: separators and elevated surfaces */
+@define-color bg-raised      #363646;
+/* waveBlue1: hover and selection */
+@define-color bg-hover       #223249;
+
+/* ── Foreground ──────────────────────────────────────────────────── */
+/* Text, brightest to dimmest. */
+/* fujiWhite: primary text */
+@define-color fg-primary     #DCD7BA;
+/* oldWhite: secondary text */
+@define-color fg-secondary   #C8C093;
+/* fujiGray: placeholders and comments */
+@define-color fg-muted       #727169;
+/* sumiInk4: disabled and inactive */
+@define-color fg-disabled    #54546D;
+
+/* ── Structure ───────────────────────────────────────────────────── */
+/* sumiInk4: borders and separators */
+@define-color border         #54546D;
+/* springBlue: the accent - prominent chrome that is not carrying a state */
+@define-color accent         #7FB4CA;
+
+/* ── Semantic states ─────────────────────────────────────────────── */
+/* What a colour *means*. Nothing here is decorative. */
+/* autumnRed: errors, critical states, destructive actions */
+@define-color danger         #C34043;
+/* waveRed: the same, where it must carry against a selection */
+@define-color danger-bright  #E46876;
+/* roninYellow: warnings, overrides, updates available */
+@define-color warning        #FF9E3B;
+/* springGreen: healthy, complete, up to date */
+@define-color success        #98BB6C;
+/* crystalBlue: informational and neutral-active */
+@define-color info           #7E9CD8;
+/* oniViolet: second informational voice - disk, audio, applying */
+@define-color secondary      #957FB8;
+/* sakuraPink: decorative, attention-drawing - the media player */
+@define-color highlight      #D27E99;
+
+window#osd {
+  border-radius: 12px;
+  border: 2px solid @border;
+  background: alpha(@bg-surface, 0.9);
+}
+
+#container {
+  margin: 8px 16px;
+}
+
+image,
+label {
+  color: @fg-primary;
+}
+
+progressbar:disabled,
+image:disabled {
+  opacity: 0.5;
+}
+
+progressbar,
+segmentedprogress {
+  min-height: 8px;
+  border-radius: 8px;
+  background: transparent;
+  border: none;
+}
+
+trough,
+segment {
+  min-height: inherit;
+  border-radius: inherit;
+  border: none;
+  background: alpha(@fg-primary, 0.5);
+}
+
+progress,
+segment.active {
+  min-height: inherit;
+  border-radius: inherit;
+  border: none;
+  background: @accent;
+}
+
+segment {
+  margin-left: 8px;
+}
+
+segment:first-child {
+  margin-left: 0;
+}

--- a/configs/waybar/config.jsonc
+++ b/configs/waybar/config.jsonc
@@ -28,14 +28,17 @@
     "custom/project",
     "tray",
     "idle_inhibitor",
+    "custom/dnd",
     "privacy",
     "custom/media",
     "custom/modifiers",
   ],
   "modules-center": ["clock"],
   "modules-right": [
+    "custom/failed-units",
     "custom/nixos-upgrade",
     "network",
+    "bluetooth",
     "cpu",
     "disk",
     "memory",
@@ -44,6 +47,7 @@
     "pulseaudio",
     "backlight",
     "custom/ddc-brightness",
+    "custom/power",
   ],
 
   // ===========================================================================
@@ -57,6 +61,28 @@
     "on-click-right": "nixos-upgrade-waybar-click --button right",
     "on-click-middle": "nixos-upgrade-waybar-click --button middle",
     "tooltip": true,
+  },
+
+  // Item 14 of the desktop plan. Quiet when every user and system unit is
+  // healthy, a visible marker when any has failed; the click lists the
+  // failed units and opens the chosen one's journal. Same shape as the
+  // nixos-upgrade module above: no news, no noise.
+  "custom/failed-units": {
+    "exec": "failed-units-waybar",
+    "return-type": "json",
+    "interval": 30,
+    "on-click": "failed-units-click",
+    "tooltip": true,
+  },
+
+  // Item 8 of the desktop plan. One click away from every action that ends
+  // the session - lock, suspend, log out, reboot, power off - with the
+  // destructive entries last so the fast path lands on Lock. SUPER+Escape is
+  // the keyboard path; neither one is the real one.
+  "custom/power": {
+    "format": "󰐥",
+    "on-click": "power-menu",
+    "tooltip": "Lock, suspend, log out, reboot or power off",
   },
 
   "custom/ddc-brightness": {
@@ -98,6 +124,19 @@
     "return-type": "json",
     "tooltip": true,
     "on-click": "project-launcher pick",
+  },
+
+  // Item 13 of the desktop plan. Reads dunst's own paused state - a bell
+  // when quiet, a "DND" label when notifications are paused, so the state
+  // cannot be left on silently. Left toggles, right opens the history of
+  // missed notifications. SUPER+N is the keyboard path.
+  "custom/dnd": {
+    "exec": "dnd-waybar",
+    "return-type": "json",
+    "interval": 2,
+    "on-click": "dunstctl set-paused toggle",
+    "on-click-right": "dnd-history",
+    "tooltip": true,
   },
 
   // ===========================================================================
@@ -215,13 +254,36 @@
   "network": {
     "interval": 30,
     "format-alt": "{ifname}: {ipaddr}/{cidr}",
+    // The plan (item 9) wanted the format toggle kept after the menu took
+    // the left click. Waybar's format-alt toggles on left click by default;
+    // format-alt-click moves it, here to the right button, so neither
+    // surface eats the other.
+    "format-alt-click": "click-right",
     "format-disconnected": "Disconnected ⚠",
     "format-ethernet": "{ifname}: {ipaddr}/{cidr}   up: {bandwidthUpBits} down: {bandwidthDownBits}",
     "format-linked": "{ifname} (No IP) ",
     "format-wifi": "{signalStrength}% ",
-    // Left = toggle format (format-alt handles natively)
-    // Middle was nm-connection-editor, which is not installed; item 9 of the
-    // desktop plan gives the network a rofi menu instead.
+    // Left = the wifi menu (item 9 of the desktop plan), SUPER+SHIFT+W the
+    // keyboard half. Right = the alternate format, kept via format-alt-click
+    // above rather than lost to the menu. Middle stays nothing: item 3
+    // dropped the dead nm-connection-editor middle click and the menu
+    // connects to networks without editing profiles, which is `full` depth
+    // and belongs to an application.
+    "on-click": "network-menu",
+  },
+
+  // Item 9 of the desktop plan. The native bluetooth module - a glyph in
+  // each adapter state, the connected device in the tooltip - with its left
+  // click opening the device menu. The CSS has been waiting for this module
+  // since before the plan existed.
+  "bluetooth": {
+    "format-disabled": "󰂲",
+    "format-off": "󰂯",
+    "format-on": "󰂯",
+    "format-connected": "󰂯",
+    "tooltip-format-connected": "{num_connections} connected{device_enumerate}",
+    "tooltip-format-enumerate-connected": "\n  {device_alias}",
+    "on-click": "bluetooth-menu",
   },
 
   // ===========================================================================
@@ -243,11 +305,13 @@
     "format-muted": " {format_source}",
     "format-source": "{volume}% ",
     "format-source-muted": "",
-    // Left = open pavucontrol, Right = toggle mute
-    // Middle was a pulsemixer TUI; item 9 of the desktop plan replaces it with
-    // a sink picker in rofi.
-    "on-click": "pavucontrol",
+    // Left = the audio device menu (item 9 of the desktop plan) - "which
+    // headphones" is a pick, not a full mixer. Right = toggle mute.
+    // Middle = pavucontrol, the full mixer, moved here from the dead
+    // pulsemixer binding (item 3).
+    "on-click": "audio-menu",
     "on-click-right": "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle",
+    "on-click-middle": "pavucontrol",
     "on-scroll-up": "wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+",
     "on-scroll-down": "wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-",
   },

--- a/configs/waybar/style.css
+++ b/configs/waybar/style.css
@@ -81,6 +81,9 @@ tooltip {
 #custom-media,
 #custom-nixos-upgrade,
 #custom-ddc-brightness,
+#custom-dnd,
+#custom-failed-units,
+#custom-power,
 #window,
 #clock,
 #battery,
@@ -160,6 +163,54 @@ tooltip {
   margin-right: 16px;
 }
 
+/* Item 13: do-not-disturb changes shape, not just colour, when it is on - a
+ * bell while quiet, a labelled chip while paused, so the state cannot be
+ * left on silently. The box is style.css's; these are the states.
+ *
+ * When quiet it reads as an idle module like any other. */
+#custom-dnd {
+  color: @fg-muted;
+  border-radius: 8px;
+  margin-left: 8px;
+  margin-right: 0px;
+}
+
+#custom-dnd.paused {
+  color: @warning;
+  background: @bg-raised;
+  font-weight: bold;
+}
+
+/* Item 14: the failed-units module is nothing at all when healthy - the same
+ * collapse the project module uses - and a danger chip when something has
+ * failed. `.ok` is emitted by the script, so the collapse is keyed on real
+ * state rather than on a class nobody sets. */
+#custom-failed-units.ok {
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  min-width: 0;
+  color: transparent;
+}
+
+#custom-failed-units.failed {
+  color: @danger;
+  background: @bg-raised;
+  border-radius: 8px;
+  margin-right: 8px;
+}
+
+/* Item 8: the power module closes the right end of the bar, beside the
+ * backlight chip, with the same asymmetric radius the bar's other edge
+ * modules carry. */
+#custom-power {
+  color: @fg-secondary;
+  border-radius: 0px 8px 8px 0px;
+  margin-right: 16px;
+  border-left: 0px;
+}
+
 /* nixos-upgrade.css and ddc.css own these two modules' states - which colour
  * means "updates available", which means "override". They used to own the box
  * as well, and restated it: the same padding, margin, border and radius
@@ -236,6 +287,12 @@ window#waybar.empty #window {
 #network {
   color: @info;
   border-radius: 8px 0px 0px 8px;
+  border-right: 0px;
+}
+
+#bluetooth {
+  color: @accent;
+  border-left: 0px;
   border-right: 0px;
 }
 

--- a/docs/plans/desktop-design.md
+++ b/docs/plans/desktop-design.md
@@ -1,6 +1,6 @@
 # Plan: the desktop, as a designed system
 
-Status: proposed 2026-09-05; the four open questions were answered on 2026-09-06 and two requirements were added that change the shape of the bar and remove motion from the desktop entirely — see _Decisions, 2026-09-06_ below. Items 22, 1–4 and 5–7 were built on 2026-09-06; everything from 8 on is still proposed. This is the spine document for a series of sessions — it decides what the desktop is _for_, names the rules a change can be checked against, records what is actually there today, and sequences the work. The per-tool sessions (waybar, rofi, the lock screen) come after, and their brief is this document rather than a fresh opinion.
+Status: proposed 2026-09-05; the four open questions were answered on 2026-09-06 and two requirements were added that change the shape of the bar and remove motion from the desktop entirely — see _Decisions, 2026-09-06_ below. Items 22, 1–4, 5–7 were built on 2026-09-06, and **8–15 on 2026-09-06 as well**; 16, 17, 18, 20 and 21 are still proposed. This is the spine document for a series of sessions — it decides what the desktop is _for_, names the rules a change can be checked against, records what is actually there today, and sequences the work. The per-tool sessions (waybar, rofi, the lock screen) come after, and their brief is this document rather than a fresh opinion.
 
 Scope is the `xps15` host: `modules/home/desktop/`, `modules/nixos/hyprland.nix`, `modules/nixos/stylix.nix` and the eleven files under `configs/` that they deploy. The servers are out of scope and have no desktop.
 
@@ -111,14 +111,14 @@ These are the load-bearing ones. Each is argued in its item below; they are coll
 | 5 | One palette, one source | medium | – | **done 2026-09-06** — the repository owns the palette |
 | 6 | A geometry scale | small | – | **done 2026-09-06**; motion half withdrawn 2026-09-06 |
 | 7 | Rofi is the menu system | medium | 5 | **done 2026-09-06** — scaffolding, and the picker moved onto it |
-| 8 | Power and session | small | 7 | proposed |
-| 9 | Network, bluetooth, audio | medium | 7 | proposed |
-| 10 | Clipboard history that survives its window | small | 7 | proposed |
-| 11 | The keybind sheet | small | 7 | proposed |
-| 12 | Hardware feedback has nowhere to land | small | 5 | proposed; rewritten for swayosd 2026-09-06 |
-| 13 | Do not disturb, and a history | small | 7 | proposed |
-| 14 | What is running, and what has failed | medium | 3, 7 | proposed |
-| 15 | The screenshot suite | small | – | proposed |
+| 8 | Power and session | small | 7 | **done 2026-09-06** |
+| 9 | Network, bluetooth, audio | medium | 7 | **done 2026-09-06** |
+| 10 | Clipboard history that survives its window | small | 7 | **done 2026-09-06** |
+| 11 | The keybind sheet | small | 7 | **done 2026-09-06** |
+| 12 | Hardware feedback has nowhere to land | small | 5 | **done 2026-09-06** — rewritten for swayosd 2026-09-06 |
+| 13 | Do not disturb, and a history | small | 7 | **done 2026-09-06** |
+| 14 | What is running, and what has failed | medium | 3, 7 | **done 2026-09-06** |
+| 15 | The screenshot suite | small | – | **done 2026-09-06** |
 | 16 | Measure, then tune: blur and the cursor | medium | 22 | proposed; motion variable withdrawn 2026-09-06 |
 | 17 | The lock screen is off-palette | small | 5 | proposed |
 | 18 | The greeter, on the record | small | 5 | proposed |
@@ -296,7 +296,7 @@ Four things the item did not anticipate:
 
 - **The calendar is answered by an `include`, not by generating `config.jsonc`.** waybar's `mergeConfig` recurses into objects and lets the including file win any key it already sets (confirmed in `src/config.cpp`), so `config.jsonc` keeps every decision about the calendar and `calendar.jsonc` supplies only the four Pango colours. `config.jsonc` is now hex-free. `waybar-commands.py` follows `include` too, so a command arriving from one is checked like any other.
 - **The calendar is the one surface that reads `colours` rather than `roles`,** and this is the exception the item's rule asks to be put on the record. It is markup inside JSON with no widget to theme; the four spans are typography, not state. Inventing four roles with one user each would have been worse than naming the pigment, which is still named in exactly one file.
-- **rofi silently ignores a theme it cannot parse** — it warns to a log nobody reads and loads its own default, so a broken theme looks like a launcher that has reverted to Solarized. That is now a build gate as well (`rofi -no-config -theme … -dump-theme` needs no display). It earned itself immediately: rofi's grammar takes a *literal* colour in `element-text`'s `highlight` and rejects both `@info` and `var(info)`, so that one declaration is generated into `palette.rasi` rather than left as the last hex in the layout file.
+- **rofi silently ignores a theme it cannot parse** — it warns to a log nobody reads and loads its own default, so a broken theme looks like a launcher that has reverted to Solarized. That is now a build gate as well (`rofi -no-config -theme … -dump-theme` needs no display). It earned itself immediately: rofi's grammar takes a _literal_ colour in `element-text`'s `highlight` and rejects both `@info` and `var(info)`, so that one declaration is generated into `palette.rasi` rather than left as the last hex in the layout file.
 - **A fifth hand-written palette turned up.** `modules/home/desktop/waybar-modifiers.nix` emits Pango markup, so its colours were out of CSS's reach — and it had been carrying a **Rose Pine** palette from before the machine was themed. Its four modifier colours now come from `roles`.
 
 Role names were reconciled to waybar's, as the item asks, and the audit shaved two: `accent-primary` (waveAqua1) was declared and referenced by nothing, and rofi's `accent2` likewise. What was `accent-secondary` is now `accent`, which is the only change `style.css` needed. Six theme files that had never been rendered are gone — two waybar, four rofi — and `stylix.targets.rofi.enable` is now explicitly `false` rather than inert-by-accident, so the latent fight over `~/.config/rofi` is settled on the record.
@@ -404,6 +404,17 @@ The rule underneath that answer generalises, and is the reason to write it down 
 
 An hour once item 7 exists.
 
+### Built, 2026-09-06
+
+`packages/power-menu`, built with the `mkMenu` builder item 7 asked the
+second menu to extract, and reachable both ways: `SUPER+Escape` in binds.lua
+and a `custom/power` module at the right end of the bar. The list is the
+order the decision settled on — lock, suspend, log out, reboot, power off —
+so a bare Return on an empty filter lands on Lock. `loginctl lock-session`
+for lock, `systemctl` for suspend/reboot/poweroff, and `hyprctl dispatch
+exit` for log out: UWSM ends the session when the compositor does, which is
+loginctl's "log out" wearing the name of the mechanism that actually does it.
+
 ## 9. Network, bluetooth, audio
 
 ### The problem
@@ -422,6 +433,39 @@ Three rofi menus and three bar modules, in that order of dependency.
 
 A session, or one each if taken separately. The passphrase prompt is the only fiddly part — rofi can read a masked line, and the alternative is deferring to `nmtui` for new networks and handling only saved ones, which is a smaller and possibly better first version.
 
+### Built, 2026-09-06
+
+Three menus and three bar modules, plus the three keyboard binds that make
+each one reachable two ways — `SUPER+SHIFT+W` network, `SUPER+SHIFT+B`
+bluetooth, `SUPER+SHIFT+A` audio (the plain letters belong to applications).
+`network-menu` over `nmcli` — saved and visible networks with signal
+strength, a masked rofi password prompt for the not-yet-saved case, and
+"saved" decided on the connection name field alone (`nmcli -g NAME`,
+fixed-string), so an SSID full of regex is still an SSID and a whole-line
+match cannot silently send every network down the passphrase path.
+`bluetooth-menu` over `bluetoothctl` — paired _and_ discoverable devices,
+state-marked (connected, paired, or just discovered), with a scan entry that
+runs a bounded discovery scan and re-opens the menu so freshly seen devices
+appear; pairing itself stays one entry that opens `blueman-manager` rather
+than asking a PIN a menu should not. `audio-menu` over `wpctl` — sinks then
+sources, each row carrying the node id tab-separated from the name, so
+`wpctl set-default` needs no further parsing; PipeWire node ids are unique
+across sinks and sources, which is what makes one menu over both possible.
+
+The bar changes follow the item's order of dependency. The `network` module's
+left click opens the wifi menu and its right keeps the alternate format —
+waybar toggles `format-alt` on left click by default, and `format-alt-click:
+click-right` moves the toggle rather than letting the menu eat it; the
+`pulseaudio` module's left opens the audio menu and pavucontrol moves to
+middle, where the dead `pulsemixer` binding was; the `bluetooth` module —
+whose CSS has been waiting in style.css since before the plan existed — is
+added, and its left click opens the device menu. The `blueman` package moved
+out of the host's package list into the bluetooth menu's own closure, which
+resolves the half-installed state by giving the package the pairing job a
+menu should not attempt, instead of leaving it inert. The three binds and the
+right-click toggle are review corrections: the first built version had the
+menus pointer-only and had let the format toggle die on the left click.
+
 ## 10. Clipboard history that survives its window
 
 ### The problem
@@ -438,6 +482,16 @@ Two things need deciding: how long the history is, and whether password-manager 
 
 An hour. Low risk and probably the highest ratio of daily relief to effort in this entire document.
 
+### Built, 2026-09-06
+
+`services.cliphist` and `services.wl-clip-persist`, plus `clipboard-menu`
+bound to `SUPER+SHIFT+V`, all under one `cg.home.clipboard` toggle. The
+sensitive-hint question resolved itself rather than needing a filter:
+cliphist's `store` reads `CLIPBOARD_STATE` — which wl-clipboard sets when an
+offer carries the `secret` hint — and skips, so password-manager fields are
+excluded by the tool's own logic. History length is cliphist's default
+`-max-items 500`, which nobody argued with because nobody has a reason to.
+
 ## 11. The keybind sheet
 
 ### The problem
@@ -453,6 +507,24 @@ Parsing Lua with a regex is the obvious objection. The counter is that `binds.lu
 ### Cost and risk
 
 Half a session. Consider making the entries actionable — picking one runs it — which turns the cheat sheet into a command palette for free.
+
+### Built, 2026-09-06
+
+`packages/keybind-sheet`, bound to `SUPER+slash`. It parses the _deployed_
+binds.lua — every `hl.bind` call, grouped by the section comments — and
+renders into rofi-menu. The parse is deliberately over this file's one style
+rather than Lua, and it is gated rather than trusted: hyprland.nix runs the
+identical parser over the checked-in binds.lua — via the package's own
+`keybind-sheet-parse` command, so the build gate calls a script that lives
+where the parser lives rather than reaching into its source — and a file the
+sheet stops understanding (including one that parses to nothing) fails the
+build instead of silently losing its documentation. The regex objections the
+item anticipated showed up as real bugs in the first pass — multi-line binds,
+and the prose comments that sit beside fenced section titles — and both are
+answered by the file's own conventions (a bind keeps accumulating until its
+parens balance; a title is only a title when a fence precedes it and it is
+short). Entries are display-only for now; making them runnable is the
+"consider" the item left open.
 
 ## 12. Hardware feedback has nowhere to land
 
@@ -477,6 +549,24 @@ While here: `brillo` on the function keys and `brightnessctl` in the bar and in 
 
 Half a session, most of it theming. The volume and brightness binds grow a second command each, which argues for moving them out of `binds.lua` into a small script rather than lengthening the Lua — the same move item 15 wants for the screenshot binds.
 
+### Built, 2026-09-06
+
+`services.swayosd.enable`, with the volume, mute and brightness binds in
+binds.lua calling `swayosd-client` — which performs the change _and_ shows
+the OSD — instead of `wpctl` and `brillo`. `brillo` is gone, so brightnessctl
+is the one brightness tool, used by the bar's backlight module, hypridle and
+swayosd alike, which is the "pick one" the item asked for. The client route
+is the one taken: the libinput backend is not started, because the binds are
+already explicit and caps-lock is already reported by `custom/modifiers`.
+
+The theming half is where the item's other point landed. `configs/swayosd/style.css`
+is generated from lib/kanagawa-wave.nix and checked in, and it sits behind
+three gates: the palette match, the geometry scale, and a new GTK 4 parse
+check (`swayosd-css-parse.py`) — swayosd, unlike waybar, only warns and
+carries on when its stylesheet fails, so a file GTK rejects would otherwise
+be an OSD that silently looks default. The OSD keeps the server's default
+top-margin; item 21 positions it against the new bar when that lands.
+
 ## 13. Do not disturb, and a history
 
 ### The problem
@@ -494,6 +584,17 @@ Consider also pausing automatically during fullscreen — Hyprland can signal it
 ### Cost and risk
 
 Half a session.
+
+### Built, 2026-09-06
+
+A `custom/dnd` waybar module reading `dunstctl is-paused` — a bell when
+quiet, a labelled "DND" chip when paused, so the state changes shape rather
+than only colour and cannot be left on silently. Left click toggles
+`dunstctl set-paused toggle` (also `SUPER+N`); right click opens a rofi menu
+over `dunstctl history`, and picking an entry `history-pop`s it, which
+re-displays the notification the user missed. Auto-pause during fullscreen
+is deliberately not added: that is a system deciding something on the user's
+behalf, and it stays a revisitable choice rather than a default.
 
 ## 14. What is running, and what has failed
 
@@ -517,6 +618,20 @@ The `custom/nixos-upgrade` module is worth pointing at as the pattern for the wh
 
 A session. The failed-units module is the interesting half and is a good candidate for the same Go treatment the other custom modules got, since shelling out to `systemctl` twice on an interval is exactly the kind of poller principle 1's second sentence warns about — it should be event-driven off the systemd D-Bus signal instead.
 
+### Built, 2026-09-06
+
+A `custom/failed-units` module — `systemctl --user --failed` plus the system
+equivalent, rendered as nothing at all when every unit is healthy and as a
+danger marker when any has failed. That is the `custom/nixos-upgrade`
+pattern verbatim, which is the point of the item's last paragraph. Clicking
+it lists the failed units in rofi — each tagged `user` or `system` — and
+opens the chosen one's journal in ghostty, `journalctl --user` or not
+depending on which side of the line the unit sits on. The process half was
+already built as item 3: cpu, memory and temperature carry their single
+consistent left click into btop, so this item was the half that was not. The
+module polls on a 30-second interval, far slower than the thing it watches
+changes; the Go/D-Bus treatment stays the upgrade path, as the item notes.
+
 ## 15. The screenshot suite
 
 ### The problem
@@ -532,6 +647,17 @@ Keep `grimblast` and give it the full set, under `Print` with modifiers: region 
 ### Cost and risk
 
 An hour. Purely additive.
+
+### Built, 2026-09-06
+
+`packages/screenshot`, with binds under `Print`: region to clipboard
+(unchanged, the common case), region to file, active window, current
+monitor, and `SUPER+SHIFT+C` for hyprpicker. The save modes write to
+`~/Pictures/screenshots` and offer satty as a second decision — a dismissed
+prompt means "save it as it is", never a captured frame that vanished. The
+screenshot binds moved out of binds.lua into the script, the move item 12's
+note and this item's shape both pointed at. `satty` over `swappy`, as the
+item decided on maintenance grounds.
 
 ## 16. Measure, then tune: blur and the cursor
 

--- a/hosts/xps15/default.nix
+++ b/hosts/xps15/default.nix
@@ -137,6 +137,12 @@
     powerOnBoot = true;
     settings.General.Enable = "Source,Sink,Media,Socket";
   };
+  # No blueman-applet, on purpose: the bluetooth-menu owns connect/disconnect
+  # (item 9 of the desktop plan) and item 7 rejected the applet as the UI.
+  # The blueman *package* is carried by the bluetooth-menu module instead of
+  # the host's package list, so the pairing flow that menu should not attempt
+  # stays one keystroke away in blueman-manager and the package gains the
+  # purpose the "half-installed" state never had.
   services.blueman.enable = false;
 
   # Logitech wireless devices
@@ -196,7 +202,6 @@
     glib
     dconf
     xdg-utils
-    blueman
     libsmbios # Dell-specific BIOS utilities (fan control, etc.)
     dmidecode
 

--- a/hosts/xps15/home.nix
+++ b/hosts/xps15/home.nix
@@ -41,6 +41,19 @@
     playerctl.enable = true;
     yazi.enable = true;
 
+    # Items 8-15 of docs/plans/desktop-design.md - the missing surfaces, one
+    # toggle each. The menus all go through rofi-menu (item 7).
+    power-menu.enable = true;
+    network-menu.enable = true;
+    bluetooth-menu.enable = true;
+    audio-menu.enable = true;
+    clipboard.enable = true;
+    keybind-sheet.enable = true;
+    swayosd.enable = true;
+    dnd.enable = true;
+    failed-units.enable = true;
+    screenshot.enable = true;
+
     obsidian-sync.enable = true;
 
     project-launcher = {

--- a/lib/kanagawa-wave.nix
+++ b/lib/kanagawa-wave.nix
@@ -315,6 +315,25 @@ rec {
   # file, including its header, so that what is checked in is exactly what the
   # build produces and `diff` is the entire check.
 
+  # The @define-color block shared by every GTK CSS surface. GTK 3 CSS has no
+  # custom properties, so this is the only indirection available - which is why
+  # the layouts in style.css and the swayosd rules can stay hand-written and
+  # hex-free while this half is generated.
+  defineColors = lib.concatStringsSep "\n" (
+    map (group: ''
+
+      /* ── ${group.title} ${repeat (62 - lib.stringLength group.title) "─"} */
+      ${lib.optionalString (group.note != "") "/* ${group.note} */\n"}${
+        lib.concatStringsSep "\n" (
+          map (
+            role:
+            "/* ${role.colour}: ${role.note} */\n"
+            + "@define-color ${role.name}${pad 15 role.name}${cssValue role};"
+          ) group.roles
+        )
+      }'') groups
+  );
+
   # waybar. GTK 3 CSS has no custom properties, so `@define-color` is the only
   # indirection available - which is why the layout in style.css can stay
   # hand-written and hex-free while this half is generated.
@@ -328,20 +347,84 @@ rec {
      * the palette at different pigment; the role names are the interface and
      * do not change.
      */
-    ${lib.concatStringsSep "\n" (
-      map (group: ''
+    ${defineColors}
+  '';
 
-        /* ── ${group.title} ${repeat (62 - lib.stringLength group.title) "─"} */
-        ${lib.optionalString (group.note != "") "/* ${group.note} */\n"}${
-          lib.concatStringsSep "\n" (
-            map (
-              role:
-              "/* ${role.colour}: ${role.note} */\n"
-              + "@define-color ${role.name}${pad 15 role.name}${cssValue role};"
-            ) group.roles
-          )
-        }'') groups
-    )}
+  # swayosd (item 12 of docs/plans/desktop-design.md). The OSD reads a plain
+  # ~/.config/swayosd/style.css and stylix has no target for it, so it joins
+  # the generated scheme from its first commit rather than arriving as a
+  # fourth hand-written copy of the palette and being cleaned up afterwards.
+  #
+  # The rules mirror swayosd's own default theme - window#osd, #container, the
+  # progressbar/trough/progress stack, segment for the segmented variant -
+  # with the palette's roles instead of GTK's theme variables, and the
+  # geometry scale's numbers instead of the default's pill shape. It is GTK 4
+  # CSS, which is the same grammar as the waybar half above with a narrower
+  # parser; the build validates it with GTK 4 (swayosd-css-parse.nix).
+  toSwayosdCss = ''
+    /*
+     * SwayOSD colours: Kanagawa Wave
+     *
+    ${comment " *" (banner "swayosd")}
+     *
+     * The OSD is overlay-sized, so it takes the surface radius (12) and the
+     * border (2) from lib/geometry.nix like every other surface. Item 12 of
+     * docs/plans/desktop-design.md; the same two gates the bar and the
+     * launcher sit behind.
+     */
+    ${defineColors}
+
+    window#osd {
+      border-radius: 12px;
+      border: 2px solid @border;
+      background: alpha(@bg-surface, 0.9);
+    }
+
+    #container {
+      margin: 8px 16px;
+    }
+
+    image,
+    label {
+      color: @fg-primary;
+    }
+
+    progressbar:disabled,
+    image:disabled {
+      opacity: 0.5;
+    }
+
+    progressbar,
+    segmentedprogress {
+      min-height: 8px;
+      border-radius: 8px;
+      background: transparent;
+      border: none;
+    }
+
+    trough,
+    segment {
+      min-height: inherit;
+      border-radius: inherit;
+      border: none;
+      background: alpha(@fg-primary, 0.5);
+    }
+
+    progress,
+    segment.active {
+      min-height: inherit;
+      border-radius: inherit;
+      border: none;
+      background: @accent;
+    }
+
+    segment {
+      margin-left: 8px;
+    }
+
+    segment:first-child {
+      margin-left: 0;
+    }
   '';
 
   # rofi. Imported by themes/kanagawa-wave.rasi, which keeps the layout.
@@ -428,5 +511,6 @@ rec {
     "configs/waybar/kanagawa-wave.css" = toCss;
     "configs/waybar/calendar.jsonc" = toCalendarJson;
     "configs/rofi/themes/palette.rasi" = toRasi;
+    "configs/swayosd/style.css" = toSwayosdCss;
   };
 }

--- a/modules/home/desktop/audio-menu.nix
+++ b/modules/home/desktop/audio-menu.nix
@@ -1,0 +1,22 @@
+# Audio device menu - item 9 of docs/plans/desktop-design.md.
+#
+# The bar's pulseaudio module opens it on left click, and pavucontrol - the
+# full mixer - moves to middle click. See packages/audio-menu.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.cg.home.audio-menu;
+
+  audio-menu = pkgs.audio-menu or (pkgs.callPackage ../../../packages/audio-menu { });
+in
+{
+  options.cg.home.audio-menu.enable = lib.mkEnableOption "Audio sink and source menu";
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ audio-menu ];
+  };
+}

--- a/modules/home/desktop/binds-commands.py
+++ b/modules/home/desktop/binds-commands.py
@@ -1,0 +1,64 @@
+"""Assert that every command binds.lua hands to a shell actually exists.
+
+Item 1 of docs/plans/desktop-design.md checked waybar's config and noted that
+the same question applies to binds.lua, which also names binaries -
+"extending it is cheap afterwards". This is that extension, taken when items
+8-15 added about a dozen commands to the file and made the keybind sheet
+worth gating: a bind that runs a binary the closure does not carry is the
+same dead-interaction defect the bar's check exists to stop.
+
+Scope, deliberately narrow, like the waybar check: the *head* of every
+exec_cmd("...") string, resolved against the same two closures the session
+provides on PATH. A dispatch call (hl.dsp.*) is not a command and is not
+looked for; neither is the inside of a `$(...)` in a non-exec_cmd string,
+because there are none in this file and the waybar check's reasoning applies
+unchanged.
+
+Usage: binds-commands.py <binds.lua> <bin-dir:bin-dir:...>
+"""
+
+import os
+import re
+import sys
+
+# exec_cmd("...") - the one way this file asks for a shell. The capture
+# tolerates an escaped quote inside the string, the way the Lua does.
+EXEC_CMD = re.compile(r'exec_cmd\(\s*"((?:[^"\\]|\\.)*)"')
+
+
+def head(command):
+    words = command.split()
+    return words[0] if words else ""
+
+
+def main(argv):
+    binds_path, search_path = argv[1], argv[2]
+    bindirs = [d for d in search_path.split(":") if d]
+
+    with open(binds_path) as handle:
+        text = handle.read()
+
+    failures = []
+    for command in EXEC_CMD.findall(text):
+        name = head(command)
+        if not name:
+            failures.append((command, "the command is empty"))
+        elif not any(os.path.exists(os.path.join(d, name)) for d in bindirs):
+            failures.append((command, "%s: not found" % name))
+
+    if not failures:
+        return 0
+
+    print("%s names commands that are not installed:\n" % binds_path, file=sys.stderr)
+    for command, why in failures:
+        print("    %s\n    -> %s\n" % (command, why), file=sys.stderr)
+    print(
+        "Add the package that provides it to the closure, or change the bind.\n"
+        "A bind that runs nothing is the bar's dead click wearing a keyboard.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/modules/home/desktop/bluetooth-menu.nix
+++ b/modules/home/desktop/bluetooth-menu.nix
@@ -1,0 +1,23 @@
+# Bluetooth menu - item 9 of docs/plans/desktop-design.md.
+#
+# The bar's bluetooth module opens it on left click. The menu owns
+# connect/disconnect for known devices; pairing goes through blueman-manager,
+# which the package carries. See packages/bluetooth-menu.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.cg.home.bluetooth-menu;
+
+  bluetooth-menu = pkgs.bluetooth-menu or (pkgs.callPackage ../../../packages/bluetooth-menu { });
+in
+{
+  options.cg.home.bluetooth-menu.enable = lib.mkEnableOption "Bluetooth device menu";
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ bluetooth-menu ];
+  };
+}

--- a/modules/home/desktop/brightness.nix
+++ b/modules/home/desktop/brightness.nix
@@ -12,9 +12,13 @@ in
   options.cg.home.brightness.enable = lib.mkEnableOption "Brightness control utilities";
 
   config = lib.mkIf cfg.enable {
-    home.packages = with pkgs; [
-      brillo # Backlight control (used in hyprland config)
-      brightnessctl # Alternative brightness control
+    # brightnessctl is the one brightness tool, after item 12 of
+    # docs/plans/desktop-design.md: the media-key binds go through
+    # swayosd-client (which uses brightnessctl under the hood), the bar's
+    # backlight module and hypridle both use it already, and brillo - which
+    # used to own the keys and could disagree with all of them - is gone.
+    home.packages = [
+      pkgs.brightnessctl # Backlight control (bar module, hypridle, swayosd)
     ];
   };
 }

--- a/modules/home/desktop/clipboard.nix
+++ b/modules/home/desktop/clipboard.nix
@@ -1,0 +1,35 @@
+# Clipboard history - item 10 of docs/plans/desktop-design.md.
+#
+# Two daemons and one menu. cliphist stores the history (skipping offers that
+# carry the secret hint, which is what makes it safe to keep password-manager
+# fields near the clipboard); wl-clip-persist keeps the current selection
+# alive beyond the window that copied it - the papercut that fires several
+# times a day. The menu is SUPER+SHIFT+V. See packages/clipboard-menu.
+#
+# History length is cliphist's own default (-max-items 500, which the
+# home-manager service sets) and has not been argued with; a number nobody
+# has a reason for is a number nobody should choose.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.cg.home.clipboard;
+
+  clipboard-menu = pkgs.clipboard-menu or (pkgs.callPackage ../../../packages/clipboard-menu { });
+in
+{
+  options.cg.home.clipboard.enable =
+    lib.mkEnableOption "Clipboard history (cliphist + wl-clip-persist)";
+
+  config = lib.mkIf cfg.enable {
+    services.cliphist.enable = true;
+    services.wl-clip-persist.enable = true;
+
+    # The menu is the same toggle's other half: clipboard history without a
+    # way to recall it is a store that only grows.
+    home.packages = [ clipboard-menu ];
+  };
+}

--- a/modules/home/desktop/dnd.nix
+++ b/modules/home/desktop/dnd.nix
@@ -1,0 +1,26 @@
+# Do not disturb, and a history - item 13 of docs/plans/desktop-design.md.
+#
+# Principle 3's off switch, surfaced: the custom/dnd bar module reads dunst's
+# own state and toggles it on click (SUPER+N is the keyboard path), and its
+# right click opens the history menu for notifications that were missed. The
+# module changes shape rather than only colour when paused, so do-not-disturb
+# cannot be left on silently. See packages/dnd.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.cg.home.dnd;
+
+  dnd = pkgs.dnd or (pkgs.callPackage ../../../packages/dnd { });
+in
+{
+  options.cg.home.dnd.enable =
+    lib.mkEnableOption "Do-not-disturb bar module and notification history";
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ dnd ];
+  };
+}

--- a/modules/home/desktop/failed-units.nix
+++ b/modules/home/desktop/failed-units.nix
@@ -1,0 +1,28 @@
+# What is running, and what has failed - item 14 of docs/plans/desktop-design.md.
+#
+# The custom/failed-units bar module is quiet when every user and system
+# unit is healthy and shows a marker when any has failed - the same pattern
+# as custom/nixos-upgrade. Clicking it lists the failed units and opens the
+# chosen one's journal in the terminal. The process half of the item (a
+# single consistent left click into btop on cpu, memory and temperature) was
+# already built as item 3; this is the half that was not. See
+# packages/failed-units.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.cg.home.failed-units;
+
+  failed-units = pkgs.failed-units or (pkgs.callPackage ../../../packages/failed-units { });
+in
+{
+  options.cg.home.failed-units.enable =
+    lib.mkEnableOption "Failed systemd units bar module and journal menu";
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ failed-units ];
+  };
+}

--- a/modules/home/desktop/hyprland.nix
+++ b/modules/home/desktop/hyprland.nix
@@ -3,6 +3,7 @@
 {
   inputs,
   config,
+  osConfig,
   lib,
   pkgs,
   ...
@@ -18,6 +19,32 @@ let
   # window rounding are the compositor's half of the same four numbers waybar,
   # rofi and dunst use. See ./lib/scale.nix.
   geometryScale = import ./lib/scale.nix { inherit pkgs; };
+
+  # Where the binds' commands will actually be found. Hyprland runs inside the
+  # graphical session, so its PATH is the user's profile plus the system one -
+  # the same two closures, read from the evaluated configuration rather than
+  # restated, exactly as waybar.nix does for the bar. See ./lib/session-path.nix.
+  searchPath = import ./lib/session-path.nix { inherit lib config osConfig; };
+
+  # The keybind sheet's parser, as the build-gate command. Same resolution the
+  # keybind-sheet module uses: the overlay's package, or the source on its own.
+  # See ../../../packages/keybind-sheet.
+  keybind-sheet = pkgs.keybind-sheet or (pkgs.callPackage ../../../packages/keybind-sheet { });
+
+  # Item 1's extension, taken with items 8-15. binds.lua names binaries in
+  # its exec_cmd strings and no check covered them; a bind that runs nothing
+  # is the bar's dead click wearing a keyboard. See ./binds-commands.py.
+  #
+  # The same runCommand also gates item 11's keybind sheet: the parser reads
+  # the *deployed* binds.lua at runtime, and keybind-sheet-parse - the
+  # package's own command - runs the identical parser over the checked-in
+  # file so a binds.lua the sheet stops understanding fails the build instead
+  # of silently losing its documentation.
+  checkedBinds = pkgs.runCommand "hypr-binds.lua" { nativeBuildInputs = [ pkgs.python3 ]; } ''
+    python3 ${./binds-commands.py} ${configs}/binds.lua ${lib.escapeShellArg searchPath}
+    ${keybind-sheet}/bin/keybind-sheet-parse ${configs}/binds.lua > /dev/null
+    cp ${configs}/binds.lua $out
+  '';
 
   checkedSettings = pkgs.runCommand "hypr-settings.lua" { } ''
     ${geometryScale}/bin/geometry-scale ${configs}/settings.lua
@@ -37,7 +64,7 @@ in
       "hypr/settings.lua".source = checkedSettings;
       "hypr/animations.lua".source = ../../../configs/hypr/animations.lua;
       "hypr/rules.lua".source = ../../../configs/hypr/rules.lua;
-      "hypr/binds.lua".source = ../../../configs/hypr/binds.lua;
+      "hypr/binds.lua".source = checkedBinds;
       "hypr/autostart.lua".source = ../../../configs/hypr/autostart.lua;
     };
 

--- a/modules/home/desktop/keybind-sheet.nix
+++ b/modules/home/desktop/keybind-sheet.nix
@@ -1,0 +1,25 @@
+# Keybind sheet - item 11 of docs/plans/desktop-design.md.
+#
+# SUPER+slash opens the sheet, parsed live from the deployed binds.lua. The
+# parse is gated at build time too - hyprland.nix runs the same parser over
+# the checked-in file, so a binds.lua this stops understanding fails the
+# build rather than silently losing its documentation. See
+# packages/keybind-sheet.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.cg.home.keybind-sheet;
+
+  keybind-sheet = pkgs.keybind-sheet or (pkgs.callPackage ../../../packages/keybind-sheet { });
+in
+{
+  options.cg.home.keybind-sheet.enable = lib.mkEnableOption "Keybind reference sheet";
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ keybind-sheet ];
+  };
+}

--- a/modules/home/desktop/lib/session-path.nix
+++ b/modules/home/desktop/lib/session-path.nix
@@ -1,0 +1,23 @@
+# session-path.nix: the PATH a graphical-session command will see.
+#
+# Hyprland's binds and waybar's clicks both run inside the user's graphical
+# session, so their PATH is the user's own profile plus the system one - the
+# same two closures, not a hand-written list that could disagree with them.
+# The command checks in hyprland.nix and waybar.nix gate against exactly this
+# path, so the two used to restate the formula in parallel; a formula that
+# must not disagree now lives here.
+#
+# `/run/wrappers/bin` is not modelled: nothing on the bar or in the binds is
+# setuid today, and a wrapper cannot be resolved from inside the build
+# sandbox. A command that needs one will fail the check, which is the right
+# moment to decide whether it belongs in the session at all.
+{
+  lib,
+  config,
+  osConfig,
+}:
+lib.concatStringsSep ":" [
+  "${config.home.path}/bin"
+  "${osConfig.system.path}/bin"
+  "${osConfig.system.path}/sbin"
+]

--- a/modules/home/desktop/lib/swayosd-css.nix
+++ b/modules/home/desktop/lib/swayosd-css.nix
@@ -1,0 +1,46 @@
+# The build gate for swayosd's stylesheet.
+#
+# Item 12 of docs/plans/desktop-design.md gives swayosd the same three gates
+# the bar and the launcher sit behind, so it joins the palette scheme rather
+# than arriving as a fourth hand-written copy: the generated-file gate (the
+# checked-in copy under configs/ must match lib/kanagawa-wave.nix), the
+# geometry gate (its lengths must be on the scale), and this one - a
+# stylesheet GTK 4 will not parse is an OSD that silently looks default,
+# because swayosd warns and carries on. See ../swayosd-css-parse.py.
+{ pkgs }:
+let
+  # Same shape as lib/gtk-css.nix but for GTK 4, which is what swayosd hands
+  # its stylesheet to. Parsing needs no display, but it does need the typelibs
+  # on GI_TYPELIB_PATH and nothing else.
+  typelibs = pkgs.lib.makeSearchPathOutput "out" "lib/girepository-1.0" (
+    with pkgs;
+    [
+      gtk4
+      glib
+      graphene
+      pango
+      gdk-pixbuf
+      harfbuzz
+      gobject-introspection
+    ]
+  );
+in
+pkgs.writeShellApplication {
+  name = "swayosd-css-parse";
+  runtimeInputs = [ (pkgs.python3.withPackages (ps: [ ps.pygobject3 ])) ];
+  text = ''
+    export GI_TYPELIB_PATH=${typelibs}
+    export FONTCONFIG_FILE=${pkgs.fontconfig.out}/etc/fonts/fonts.conf
+
+    work=$(mktemp -d)
+    trap 'rm -rf "$work"' EXIT
+    cp "$@" "$work"/
+
+    names=()
+    for file in "$@"; do
+      names+=("$work/$(basename "$file")")
+    done
+
+    HOME=$work exec python3 ${../swayosd-css-parse.py} "''${names[@]}"
+  '';
+}

--- a/modules/home/desktop/network-menu.nix
+++ b/modules/home/desktop/network-menu.nix
@@ -1,0 +1,24 @@
+# Network menu - item 9 of docs/plans/desktop-design.md.
+#
+# The bar's network module opens it on left click (its format toggle stays on
+# right, via format-alt-click) and SUPER+SHIFT+W opens the same menu from the
+# keyboard - principle 2's two reachable surfaces, the same arrangement the
+# project picker has. See packages/network-menu.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.cg.home.network-menu;
+
+  network-menu = pkgs.network-menu or (pkgs.callPackage ../../../packages/network-menu { });
+in
+{
+  options.cg.home.network-menu.enable = lib.mkEnableOption "Wifi network menu";
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ network-menu ];
+  };
+}

--- a/modules/home/desktop/power-menu.nix
+++ b/modules/home/desktop/power-menu.nix
@@ -1,0 +1,24 @@
+# Power and session menu - item 8 of docs/plans/desktop-design.md.
+#
+# The bar's custom/power module and SUPER+Escape both reach the same menu:
+# every action is keybound and every action that can be a pointer target is
+# one, and neither path is the real one. See packages/power-menu for what it
+# does and why it needs no confirmation.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.cg.home.power-menu;
+
+  power-menu = pkgs.power-menu or (pkgs.callPackage ../../../packages/power-menu { });
+in
+{
+  options.cg.home.power-menu.enable = lib.mkEnableOption "Power and session menu";
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ power-menu ];
+  };
+}

--- a/modules/home/desktop/screenshot.nix
+++ b/modules/home/desktop/screenshot.nix
@@ -1,0 +1,28 @@
+# Screenshot suite - item 15 of docs/plans/desktop-design.md.
+#
+# The full set under Print with modifiers: region to clipboard (the common
+# case, unchanged), region to file, active window, current monitor - with
+# satty offered as an optional annotation step on the save modes, and
+# hyprpicker on its own binding for colours. See packages/screenshot.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.cg.home.screenshot;
+
+  screenshot = pkgs.screenshot or (pkgs.callPackage ../../../packages/screenshot { });
+in
+{
+  options.cg.home.screenshot.enable =
+    lib.mkEnableOption "Screenshot suite (grimblast + satty + hyprpicker)";
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [
+      screenshot
+      pkgs.hyprpicker # colour picker, bound alongside in binds.lua
+    ];
+  };
+}

--- a/modules/home/desktop/swayosd-css-parse.py
+++ b/modules/home/desktop/swayosd-css-parse.py
@@ -1,0 +1,76 @@
+"""Ask GTK 4 whether it can parse swayosd's stylesheet.
+
+swayosd loads ~/.config/swayosd/style.css with GTK 4's CSS parser and only
+warns when it fails - a file GTK rejects is an OSD that silently looks
+default, which is the same failure mode as a rofi theme that does not parse.
+GTK's parser is narrower than CSS on the web, so "does the file match the
+palette" and "do its lengths sit on the scale" are both necessary and neither
+is sufficient; the file also has to be something GTK accepts. This is that
+check, run at build time on the file swayosd will actually read.
+
+The GTK 3 equivalent for waybar is gtk-css-parse.py; swayosd is GTK 4, whose
+parser is strict enough that this earns its keep separately. See
+../lib/swayosd-css.nix for the wrapper that supplies the typelibs.
+"""
+
+import os
+import sys
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+
+from gi.repository import GLib, Gtk  # noqa: E402
+
+
+def errors_in(path):
+    found = []
+
+    def on_error(_provider, section, error):
+        # The section names the file the error is *in*, which is not `path`
+        # when the mistake is inside an @import. Only the basename is useful:
+        # these are copies in a build sandbox, and the name is what swayosd
+        # would print anyway.
+        where = section.get_file()
+        name = os.path.basename(where.get_path() if where is not None else path)
+        found.append(
+            f"{name}:{section.get_start_line() + 1}:"
+            f"{section.get_start_position() + 1}: {error.message}"
+        )
+
+    provider = Gtk.CssProvider()
+    provider.connect("parsing-error", on_error)
+    try:
+        provider.load_from_path(path)
+    except GLib.Error as exc:
+        if not found:
+            found.append(f"{os.path.basename(path)}: {exc.message}")
+
+    return found
+
+
+def main(paths):
+    failures = list(dict.fromkeys(line for path in paths for line in errors_in(path)))
+    if not failures:
+        return 0
+
+    print(
+        "GTK 4 cannot parse these stylesheets, so swayosd would fall back to its default:",
+        file=sys.stderr,
+    )
+    print(file=sys.stderr)
+    for line in failures:
+        print(f"    {line}", file=sys.stderr)
+    print(file=sys.stderr)
+    print(
+        "swayosd only warns and keeps its default theme, which is why this is",
+        file=sys.stderr,
+    )
+    print(
+        "checked at build time rather than discovered on the desktop.", file=sys.stderr
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/modules/home/desktop/swayosd.nix
+++ b/modules/home/desktop/swayosd.nix
@@ -1,0 +1,67 @@
+# SwayOSD - item 12 of docs/plans/desktop-design.md.
+#
+# Volume, mute and brightness keys had no immediate confirmation - the bar's
+# module is small, may be on another monitor, and after item 21 rotates the
+# bar there is no room for a number at all. swayosd-client both performs the
+# change and shows the OSD, centred over the focused output, and it is
+# transient and undismissable, which is a different job from a notification -
+# the reason this item exists even though dunst already has a progress bar.
+#
+# It is a new daemon, which principle 6's ordering asks to justify: the
+# justification is that this is a surface that should appear centred, over
+# the focused output, and disappear without being dismissed - a different job
+# from a notification, done by a process whose only job that is.
+#
+# And it has no stylix target, so it joins item 5's generated-colour scheme
+# from its first commit: configs/swayosd/style.css is generated from
+# lib/kanagawa-wave.nix and checked in, and the build gates the copy - the
+# palette match, the geometry scale, and (because swayosd only warns and
+# carries on) that GTK 4 will parse it at all.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.cg.home.swayosd;
+
+  configs = ../../../configs/swayosd;
+
+  palette = import ../../../lib/kanagawa-wave.nix { inherit lib; };
+  inherit (import ./lib/generated.nix { inherit pkgs; }) assertGenerated;
+  geometryScale = import ./lib/scale.nix { inherit pkgs; };
+  swayosdCssParse = import ./lib/swayosd-css.nix { inherit pkgs; };
+
+  checkedStyle = pkgs.runCommand "swayosd-style.css" { } ''
+    ${assertGenerated [
+      {
+        path = "configs/swayosd/style.css";
+        deployed = "${configs}/style.css";
+        expected = palette.toSwayosdCss;
+      }
+    ]}
+
+    ${geometryScale}/bin/geometry-scale ${configs}/style.css
+
+    ${swayosdCssParse}/bin/swayosd-css-parse ${configs}/style.css
+
+    cp ${configs}/style.css $out
+    chmod u+w $out
+  '';
+in
+{
+  options.cg.home.swayosd.enable = lib.mkEnableOption "SwayOSD volume and brightness overlay";
+
+  config = lib.mkIf cfg.enable {
+    services.swayosd.enable = true;
+
+    # swayosd reads ~/.config/swayosd/style.css itself and falls back to its
+    # default theme when the file is absent - so the deployed file is the
+    # check's output, and a hand-edited colour or an off-scale length cannot
+    # be switched to. The OSD sits at the server's default top-margin (0.85,
+    # near the bottom); item 21 positions it against the new bar geometry
+    # when that lands.
+    xdg.configFile."swayosd/style.css".source = checkedStyle;
+  };
+}

--- a/modules/home/desktop/waybar.nix
+++ b/modules/home/desktop/waybar.nix
@@ -19,17 +19,8 @@ let
   # Where the bar will actually look for the commands it names. waybar runs as
   # a systemd user service inside the graphical session, so its PATH is the
   # user's own profile plus the system one - the same two closures, not a
-  # hand-written list that could disagree with them.
-  #
-  # `/run/wrappers/bin` is not modelled: nothing on the bar is setuid today,
-  # and a wrapper cannot be resolved from inside the build sandbox. A command
-  # that needs one will fail this check, which is the right moment to decide
-  # whether it belongs on the bar at all.
-  searchPath = lib.concatStringsSep ":" [
-    "${config.home.path}/bin"
-    "${osConfig.system.path}/bin"
-    "${osConfig.system.path}/sbin"
-  ];
+  # hand-written list that could disagree with them. See ./lib/session-path.nix.
+  searchPath = import ./lib/session-path.nix { inherit lib config osConfig; };
 
   # Item 1 of docs/plans/desktop-design.md.
   #

--- a/packages/audio-menu/default.nix
+++ b/packages/audio-menu/default.nix
@@ -1,0 +1,65 @@
+# audio-menu: switch the default sink or source, from a menu.
+#
+# Item 9 of docs/plans/desktop-design.md. Switching audio devices meant
+# opening pavucontrol - a full mixer - for a question that is "which
+# headphones". This is that question, over wpctl: a list of sinks and
+# sources, and picking one makes it the default.
+#
+# Parsing `wpctl status` is the fragile half and deserves the note: the
+# output is a tree drawn in Unicode box characters, and the only stable part
+# of a line is the `NN. name` after it. The awk strips everything up to the
+# node id, reads the id and the name, and drops the `[vol: ...]` annotation
+# that is not part of the name.
+{
+  lib,
+  pkgs,
+}:
+let
+  mkMenu = import ../lib/mk-menu.nix {
+    inherit lib;
+    writeShellApplication = pkgs.writeShellApplication;
+    rofi-menu = pkgs.rofi-menu;
+  };
+in
+mkMenu {
+  name = "audio-menu";
+  prompt = "Audio";
+  rows = 10;
+
+  runtimeInputs = [
+    pkgs.pipewire # wpctl
+  ];
+
+  # Sinks first, sources second, each row `ICON NAME<TAB>ID`. PipeWire node
+  # ids are unique across sinks and sources, so `wpctl set-default` needs
+  # only the id and the kind of the row does not matter to it.
+  list = ''
+    {
+      wpctl status 2>/dev/null | awk '
+        /Sinks:/ { section = "sink"; next }
+        /Sources:/ { section = "source"; next }
+        /Streams:/ { section = ""; next }
+        /Aux\// { section = ""; next }
+        section == "" { next }
+        {
+          line = $0
+          sub(/^[^0-9]*/, "", line)
+          if (line !~ /^[0-9]+\./) next
+          id = line
+          sub(/\..*/, "", id)
+          name = line
+          sub(/^[0-9]+\. /, "", name)
+          sub(/[[:space:]]*\[.*$/, "", name)
+          if (name == "") next
+          if (section == "sink") printf "󰓃 %s\t%s\n", name, id
+          else printf " %s\t%s\n", name, id
+        }'
+    }
+  '';
+
+  action = ''
+    id="''${choice#*$'\t'}"
+    [ -n "$id" ] || exit 0
+    wpctl set-default "$id"
+  '';
+}

--- a/packages/bluetooth-menu/default.nix
+++ b/packages/bluetooth-menu/default.nix
@@ -1,0 +1,91 @@
+# bluetooth-menu: connect, disconnect and discover bluetooth devices.
+#
+# Item 9 of docs/plans/desktop-design.md. Bluetooth had no visual path either
+# - blueman was installed, its applet was explicitly off, and nothing used
+# either. This is the connect/disconnect/discover path, over bluetoothctl.
+#
+# The list is paired and discoverable devices: everything bluetoothctl knows,
+# marked by state (connected, paired, or just discovered), plus a scan entry
+# that runs a bounded discovery scan and re-opens the menu so freshly seen
+# devices appear. Connecting to an unpaired device lets bluetoothctl pair it
+# when no PIN is involved.
+#
+# A PIN is the one thing item 7 said a menu should not ask for, which is why
+# the package carries blueman: the "Pair a new device" entry opens
+# blueman-manager, the on-demand pairing tool, and the half-installed blueman
+# package gains its stated purpose.
+{
+  lib,
+  pkgs,
+}:
+let
+  mkMenu = import ../lib/mk-menu.nix {
+    inherit lib;
+    writeShellApplication = pkgs.writeShellApplication;
+    rofi-menu = pkgs.rofi-menu;
+  };
+in
+mkMenu {
+  name = "bluetooth-menu";
+  prompt = "Bluetooth";
+  rows = 10;
+
+  runtimeInputs = [
+    pkgs.bluez # bluetoothctl
+    pkgs.coreutils # timeout, for the bounded scan
+    pkgs.libnotify # notify-send, so the scan is announced rather than silent
+    pkgs.blueman # blueman-manager, the pairing path a menu should not attempt
+  ];
+
+  # Everything bluetoothctl knows, state-marked: connected with a filled dot,
+  # paired-but-idle with an open one, discovered-but-unpaired flagged so the
+  # user can see what a connect would try to pair. Scanning and pairing last,
+  # both sentinel rows that cannot be a device address. Each row is
+  # `NAME<TAB>MAC` so a name with spaces round-trips. The sentinel lines are
+  # the group's last commands, so the group always succeeds even if
+  # bluetoothctl hiccups on the devices list.
+  list = ''
+    {
+      bluetoothctl devices 2>/dev/null | while read -r _ mac name; do
+        [ -n "$mac" ] || continue
+        if bluetoothctl info "$mac" 2>/dev/null | grep -q "Connected: yes"; then
+          printf '● %s\t%s\n' "$name" "$mac"
+        elif bluetoothctl info "$mac" 2>/dev/null | grep -q "Paired: yes"; then
+          printf '○ %s\t%s\n' "$name" "$mac"
+        else
+          printf '◇ %s (discovered)\t%s\n' "$name" "$mac"
+        fi
+      done || true
+      printf '󰂲 Scan for devices…\t__scan__\n'
+      printf '󰂲 Pair a new device…\t__pair__\n'
+    }
+  '';
+
+  action = ''
+    mac="''${choice#*$'\t'}"
+    case "$mac" in
+      __scan__)
+        # A bounded discovery scan - bluetoothctl scan blocks until told to
+        # stop, so timeout ends it - announced once, then the menu re-opens
+        # with whatever was found. New devices arrive unpaired; connect
+        # handles the PIN-less case below and a PIN stays blueman-manager's.
+        notify-send "Scanning for bluetooth devices (12s)…" || true
+        timeout 12 bluetoothctl scan on >/dev/null 2>&1 || true
+        exec bluetooth-menu
+        ;;
+      __pair__)
+        exec blueman-manager
+        ;;
+      "")
+        exit 0
+        ;;
+      *)
+        if bluetoothctl info "$mac" | grep -q "Connected: yes"; then
+          bluetoothctl disconnect "$mac"
+        else
+          bluetoothctl connect "$mac"
+        fi
+        ;;
+    esac
+  '';
+}

--- a/packages/clipboard-menu/default.nix
+++ b/packages/clipboard-menu/default.nix
@@ -1,0 +1,42 @@
+# clipboard-menu: the clipboard history that survives its window.
+#
+# Item 10 of docs/plans/desktop-design.md. Under Wayland the clipboard is
+# owned by the source window, so copying from a terminal and closing it lost
+# the copy - a papercut that fires several times a day. cliphist stores
+# history (and, by way of wl-clipboard's CLIPBOARD_STATE, skips offers
+# carrying the secret hint that password managers set); wl-clip-persist keeps
+# the current selection alive beyond its source window; this menu recalls
+# history. SUPER+SHIFT+V.
+#
+# cliphist list already emits ID<TAB>preview, which is exactly the shape
+# rofi-menu wants, and cliphist decode turns the picked id back into the
+# original byte-for-byte selection, which wl-copy restores to the clipboard.
+{
+  lib,
+  pkgs,
+}:
+let
+  mkMenu = import ../lib/mk-menu.nix {
+    inherit lib;
+    writeShellApplication = pkgs.writeShellApplication;
+    rofi-menu = pkgs.rofi-menu;
+  };
+in
+mkMenu {
+  name = "clipboard-menu";
+  prompt = "Clipboard";
+  rows = 12;
+
+  runtimeInputs = [
+    pkgs.cliphist
+    pkgs.wl-clipboard # wl-copy, to put the picked item back on the clipboard
+  ];
+
+  list = ''
+    cliphist list
+  '';
+
+  action = ''
+    printf '%s\n' "$choice" | cliphist decode | wl-copy
+  '';
+}

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -28,6 +28,29 @@ pkgs: {
   # The shared rofi dmenu wrapper every desktop menu goes through
   rofi-menu = pkgs.callPackage ./rofi-menu { };
 
+  # Desktop menus - items 8, 9, 10 and 13 of docs/plans/desktop-design.md,
+  # all built with lib/mk-menu.nix so they cannot drift into looking like
+  # four menus. The builder itself is not a package and deliberately does not
+  # appear here: flake `packages` are derivations, and a function would trip
+  # `nix flake check`.
+  power-menu = pkgs.callPackage ./power-menu { };
+  network-menu = pkgs.callPackage ./network-menu { };
+  bluetooth-menu = pkgs.callPackage ./bluetooth-menu { };
+  audio-menu = pkgs.callPackage ./audio-menu { };
+  clipboard-menu = pkgs.callPackage ./clipboard-menu { };
+
+  # Do-not-disturb bar module + history menu (item 13)
+  dnd = pkgs.callPackage ./dnd { };
+
+  # Failed-units bar module + journal menu (item 14)
+  failed-units = pkgs.callPackage ./failed-units { };
+
+  # Keybind reference parsed from binds.lua (item 11)
+  keybind-sheet = pkgs.callPackage ./keybind-sheet { };
+
+  # Screenshot suite (item 15)
+  screenshot = pkgs.callPackage ./screenshot { };
+
   # Project launcher / picker
   project-launcher = pkgs.callPackage ./project-launcher { };
 

--- a/packages/dnd/default.nix
+++ b/packages/dnd/default.nix
@@ -1,0 +1,82 @@
+# dnd: do-not-disturb's two surfaces - the bar module and the history menu.
+#
+# Item 13 of docs/plans/desktop-design.md. Principle 3's off switch did not
+# exist: dunst can be paused and nothing offered it, and the twenty
+# notifications it keeps in history had no way in. Two scripts:
+#
+#   dnd-waybar   reports whether dunst is paused, so the bar can show the
+#                state - and change shape, not just colour, when it is on,
+#                because a do-not-disturb that can be left on silently is a
+#                worse failure than not having one.
+#
+#   dnd-history  a rofi menu over dunst's history; picking an entry pops it,
+#                which re-displays the notification the user missed.
+#
+# Both read from dunst itself rather than keeping state, so the module cannot
+# drift from what is actually true.
+{
+  lib,
+  writeShellApplication,
+  symlinkJoin,
+  dunst,
+  jq,
+  rofi-menu,
+}:
+let
+  mkMenu = import ../lib/mk-menu.nix {
+    inherit lib writeShellApplication rofi-menu;
+  };
+
+  status = writeShellApplication {
+    name = "dnd-waybar";
+    runtimeInputs = [
+      dunst
+      jq
+    ];
+    text = ''
+      if [ "$(dunstctl is-paused)" = "true" ]; then
+        jq -cn --arg tooltip "Do not disturb is on - notifications are paused. Click to turn it off." \
+          '{text: "󰂛 DND", class: "paused", tooltip: $tooltip}'
+      else
+        jq -cn --arg tooltip "Do not disturb is off. Click to pause notifications." \
+          '{text: "󰂛", class: "on", tooltip: $tooltip}'
+      fi
+    '';
+  };
+
+  # The history view, as item 7's menu shape. dunstctl history is JSON here -
+  # an array of arrays of notifications - and every value is itself wrapped
+  # as {type, data}. The jq unwraps both and cuts the body to a preview, and
+  # the row is ID<TAB>summary<TAB>body so the id survives the menu.
+  # history-pop re-displays the picked notification in full.
+  history = mkMenu {
+    name = "dnd-history";
+    prompt = "Notification history";
+    rows = 12;
+    runtimeInputs = [
+      dunst
+      jq
+    ];
+    list = ''
+      dunstctl history | jq -r '.data[][] | "\(.id.data)\t\(.summary.data // "")\t\(((.body.data // "") | .[0:80]))"'
+    '';
+    action = ''
+      id="''${choice%%$'\t'*}"
+      [ -n "$id" ] || exit 0
+      dunstctl history-pop "$id"
+    '';
+  };
+in
+symlinkJoin {
+  name = "dnd";
+  paths = [
+    status
+    history
+  ];
+
+  meta = {
+    description = "Do-not-disturb bar module and notification history menu for dunst";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/packages/failed-units/default.nix
+++ b/packages/failed-units/default.nix
@@ -1,0 +1,97 @@
+# failed-units: the one question the tray cannot answer - what has failed.
+#
+# Item 14 of docs/plans/desktop-design.md. The escalation ladder had a rung
+# missing: glance should say "something is wrong", pick should say what, and
+# full is journalctl. The tray covers applications that ship a tray icon and
+# nothing else; a user service that dies under graphical-session.target just
+# means a missing bar module and a wallpaper that did not appear.
+#
+# Two scripts, built on the same pattern as nixos-upgrade:
+#
+#   failed-units-waybar  renders nothing at all when every unit is healthy
+#                        and a visible marker when any user or system unit
+#                        has failed. Reading is event-free: it shells out to
+#                        systemctl on an interval, which is exactly the
+#                        poller principle 1 warns about - but unit failures
+#                        change at human speed, so a 30s interval is far
+#                        slower than the thing it watches.
+#
+#   failed-units-click   a rofi menu over the failed units; picking one opens
+#                        its journal in the terminal. User units read
+#                        `journalctl --user`; system units need journal
+#                        access the user may not have, in which case the
+#                        terminal says so honestly rather than hiding it.
+{
+  lib,
+  writeShellApplication,
+  symlinkJoin,
+  systemd,
+  jq,
+  rofi-menu,
+}:
+let
+  status = writeShellApplication {
+    name = "failed-units-waybar";
+    runtimeInputs = [
+      systemd
+      jq
+    ];
+    text = ''
+      user_failed="$(systemctl --user --failed --no-legend --no-pager 2>/dev/null | wc -l)"
+      system_failed="$(systemctl --failed --no-legend --no-pager 2>/dev/null | wc -l)"
+      total="$((user_failed + system_failed))"
+
+      if [ "$total" -eq 0 ]; then
+        jq -cn --arg tooltip "All services running" \
+          '{text: "", class: "ok", tooltip: $tooltip}'
+      else
+        jq -cn --arg n "$total" --arg tooltip "$total failed unit(s). Click to inspect." \
+          '{text: "󰅙", class: "failed", tooltip: $tooltip}'
+      fi
+    '';
+  };
+
+  click = writeShellApplication {
+    name = "failed-units-click";
+    runtimeInputs = [
+      systemd
+      rofi-menu
+    ];
+    text = ''
+      # Every row is SCOPE<TAB>UNIT so the journal open knows which side of
+      # the user/system line the unit lives on.
+      list() {
+        systemctl --user --failed --no-legend --no-pager 2>/dev/null | while read -r unit _; do
+          [ -n "$unit" ] && printf 'user\t%s\n' "$unit"
+        done
+        systemctl --failed --no-legend --no-pager 2>/dev/null | while read -r unit _; do
+          [ -n "$unit" ] && printf 'system\t%s\n' "$unit"
+        done
+      }
+
+      choice="$(list | rofi-menu "Failed units" 10)" || exit 1
+      scope="''${choice%%$'\t'*}"
+      unit="''${choice#*$'\t'}"
+      [ -n "$unit" ] || exit 0
+
+      if [ "$scope" = "user" ]; then
+        exec term-run journalctl --user -u "$unit" -n 200 --no-pager
+      else
+        exec term-run journalctl -u "$unit" -n 200 --no-pager
+      fi
+    '';
+  };
+in
+symlinkJoin {
+  name = "failed-units";
+  paths = [
+    status
+    click
+  ];
+
+  meta = {
+    description = "Waybar module and journal menu for failed systemd units";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/packages/keybind-sheet/default.nix
+++ b/packages/keybind-sheet/default.nix
@@ -1,0 +1,68 @@
+# keybind-sheet: the documentation binds.lua never had.
+#
+# Item 11 of docs/plans/desktop-design.md. Around sixty bindings across nine
+# labelled sections, and no way to see them except by opening the file - which
+# makes a keyboard-first desktop keyboard-first only for the bindings already
+# memorised, and the eight new menus this plan adds are eight more things to
+# forget. SUPER+slash shows them all.
+#
+# It reads the *deployed* binds.lua, so it shows what is actually bound rather
+# than a hand-maintained copy that drifts. If the parse ever breaks, the
+# failure is a sheet that does not open - not a system failure - and the build
+# gates the same parse over the checked-in file so that cannot happen at
+# runtime without being noticed at build time first.
+{
+  lib,
+  writeShellApplication,
+  symlinkJoin,
+  rofi-menu,
+  python3,
+}:
+let
+  # The sheet itself: parse the *deployed* binds.lua and present it in rofi.
+  sheet = writeShellApplication {
+    name = "keybind-sheet";
+    runtimeInputs = [
+      rofi-menu
+      python3
+    ];
+
+    text = ''
+      exec python3 ${./keybind-sheet.py} | rofi-menu "Keybinds" 20
+    '';
+  };
+
+  # The same parser, as a command a build gate can call: prints the sheet and
+  # fails if the file cannot be parsed or yields no binds at all. hyprland.nix
+  # runs this over the checked-in binds.lua, so a file the sheet stops
+  # understanding fails the build instead of silently losing its
+  # documentation - the half of this package's contract that cannot wait for
+  # runtime to notice.
+  parse = writeShellApplication {
+    name = "keybind-sheet-parse";
+    runtimeInputs = [ python3 ];
+
+    text = ''
+      out="$(python3 ${./keybind-sheet.py} "$1")" || exit 1
+      [ -n "$out" ] || {
+        echo "keybind-sheet-parse: no binds parsed from '$1'" >&2
+        exit 1
+      }
+      printf '%s\n' "$out"
+    '';
+  };
+in
+symlinkJoin {
+  name = "keybind-sheet";
+  paths = [
+    sheet
+    parse
+  ];
+
+  meta = {
+    description = "Rofi keybind reference parsed from binds.lua";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "keybind-sheet";
+  };
+}

--- a/packages/keybind-sheet/keybind-sheet.py
+++ b/packages/keybind-sheet/keybind-sheet.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Render binds.lua as the keybind sheet rofi-menu presents.
+
+Item 11 of docs/plans/desktop-design.md. binds.lua defines around sixty
+bindings across labelled sections, and the only way to see them used to be
+opening the file. This parses the deployed copy and renders every hl.bind(...)
+call, grouped by the section comments the file already has.
+
+The parse is deliberately narrow - it understands this file's one style, not
+Lua. It is written by one person in one style and the form is stable; if it
+ever stops parsing, the failure is a sheet that does not open, not a system
+failure. The build also runs this over the checked-in binds.lua (see
+hyprland.nix) so the sheet cannot silently stop opening at runtime.
+
+Usage: keybind-sheet.py [binds.lua]   (defaults to ~/.config/hypr/binds.lua)
+Prints the sheet - section headers and one entry per line - for rofi-menu.
+"""
+
+import os
+import re
+import sys
+
+# A token in a key expression: a string literal, or a bare word (a variable
+# or a name). Literals carry the separators, so they are concatenated raw.
+TOKEN = re.compile(r'"(?:[^"\\]|\\.)*"|[A-Za-z_][A-Za-z0-9_]*')
+
+# Section headers are "----"-fenced "-- Title" lines - the file's convention
+# since it first existed - so a title is only a title when a fence precedes
+# it. A prose comment never does, which is what keeps multi-line explanation
+# out of the sheet. A fence is "--" plus dashes; a title line is a single
+# short "-- Title".
+FENCE = re.compile(r"^--[\s-]+$")
+HEADER = re.compile(r"^--\s+[A-Z]")
+NOT_HEADER = re.compile(r"https?://|[.:/]$")
+
+
+def render_key(expr):
+    """Expand a bind's key expression the way the file uses it.
+
+    `mod` is the SUPER variable the file defines; the workspace-loop binds
+    concatenate a `key` variable that iterates 1-10. Everything else is a
+    literal, or a name this parser does not understand and marks as such.
+    """
+    out = ""
+    for token in TOKEN.findall(expr):
+        if token.startswith('"'):
+            out += token[1:-1]
+        elif token == "mod":
+            out += "SUPER"
+        elif token == "key":
+            out += "1-10"
+        else:
+            out += "<%s>" % token
+    return out.strip()
+
+
+def describe(action):
+    """A label for the bind's action, from the action expression.
+
+    An exec_cmd string is the command itself; a dispatcher call is its method
+    name (window.close, focus); anything else is shown as written.
+    """
+    match = re.search(r'exec_cmd\("((?:[^"\\]|\\.)*)"\)', action)
+    if match:
+        return match.group(1)
+    match = re.search(r"hl\.dsp\.([A-Za-z0-9_.]+)\(", action)
+    if match:
+        return match.group(1)
+    return action
+
+
+def parse(path):
+    """Yield (section, key, action) for every bind, in file order."""
+    section = "Keybinds"
+    in_submap = False
+    prev_was_fence = False
+    buf = ""
+    depth = 0
+
+    with open(path) as handle:
+        for raw in handle:
+            line = raw.rstrip("\n").strip()
+
+            if line.startswith("--"):
+                if FENCE.match(line):
+                    prev_was_fence = True
+                else:
+                    title = line[2:].strip()
+                    if (
+                        prev_was_fence
+                        and HEADER.match(line)
+                        and len(title) <= 45
+                        and not NOT_HEADER.search(line)
+                        and title
+                    ):
+                        section = title
+                    prev_was_fence = False
+                continue
+            prev_was_fence = False
+
+            if "define_submap" in line:
+                in_submap = True
+                continue
+            if in_submap:
+                if line == "end)":
+                    in_submap = False
+                continue
+
+            if "hl.bind(" in line:
+                if buf == "":
+                    buf = line
+                    depth = line.count("(") - line.count(")")
+                else:
+                    buf += " " + line
+                    depth += line.count("(") - line.count(")")
+            elif buf != "":
+                # A continuation line of a multi-line bind - an argument line
+                # does not itself contain "hl.bind(".
+                buf += " " + line
+                depth += line.count("(") - line.count(")")
+            else:
+                continue
+
+            if depth <= 0:
+                args = buf[len("hl.bind(") :].rstrip()
+                if args.endswith(")"):
+                    args = args[:-1]
+                key_expr, _, rest = args.partition(",")
+                yield section, render_key(key_expr), describe(rest)
+                buf = ""
+                depth = 0
+
+
+def main(argv):
+    path = argv[1] if len(argv) > 1 else os.path.expanduser("~/.config/hypr/binds.lua")
+    try:
+        rows = list(parse(path))
+    except OSError as exc:
+        print("keybind-sheet: %s" % exc, file=sys.stderr)
+        return 1
+
+    current = None
+    for section, key, action in rows:
+        if section != current:
+            current = section
+            print("── %s ──" % section)
+        print("%s  %s" % (key.ljust(18), action))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/packages/lib/mk-menu.nix
+++ b/packages/lib/mk-menu.nix
@@ -1,0 +1,56 @@
+# mkMenu: the one shape a desktop menu is allowed to have.
+#
+# Item 7 of docs/plans/desktop-design.md made rofi the menu system and gave
+# every menu the same shape - a list you filter by typing, pick with the
+# keyboard or the pointer, dismiss with Escape - and then said it out loud:
+# "whoever writes the second menu should extract a `mkMenu` builder and put
+# the rule in it." Every menu written since (items 8, 9, 10, 13, 14 and 15 -
+# the annotation prompt included) goes through this, so the rule lives here
+# rather than being restated in each package's header.
+#
+# The rule, in one sentence: a menu is <list> piped through rofi-menu with a
+# prompt and a row count, and the picked line is $choice. That is everything.
+# The list and the action differ per menu; the interface between them does
+# not, which is what stops the wifi menu and the power menu from drifting
+# into looking like different things.
+#
+# One convention is baked in rather than restated: `$choice` is captured with
+# `|| exit 1`, so a dismissed menu (rofi's exit 1) is indistinguishable from
+# "the user changed their mind" and a caller never acts on an empty pick. A
+# menu does nothing when its question is dismissed; that is the whole point
+# of Escape.
+{
+  lib,
+  writeShellApplication,
+  rofi-menu,
+}:
+{
+  name,
+  prompt,
+  rows,
+  runtimeInputs ? [ ],
+  list,
+  action,
+}:
+writeShellApplication {
+  inherit name;
+  runtimeInputs = [ rofi-menu ] ++ runtimeInputs;
+
+  text = ''
+    # ${name}: item 7's menu shape. <list> emits one choice per line;
+    # rofi-menu presents them with the shared theme; the picked line is
+    # $choice below. Rows is the only knob a menu is allowed to turn.
+    #
+    # The list is wrapped in a brace group so that a multi-line list
+    # generator stays one pipeline element - a bare `|| true` on its own
+    # line would otherwise swallow the appended `| rofi-menu` into a
+    # second pipeline that never runs.
+    choice="$(
+      {
+        ${list}
+      } | rofi-menu ${lib.escapeShellArg prompt} ${toString rows}
+    )" || exit 1
+
+    ${action}
+  '';
+}

--- a/packages/network-menu/default.nix
+++ b/packages/network-menu/default.nix
@@ -1,0 +1,64 @@
+# network-menu: connect to a wifi network, from a menu.
+#
+# Item 9 of docs/plans/desktop-design.md. Changing wifi networks had no
+# visual path at all before this - nmtui in a terminal or nothing. The menu
+# lists saved and visible networks with signal strength, connects on pick,
+# and asks for a passphrase when the network is not saved yet.
+#
+# One deliberate boundary, from the item: a menu does one thing, and editing
+# connection profiles is not that thing - that is `full` depth on the
+# escalation ladder and belongs to nm-connection-editor. This connects to
+# networks. It does not edit them.
+#
+# The passphrase is the one case that does not go through rofi-menu: it is a
+# prompt, not a list of answers, so rofi's own -password flag is used for it.
+# It still loads the shared theme, because rofi reads config.rasi by default.
+{
+  lib,
+  pkgs,
+}:
+let
+  mkMenu = import ../lib/mk-menu.nix {
+    inherit lib;
+    writeShellApplication = pkgs.writeShellApplication;
+    rofi-menu = pkgs.rofi-menu;
+  };
+in
+mkMenu {
+  name = "network-menu";
+  prompt = "Network";
+  rows = 12;
+
+  runtimeInputs = [
+    pkgs.networkmanager # nmcli
+    pkgs.rofi # the passphrase prompt, the one non-list rofi this desktop runs
+  ];
+
+  # SSID and signal, tab-separated so a name containing spaces round-trips.
+  # `--escape no` reads an SSID containing a colon, at the cost of one that
+  # does; `--rescan auto` refreshes the list when the last scan is stale but
+  # does not force a slow rescan every time the menu opens. In-progress
+  # scans show "--" and are skipped rather than offered.
+  list = ''
+    {
+      nmcli -t --escape no -f SSID,SIGNAL device wifi list --rescan auto 2>/dev/null |
+        awk -F: 'NF >= 2 && $1 != "" && $1 != "--" { printf "%s\t%3s%%\n", $1, $2 }' || true
+    }
+  '';
+
+  action = ''
+    ssid="''${choice%%$'\t'*}"
+    [ -n "$ssid" ] || exit 0
+
+    # Saved, then, is decided on the connection *name* field alone: a terse
+    # `connection show` line is NAME:UUID:TYPE:DEVICE, and a whole-line match
+    # would never fire. `-g NAME` prints just the names, unescaped, one per
+    # line - fixed-string still, so an SSID full of regex is still an SSID.
+    if nmcli -g NAME connection show | grep -Fqx "$ssid"; then
+      nmcli connection up "$ssid"
+    else
+      password="$(rofi -dmenu -password -p "Password for $ssid")"
+      nmcli device wifi connect "$ssid" password "$password"
+    fi
+  '';
+}

--- a/packages/power-menu/default.nix
+++ b/packages/power-menu/default.nix
@@ -1,0 +1,59 @@
+# power-menu: shut down, reboot, suspend, log out or lock, from one menu.
+#
+# Item 8 of docs/plans/desktop-design.md. There was no visual way to shut
+# down or reboot - SUPER+S only locks, everything else was a terminal command.
+# This is that visual path: a rofi menu over loginctl and systemctl.
+#
+# No confirmation, on purpose. The menu is already two layers - opening it is
+# one decision, picking the entry is the second - which is enough deliberation
+# for an action that costs an unsaved buffer. That is why destructive entries
+# come last and the bare-Return fast path lands on Lock: a one-step action
+# gets a confirmation, a two-step one does not, and binding SUPER+SHIFT+Q
+# straight to shutdown later would collapse the layers and have to bring a
+# confirmation back with it.
+{
+  lib,
+  pkgs,
+}:
+let
+  mkMenu = import ../lib/mk-menu.nix {
+    inherit lib;
+    writeShellApplication = pkgs.writeShellApplication;
+    rofi-menu = pkgs.rofi-menu;
+  };
+in
+mkMenu {
+  name = "power-menu";
+  prompt = "Power";
+  rows = 5;
+
+  runtimeInputs = [
+    # loginctl, systemctl: the session and system commands below.
+    pkgs.systemd
+    # hyprctl talks to the running compositor; logging out is the
+    # compositor's decision to make, not loginctl's, because UWSM watches
+    # the session end.
+    pkgs.hyprland
+  ];
+
+  # Destructive entries ordered last, and never first: the fast path (a bare
+  # Return on an empty filter) lands on Lock.
+  list = ''
+    printf '%s\n' \
+      '󰌾 Lock' \
+      '󰒲 Suspend' \
+      '󰍃 Log out' \
+      '󰜉 Reboot' \
+      '󰐥 Power off'
+  '';
+
+  action = ''
+    case "$choice" in
+      '󰌾 Lock') loginctl lock-session ;;
+      '󰒲 Suspend') systemctl suspend ;;
+      '󰍃 Log out') hyprctl dispatch exit ;;
+      '󰜉 Reboot') systemctl reboot ;;
+      '󰐥 Power off') systemctl poweroff ;;
+    esac
+  '';
+}

--- a/packages/screenshot/default.nix
+++ b/packages/screenshot/default.nix
@@ -1,0 +1,103 @@
+# screenshot: the full screenshot suite under Print.
+#
+# Item 15 of docs/plans/desktop-design.md. One binding used to exist - Print
+# ran `grimblast copy area` - and there was no way to save to a file, capture
+# a window or a monitor, annotate, or pick a colour. This is the full set,
+# with the region-to-clipboard case kept exactly as it was.
+#
+# Annotation is a second decision, so it is offered rather than forced: the
+# save modes ask once (via rofi-menu, of course) and a dismissed prompt means
+# "save it as it is", never a captured frame that vanished. hyprpicker lives
+# on its own binding rather than in this script.
+#
+# Files land in ~/Pictures/screenshots, which is where the machine's
+# documentation images are already written from.
+{
+  lib,
+  writeShellApplication,
+  symlinkJoin,
+  grimblast,
+  satty,
+  coreutils,
+  rofi-menu,
+}:
+let
+  mkMenu = import ../lib/mk-menu.nix {
+    inherit lib writeShellApplication rofi-menu;
+  };
+
+  # The annotation decision, as item 7's menu shape. "Annotate in satty" is
+  # the only entry with an action; a dismissed prompt and "Save without
+  # annotating" both mean "save it as it is", never a captured frame that
+  # vanished. The file being annotated arrives as $1.
+  annotate = mkMenu {
+    name = "screenshot-annotate";
+    prompt = "Screenshot";
+    rows = 2;
+    runtimeInputs = [ satty ];
+    list = ''
+      printf 'Save without annotating\nAnnotate in satty\n'
+    '';
+    action = ''
+      case "$choice" in
+        "Annotate in satty")
+          exec satty --filename "$1" --output-filename "$1"
+          ;;
+      esac
+    '';
+  };
+
+  main = writeShellApplication {
+    name = "screenshot";
+    runtimeInputs = [
+      grimblast
+      coreutils
+    ];
+
+    text = ''
+      # Usage: screenshot (area-copy|area-save|window|monitor)
+      mode="''${1:?usage: screenshot (area-copy|area-save|window|monitor)}"
+      dir="''${XDG_PICTURES_DIR:-$HOME/Pictures}/screenshots"
+      mkdir -p "$dir"
+      file="$dir/screenshot-$(date +%Y%m%d-%H%M%S).png"
+
+      case "$mode" in
+        area-copy)
+          # The common case, unchanged from the original single binding.
+          exec grimblast copy area
+          ;;
+        area-save)
+          grimblast save area "$file"
+          ;;
+        window)
+          grimblast copysave active "$file"
+          ;;
+        monitor)
+          grimblast copysave output "$file"
+          ;;
+        *)
+          echo "usage: screenshot (area-copy|area-save|window|monitor)" >&2
+          exit 64
+          ;;
+      esac
+
+      # Annotation, offered not forced (see ../lib/mk-menu.nix and the
+      # annotate script above). A dismissed prompt is "save it as is".
+      screenshot-annotate "$file" || true
+    '';
+  };
+in
+symlinkJoin {
+  name = "screenshot";
+  paths = [
+    main
+    annotate
+  ];
+
+  meta = {
+    description = "grimblast screenshot suite with optional satty annotation";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "screenshot";
+  };
+}


### PR DESCRIPTION
## What

Implements items 8-15 of `docs/plans/desktop-design.md` on `xps15`:

- **8 power/session** — `power-menu` (lock/suspend/logout/reboot/poweroff) on `SUPER+Escape` + a `custom/power` bar module.
- **9 network/bluetooth/audio** — `network-menu` (nmcli, masked passphrase when not saved), `bluetooth-menu` (paired + discoverable, bounded scan, pairing via blueman-manager), `audio-menu` (wpctl sinks+sources). Bar clicks + `SUPER+SHIFT+W/B/A`. Network format toggle kept on right click via `format-alt-click`. `blueman` moved into the menu's closure.
- **10 clipboard** — `cliphist` + `wl-clip-persist` + `clipboard-menu` (`SUPER+SHIFT+V`). Sensitive-hint exclusion is cliphist's own.
- **11 keybind sheet** — `keybind-sheet` (`SUPER+slash`), parsed live from binds.lua; the parse is gated at build time via the package's own `keybind-sheet-parse`.
- **12 swayosd** — media/brightness keys route through `swayosd-client`; `brillo` removed; `configs/swayosd/style.css` generated from the palette and gated (palette match, geometry scale, GTK 4 parse).
- **13 dnd** — `custom/dnd` bar module + history menu (`dnd-history`), `SUPER+N`.
- **14 failed units** — `custom/failed-units` module, quiet when healthy; click lists units and opens the journal in ghostty.
- **15 screenshots** — `screenshot` suite under `Print` (+ `SUPER+SHIFT+C` hyprpicker), optional satty annotation via mkMenu.

All menus go through a shared `packages/lib/mk-menu.nix` builder (plan item 7's directive). `binds-commands.py` now gates that every `exec_cmd` in binds.lua resolves. Session PATH centralized in `modules/home/desktop/lib/session-path.nix`.

## Checks

- `nix build .#nixosConfigurations.xps15.config.system.build.toplevel` — passes
- `nix flake check` — all checks passed
- `nix fmt -- --ci` — 0 changed

## Notes

- `AGENTS.md` was intentionally **not** included (external harness change).
- Nothing is activated/deployed; this is build + check only.