### PR TITLE
build(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -251,11 +251,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1788584326,
-        "narHash": "sha256-Fd3OB8J9JhgliQwOKcqx4M672CInxi1I5VnwsaXeSQo=",
+        "lastModified": 1788690626,
+        "narHash": "sha256-+v4I4LawmRD/mVxO7QIAerRrCkElp3YImzWkkUnvOTg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6713828a351efa628b025a1adf7f43cbf8597513",
+        "rev": "c25784012c9982bca5b3e0de87e90bbdac8927d3",
         "type": "github"
       },
       "original": {
@@ -267,11 +267,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1788659161,
-        "narHash": "sha256-rIzUUvgwhfJeWwm7y1ZF+xRo2Gep+QYkxpj9mJbG6cM=",
+        "lastModified": 1788761488,
+        "narHash": "sha256-mu5sizob4fS6ECwiwFMIlLRn5OZt/DlY29E1xK7ArZc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "de0ba0a81b0f6eed798a97fdec6f03a754b9d966",
+        "rev": "9485e5e151b6bcea0fef6980325ec8fb4194d30c",
         "type": "github"
       },
       "original": {
@@ -283,11 +283,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1788614874,
-        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
+        "lastModified": 1788752844,
+        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
+        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `flake.lock` update.

The per-host deltas below are recorded in the commit body so they
land in `git log` on merge (ADR 0001).

Each host was built at the current lock and at the updated one, and
the closures compared. All three builds passing is a precondition of
this PR existing at all — but the `nixos ci` gate still has to pass
before it can merge, and merging is what promotes `deploy`.

### homelab01

gh: 2.99.0 → 2.100.0, 655.6 KiB
lazygit: 0.64.1 → 0.65.0, 193.9 KiB
nilfs-utils: 2.2.12 → 2.3.1
nixos-system-homelab01: 26.11.20260905.c043004 → 26.11.20260907.dc5d91f
rclone: 1.75.0 → 1.75.1, 50.6 KiB
source: 83.2 KiB
talloc: 2.4.4 → 2.5.0, 11.0 KiB

### homelab02

gh: 2.99.0 → 2.100.0, 655.6 KiB
lazygit: 0.64.1 → 0.65.0, 193.9 KiB
nilfs-utils: 2.2.12 → 2.3.1
nixos-system-homelab02: 26.11.20260905.c043004 → 26.11.20260907.dc5d91f
rclone: 1.75.0 → 1.75.1, 50.6 KiB
source: 83.2 KiB

### xps15

bootdev-cli: 1.32.1 → 1.32.2
docker: 29.7.2 → 29.8.0, 1.3 MiB
docker-containerd: 29.7.2 → 29.8.0, 24.1 KiB
docker-runc: 29.7.2 → 29.8.0, -1.5 MiB
docker-tini: 29.7.2 → 29.8.0
egl-gbm: 1.1.3 → 1.1.4
egl-wayland: 1.1.21 → 1.1.22
egl-x11: 1.0.5 → 1.0.6, 9.0 KiB
gh: 2.99.0 → 2.100.0, 655.6 KiB
glycin-loaders: 2.1.5 added, 16.4 MiB
lazygit: 0.64.1 → 0.65.0, 193.9 KiB
moby: 29.7.2 → 29.8.0, 2.7 MiB
nilfs-utils: 2.2.12 → 2.3.1
nixos-system-xps15: 26.11.20260905.c043004 → 26.11.20260907.dc5d91f
opencode: 1.18.28 → 1.18.29
source: 83.2 KiB
talloc: 2.4.4 → 2.5.0, 13.3 KiB