### PR TITLE
build(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788620682,
-        "narHash": "sha256-qdXXcNrxlA35KvMH8yxlQen3pyJnV7yMDbv1QOOIOBQ=",
+        "lastModified": 1788651960,
+        "narHash": "sha256-v9wJd32eZ2bvhBzVOd7TIjLQd011P7nwOhjKtWlci5I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8381f3481e4424ea0b53c9e7469c14da799d5822",
+        "rev": "2c0350c759688177331b8f5242311fae8877bdb3",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1788405554,
-        "narHash": "sha256-r2f1oUwixlgq9zOdYLqJLfS/lWBT60/IITjhTKI59JU=",
+        "lastModified": 1788584326,
+        "narHash": "sha256-Fd3OB8J9JhgliQwOKcqx4M672CInxi1I5VnwsaXeSQo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a5cc6f2c37bf518436dc8d1c288ccd0c43c2f4c4",
+        "rev": "6713828a351efa628b025a1adf7f43cbf8597513",
         "type": "github"
       },
       "original": {
@@ -267,11 +267,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1788591346,
-        "narHash": "sha256-VdZ7jIKO85RAARCdBUbaiMNEy5BfhNCl5ndgpHKtyXk=",
+        "lastModified": 1788659161,
+        "narHash": "sha256-rIzUUvgwhfJeWwm7y1ZF+xRo2Gep+QYkxpj9mJbG6cM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fff9b8b5d0da3dd4cad0635776af557bce714a6e",
+        "rev": "de0ba0a81b0f6eed798a97fdec6f03a754b9d966",
         "type": "github"
       },
       "original": {
@@ -283,11 +283,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1788531059,
-        "narHash": "sha256-hLD4l3QOGBQhkVp3mQ2lJ/YbEi99qUgKapb40KovZ88=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "801bef6abd86b91e51083066b83fb354a11fc640",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `flake.lock` update.

The per-host deltas below are recorded in the commit body so they
land in `git log` on merge (ADR 0001).

Each host was built at the current lock and at the updated one, and
the closures compared. All three builds passing is a precondition of
this PR existing at all — but the `nixos ci` gate still has to pass
before it can merge, and merging is what promotes `deploy`.

### homelab01

home-configuration-reference: 8.8 KiB
katex: 0.18.4 → 0.18.5, 55.0 KiB
nixos-manual: 117.2 KiB
nixos-system-homelab01: 26.11.20260904.801bef6 → 26.11.20260905.c043004
source: 115.5 KiB

### homelab02

home-configuration-reference: 8.8 KiB
nixos-manual: 117.2 KiB
nixos-system-homelab02: 26.11.20260904.801bef6 → 26.11.20260905.c043004
source: 115.5 KiB

### xps15

binutils-wrapper: 55.3 KiB
claude-code: 2.1.258 → 2.1.260, -767.9 KiB
docker-compose: 5.4.0 → 5.5.0, 32.2 KiB
egl-wayland2: 1.0.1 → 1.0.2
firefox: 155.0 → 155.0.1
firefox-unwrapped: 155.0 → 155.0.1, 70.7 KiB
gfortran: 315.7 MiB
gfortran-wrapper: 15.3.0 added, 77.3 KiB
home-configuration-reference: 8.8 KiB
metis: 5.2.1 removed, -683.6 KiB
nixos-manual: 117.2 KiB
nixos-system-xps15: 26.11.20260904.801bef6 → 26.11.20260905.c043004
opencode: 1.18.25 → 1.18.28, -95.7 KiB
python3.14-zeroconf: 0.150.0 → 0.151.3, -1.9 MiB
source: 115.5 KiB
suitesparse: 5.13.0 → 7.10.0, 76.1 MiB
vivaldi: 8.1.4087.70 → 8.1.4087.75, -48.0 KiB