### PR TITLE
fix(backup): sweep orphaned restic metrics files on activation

### DIFF
--- a/modules/services/backup.nix
+++ b/modules/services/backup.nix
@@ -290,5 +290,27 @@ in
       "d ${builtins.dirOf cfg.incomingPath} 0755 root root -"
       "d ${cfg.incomingPath} 0700 coryg users -"
     ];
+
+    # A renamed or removed repository leaves its old restic_backup_<name>.prom
+    # behind: nothing ever runs to update or delete it once the systemd unit
+    # is gone, so node_exporter keeps serving a timestamp that only gets
+    # older, and ResticBackupStale eventually fires on a job that no longer
+    # exists. Sweep on every activation so a rename self-heals on next deploy
+    # instead of needing a manual rm.
+    system.activationScripts.resticBackupMetricsCleanup = ''
+      METRICS_DIR="/var/lib/prometheus-node-exporter"
+      KNOWN_JOBS="${lib.concatStringsSep " " (builtins.attrNames cfg.repositories)}"
+      if [ -d "$METRICS_DIR" ]; then
+        for f in "$METRICS_DIR"/restic_backup_*.prom; do
+          [ -e "$f" ] || continue
+          job="$(basename "$f" .prom)"
+          job="''${job#restic_backup_}"
+          case " $KNOWN_JOBS " in
+            *" $job "*) ;;
+            *) rm -f "$f" ;;
+          esac
+        done
+      fi
+    '';
   };
 }


### PR DESCRIPTION
## Summary
- Root cause of the currently-firing `ResticBackupStale{exported_job="gdrive"}` alerts on both homelab hosts: #150 renamed the offsite repo from `gdrive` to `onedrive`, but the old `restic_backup_gdrive.prom` textfile-collector file is never updated or removed once its systemd unit is gone, so its timestamp only gets older.
- Verified the actual `onedrive` jobs are healthy on both hosts: each auto-created its repo and completed a full backup + prune + check with no errors this morning (homelab01 03:21, homelab02 03:11).
- Adds a `system.activationScripts` sweep in `modules/services/backup.nix` that deletes any `restic_backup_*.prom` file whose job name isn't in the currently configured `cfg.repositories`, so a future rename/removal self-heals on the next deploy instead of leaving a stale metric behind.

## Test plan
- [x] `nix flake check` passes
- [x] `nix build .#nixosConfigurations.homelab01.config.system.build.toplevel` and `...homelab02...` both build
- [ ] After deploy, confirm `restic_backup_gdrive.prom` is gone on both hosts and the `ResticBackupStale` alert clears