### PR TITLE
feat(afk-agent): module scaffold with a kill switch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,7 @@ jobs:
       fail-fast: false
       matrix:
         check:
+          - afk-agent
           - alert-rules
           - alert-rules-unit
           - alertmanager-config

--- a/checks/afk-agent.nix
+++ b/checks/afk-agent.nix
@@ -1,0 +1,139 @@
+# The kill switch, and the plumbing it switches.
+#
+# ADR 0004 §7 says the AFK pipeline is a real NixOS module rather than a script
+# someone remembers to run, so that turning it off in an emergency is one
+# boolean. That claim is only worth anything if the boolean actually removes
+# the units - and "the module evaluates" cannot tell the difference between a
+# `lib.mkIf` that guards everything and one that guards half of it. So this
+# boots the module both ways and looks at the running system: two nodes, one
+# with the switch on and one with it off.
+#
+# The other half is the plumbing the scaffold exists to prove. The poller
+# itself is item 5 of docs/plans/afk-agent-pipeline.md and is not written yet;
+# what item 4 owns is everything around it - that the unit is reached by the
+# timer rather than at boot, that its three credentials arrive, and that the
+# toolchain the runner will drive is on its PATH. The placeholder ExecStart
+# checks exactly those and then exits non-zero, so this test can assert them
+# without pretending a runner exists.
+#
+# The credentials are plaintext fixtures via ./stub-secrets.nix; sops cannot
+# decrypt in the sandbox, and no real value belongs in a test either way. They
+# are ordinary store fixtures rather than `private` ones because the module
+# hands them over with `LoadCredential`, which systemd reads as root before the
+# unit drops to its own user - so there is no per-secret ownership to get
+# wrong, and nothing for a `private` fixture to catch.
+{
+  name = "afk-agent";
+
+  nodes = {
+    # The switch on.
+    enabled =
+      { ... }:
+      {
+        imports = [
+          ../modules/services/afk-agent.nix
+
+          (import ./stub-secrets.nix {
+            secrets."gh-ci/dotfiles-afk-agent-PAT" = "stub-github-pat-VALUE-MUST-NOT-BE-LOGGED";
+            secrets."opencode/api-key" = "stub-opencode-key-VALUE-MUST-NOT-BE-LOGGED";
+            secrets."opencode/username" = "stub-opencode-user-VALUE-MUST-NOT-BE-LOGGED";
+          })
+        ];
+
+        networking.hostName = "afk-enabled";
+        system.stateVersion = "24.11";
+
+        cg.service.afk-agent = {
+          enable = true;
+
+          # Not the default, deliberately. The default polls every quarter hour
+          # and this test asserts that nothing has run the service yet, which a
+          # timer firing mid-run would falsify - rarely, and only for whoever
+          # happened to push across a quarter-hour boundary. A date the VM will
+          # never reach makes "inactive" mean "the timer has not fired", which
+          # is the property under test; that the default is a sane calendar
+          # expression is the module's business, not this test's.
+          schedule = "2100-01-01 00:00:00";
+        };
+      };
+
+    # The switch off. No stub secrets: a module that declares none when
+    # disabled is part of what is being asserted, and stubbing names nothing
+    # declares would land the override on nothing and pass silently
+    # (./stub-secrets.nix says so).
+    disabled =
+      { ... }:
+      {
+        imports = [ ../modules/services/afk-agent.nix ];
+
+        networking.hostName = "afk-disabled";
+        system.stateVersion = "24.11";
+      };
+  };
+
+  testScript = ''
+    start_all()
+
+    with subtest("the timer is armed, and it - not boot - is what runs the poller"):
+        enabled.wait_for_unit("afk-agent.timer")
+        assert enabled.succeed("systemctl is-enabled afk-agent.timer").strip() == "enabled"
+        enabled.succeed("systemctl list-timers --all | grep -q afk-agent.timer")
+
+        # Nothing wants the service at boot; the timer is its only trigger. If
+        # it ever grows an [Install] section, a host that enabled the module
+        # would start a coding agent on every boot instead of on the schedule
+        # it was given.
+        #
+        # Asked as "does any target want it" rather than as `systemctl
+        # is-enabled`, which answers this one usefully in only one direction.
+        # A unit something wants comes back `enabled` - which is why the timer
+        # above can be checked that way - but a NixOS unit with no [Install]
+        # section comes back `linked` and exit 1, the same answer a genuinely
+        # disabled unit gives. The glob distinguishes them; is-enabled does not.
+        wants = enabled.succeed(
+            "ls -d /etc/systemd/system/*.wants/afk-agent.service 2>/dev/null || true"
+        ).strip()
+        assert wants == "", f"something starts the poller without the timer: {wants}"
+        state = enabled.succeed("systemctl show -p ActiveState --value afk-agent.service").strip()
+        assert state == "inactive", f"the poller ran without the timer firing: {state}"
+
+    with subtest("a run reaches its three credentials and the toolchain it drives"):
+        # The placeholder ExecStart exits non-zero on purpose - the runner is
+        # item 5 and does not exist yet - so the failure here is the expected
+        # result, and the journal is where the evidence is.
+        enabled.fail("systemctl start afk-agent.service")
+        journal = enabled.succeed("journalctl -u afk-agent.service --no-pager")
+
+        for credential in ["github-token", "opencode-api-key", "opencode-username"]:
+            assert f"credential '{credential}' present" in journal, (
+                f"{credential} did not reach the unit:\n{journal}"
+            )
+
+        for tool in ["git", "gh", "opencode", "nix", "jq"]:
+            assert f"tool '{tool}' present" in journal, f"{tool} is not on the unit's PATH:\n{journal}"
+
+        assert "runner not implemented" in journal, f"the placeholder is gone but this test is not:\n{journal}"
+
+    with subtest("no credential value reaches the journal"):
+        # The unit reads three secrets on every poll. A debug echo left behind
+        # in the runner would put a repo-write PAT into the system journal,
+        # which is exactly the mistake nothing else here would catch.
+        for value in [
+            "stub-github-pat-VALUE-MUST-NOT-BE-LOGGED",
+            "stub-opencode-key-VALUE-MUST-NOT-BE-LOGGED",
+            "stub-opencode-user-VALUE-MUST-NOT-BE-LOGGED",
+        ]:
+            assert value not in journal, "a credential value was logged"
+
+    with subtest("the kill switch leaves nothing behind"):
+        disabled.wait_for_unit("multi-user.target")
+        disabled.fail("systemctl cat afk-agent.timer")
+        disabled.fail("systemctl cat afk-agent.service")
+
+        # The service account too. "Fully stops the pipeline" is the plan's
+        # wording (item 4); an idle unit is stopped, a lingering account with a
+        # state directory is not.
+        disabled.fail("id afk-agent")
+        disabled.fail("test -e /var/lib/afk-agent")
+  '';
+}

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -320,6 +320,7 @@ in
         touch $out
       '';
 
+  afk-agent = testLib.mkTest ./afk-agent.nix;
   digital-garden = testLib.mkTest ./digital-garden.nix;
   digital-garden-sync-health = import ./digital-garden-sync-health.nix {
     inherit pkgs;

--- a/docs/adr/0004-afk-agent-runs-self-hosted-with-a-harness-split.md
+++ b/docs/adr/0004-afk-agent-runs-self-hosted-with-a-harness-split.md
@@ -22,7 +22,7 @@ Each decision below is stated without its implementation parameters - counts, pr
 
 **2. Harness is split by phase.** Claude Code, on the existing Pro subscription, stays for every *interactive* stage - grilling, planning, spec, ticket generation - where subscription terms are unambiguous. The unattended executor runs OpenCode against DeepSeek V4 via OpenCode Go. This sidesteps the Claude subscription ambiguity entirely rather than resolving it, and costs less. Which DeepSeek variant (or another model) wins is deliberately left open, to be settled by a measured pilot (plan item 1), not decided here.
 
-**3. Trigger is a polling systemd timer**, not a GitHub webhook, even though the existing Cloudflare tunnel would make a webhook receiver feasible. The timer reuses the claim convention `docs/agents/issue-tracker.md` already defines (`gh issue edit <n> --add-assignee @me`) to avoid double-processing, with no new signature-verification code or inbound surface. The poller additionally avoids DeepSeek's weekday peak-pricing windows - free to implement, and a hedge against OpenCode Go's discount pass-through being unconfirmed either way. The windows themselves are a plan parameter (item 10).
+**3. Trigger is a polling systemd timer**, not a GitHub webhook, even though the existing Cloudflare tunnel would make a webhook receiver feasible. The timer reuses the claim convention `docs/agents/issue-tracker.md` already defines (`gh issue edit <n> --add-assignee @me`) to avoid double-processing, with no new signature-verification code or inbound surface.
 
 **4. PRs are opened under a second fine-grained PAT scoped to this repo (`AFK_AGENT_TOKEN`)**, not `GITHUB_TOKEN`, following the exact shape of `FLAKE_UPDATE_TOKEN`: GitHub suppresses workflow events raised by `GITHUB_TOKEN`, so the required `nixos ci` check would never fire on the PR. Not a separate GitHub account either - a dedicated branch prefix and label carry the same at-a-glance distinction `deps/*` already provides for `FLAKE_UPDATE_TOKEN`, without a second account's credentials and 2FA to manage. The prefix and label names are plan parameters (item 3).
 
@@ -49,7 +49,7 @@ Each decision below is stated without its implementation parameters - counts, pr
 
 - `homelab01` gains a new always-on process with repo-write credentials, alongside its existing services - genuine added blast radius, bounded by the path denylist, the worktree isolation, and the bounded retry count, but real.
 - Polling adds up to one timer interval of latency between a ticket becoming eligible and work starting - accepted, since nothing about AFK ticket work needs sub-minute response.
-- DeepSeek V4's actual code-quality on this codebase's ticket types is unproven, as is OpenCode's compatibility with the `.agents/skills/` format `implement`/`code-review` are written against, and whether OpenCode Go's usage accounting reflects DeepSeek's off-peak discount. All three are pilot questions, not settled by this ADR.
+- DeepSeek V4's actual code-quality on this codebase's ticket types is unproven, as is OpenCode's compatibility with the `.agents/skills/` format `implement`/`code-review` are written against. Both are pilot questions, not settled by this ADR.
 
 ## Alternatives considered
 

--- a/docs/plans/afk-agent-pipeline.md
+++ b/docs/plans/afk-agent-pipeline.md
@@ -1,6 +1,6 @@
 # Plan: the AFK agent pipeline
 
-Status: in progress — item 1 is done (`opencode-go/glm-5.3-flash` at `high`; see its Built note and cost-sustainability finding); item 2 is done (both eligibility rules written down, and the checks-matrix conflict settled with a narrow exception); item 3 is done (the token exists, is scoped to this repo alone, and was proven on a live PR); nothing else has started. Follows [ADR 0004](../adr/0004-afk-agent-runs-self-hosted-with-a-harness-split.md), which covers the architectural decisions (platform, harness split, identity, trigger, retries, kill switch) and the alternatives rejected along the way; this plan is the work items that implement it.
+Status: in progress — item 1 is done (`opencode-go/glm-5.3-flash` at `high`; see its Built note and cost-sustainability finding); item 2 is done (both eligibility rules written down, and the checks-matrix conflict settled with a narrow exception); item 3 is done (the token exists, is scoped to this repo alone, and was proven on a live PR); item 4 is done as a scaffold (the module, the kill-switch check, and the switch itself, written down as `false` on homelab01 - the runner it wraps is item 5, so its "Done when" only completes with that item); nothing else has started. Follows [ADR 0004](../adr/0004-afk-agent-runs-self-hosted-with-a-harness-split.md), which covers the architectural decisions (platform, harness split, identity, trigger, retries, kill switch) and the alternatives rejected along the way; this plan is the work items that implement it.
 
 The engineering skills (`.agents/skills/`) already carry a ticket from idea through `to-tickets`, which publishes a GitHub issue labelled `ready-for-agent` per `docs/agents/triage-labels.md`. `implement` already runs `/tdd`, tests, and a self-review, then commits. Everything below starts at the gap right after that: nothing currently claims a `ready-for-agent` ticket unattended, pushes it, opens a PR, or tells anyone.
 
@@ -11,7 +11,7 @@ Item 1 gates the stages that depend on a model choice - item 5's implement step 
 | 1  | Measured pilot                       | medium | done |
 | 2  | Triage: AFK eligibility              | small  | done        |
 | 3  | AFK identity (`AFK_AGENT_TOKEN`)     | small  | done        |
-| 4  | `modules/services/afk-agent.nix`     | medium | not started |
+| 4  | `modules/services/afk-agent.nix`     | medium | done        |
 | 5  | Runner: claim → worktree → implement | large  | not started |
 | 6  | Review stage                         | small  | not started |
 | 7  | Raise the PR                         | small  | not started |
@@ -655,6 +655,34 @@ A module on `homelab01` wrapping the poller (item 5) as a systemd service + time
 A `pkgs.testers.runNixOSTest` under `checks/`, following the `monitoring`/`reverse-proxy` pattern (deployment-hardening.md item 4): instantiate the module with `cg.service.afk-agent.enable = true` and assert the poller's service and timer units exist and are enabled; instantiate again with `enable = false` and assert they're absent. This is the test that actually proves the kill switch — the module's whole reason for being a real service rather than a script.
 
 If the test needs secrets present to start the service, it follows the existing `checks/stub-secrets.nix` convention — plaintext fixtures swapped in for `sops.secrets.<name>.path`, real values never entering the test.
+
+### Built, 2026-09-08
+
+`modules/services/afk-agent.nix`, `checks/afk-agent.nix`, and `afk-agent.enable = false` written down in `hosts/homelab01/default.nix` - off, per item 3's ordering constraint, and with the two things it is waiting on named at the switch rather than only here.
+
+**The unit is everything around the runner, and the runner is a placeholder.** What this item settles is the schedule, the runtime ceiling, the service account, the credentials, the sandbox, and the toolchain on `PATH`; item 5 replaces one `ExecStart` and updates the check that covers it. Until then the placeholder asserts the plumbing it was handed - three credentials by name, five tools by name - and exits non-zero. Non-zero on purpose: a host that switches this on before item 5 should get a red unit that says why, not a green one that quietly does nothing.
+
+Four decisions worth having written down, because each is a departure from what the rest of this repository does:
+
+- **`Persistent = false`**, alone among the timers here. The others catch up work that had to happen; a poll has nothing to catch up on, and the tickets a missed poll would have found are still open at the next tick. A `Persistent` poller would also start a coding agent the moment a host finished booting - including the reboot at the end of every nightly upgrade.
+- **`TimeoutStartSec` is an option (`maxRuntime`, default 4h), not a default.** A `oneshot` unit's start timeout is 90 seconds, which would kill every real run: the pilot measured 15-60 minutes, and item 5 allows two retries on top. The ceiling still has to exist, because concurrency here is one unit and a hung run blocks every later poll until something stops it.
+- **Concurrency 1 is systemd's doing, not the runner's.** A single non-templated unit cannot have two live instances, so a poll firing mid-ticket cannot start a second one. Raising it means templating the unit - a deliberate act rather than something item 5 can do by accident.
+- **Two hardening exclusions, both named in the module.** `ProtectSystem` is `full` rather than `strict`, because every `nix build` the runner does is a Nix daemon client and connecting to that socket needs write access to an inode under `/nix/var`. `MemoryDenyWriteExecute` is absent because opencode is a JIT'd JavaScript runtime - the same exemption the digital garden dropped when its Node toolchain went away.
+
+**The credentials are handed over with `LoadCredential`**, which systemd reads as root before the unit drops to `afk-agent`. So the three `sops.secrets` declarations carry no `owner`: the sops-nix defaults (root:root 0400) are already right, and there is no per-secret ownership for this module to get wrong. That is also why `checks/afk-agent.nix` uses ordinary store fixtures rather than `private` ones - there is nothing a `private` fixture would catch here.
+
+**The check boots the module both ways**, because "the module evaluates" cannot tell a `lib.mkIf` that guards everything from one that guards half of it. On the enabled node it asserts the timer is armed, that no `.wants` symlink anywhere pulls the service in at boot and that it is still inactive (the timer is its only trigger), that all three credentials and all five tools arrived, and - the one assertion about an absence - that no credential value reached the journal. On the disabled node: no timer, no service, no account, no state directory.
+
+The boot-trigger assertion is written as a `.wants` glob rather than `systemctl is-enabled`, which reports every NixOS unit as `linked` whatever its `[Install]` section says and so cannot tell the two cases apart.
+
+**What is not yet true.** The "Done when" below has two halves, and only the first is satisfied. `enable = false` does fully stop the pipeline - that is what the check proves. "Flipping it back on resumes polling with no other change needed" cannot be true until item 5 exists: flipping it on today gets a red unit that says so. The switch is meant to stay off until then anyway (item 3's ordering constraint), so this is the intended state rather than an oversight - but the item is closed as a scaffold, not as a working poller.
+
+Two departures from the ticket worth recording rather than leaving to be rediscovered:
+
+- **The service is asserted *not* enabled.** The acceptance criterion asks that "the service+timer exist and are enabled". The timer is enabled; the service deliberately has no `[Install]` section, because a unit that both a timer and `multi-user.target` want would start a coding agent on every boot. So the check asserts the unit exists and that nothing wants it - which is the criterion's intent, inverted on the half where the literal reading would be a bug.
+- **`opencode/username` is wired as a third credential.** Item 11 names two. The third was moved into `secrets/homelab01.yaml` alongside the other two by #169 and is declared here so that one place owns the set; if item 5 turns out not to need it, this is where to drop it.
+
+One residual risk, named because item 5 is where it lands: the sandbox has only ever been run against the placeholder. `SystemCallFilter = [ "@system-service" ]` in particular has seen a shell script and nothing else, and a full `opencode run` meeting it for the first time may need a line loosened. `AF_NETLINK` is already in `RestrictAddressFamilies` for the same reason found in review rather than in production - Go and Node both read resolver state over netlink, so `gh` and `opencode` would have failed without it.
 
 ### Done when
 

--- a/hosts/homelab01/default.nix
+++ b/hosts/homelab01/default.nix
@@ -195,6 +195,19 @@ in
         };
       };
     };
+
+    # -------------------------------------------------------------------------
+    # AFK agent (unattended ticket runner)
+    # -------------------------------------------------------------------------
+    # Off, and it stays off until two things land: item 5's pre-push denylist
+    # gate (docs/plans/afk-agent-pipeline.md), without which
+    # docs/agents/afk-eligibility.md is enforced by nothing on the push path,
+    # and an answer to #190 on whether `deploy` should restrict who may push.
+    # Both are named in the module's own `enable` description; this is the host
+    # writing the switch down so that turning it on later is one word here
+    # rather than a new block.
+    afk-agent.enable = false;
+
     immich.enable = false;
     home-assistant.enable = false;
     miniflux.enable = true;

--- a/modules/services/afk-agent.nix
+++ b/modules/services/afk-agent.nix
@@ -1,0 +1,278 @@
+# The AFK agent: an unattended runner for `ready-for-agent` tickets.
+#
+# Item 4 of docs/plans/afk-agent-pipeline.md, implementing ADR 0004 §1, §3
+# and §7: the pipeline runs on homelab01, it is triggered by a polling systemd
+# timer rather than a webhook, and it is a real NixOS module so that turning it
+# off in an emergency is one boolean rather than remembering which script to
+# kill. `cg.service.afk-agent.enable = false` removes the timer, the unit and
+# the service account, which is what checks/afk-agent.nix pins.
+#
+# WHAT THIS MODULE OWNS, AND WHAT IT DOES NOT. This is the unit around the
+# runner, not the runner. The poll -> claim -> worktree -> implement loop is
+# item 5 and is deliberately a separate piece of work: it is script logic
+# driving `gh` and `opencode`, neither of which can run inside the Nix build
+# sandbox, so it gets a script-level test harness rather than a VM test. What
+# is settled here is everything that surrounds it - the schedule, the runtime
+# ceiling, the service account, the credentials, the sandbox, and the toolchain
+# on its PATH - so that item 5 writes logic against plumbing that is already
+# proven rather than plumbing and logic at once.
+#
+# Until item 5 lands, ExecStart is a placeholder that checks that plumbing and
+# then exits non-zero. That is on purpose: a host that switches this on early
+# should get a red unit saying why, not a green one that silently does
+# nothing. There is a real ordering constraint behind it - see the `enable`
+# option's description.
+#
+# CONCURRENCY IS ONE, and it is systemd that enforces it rather than anything
+# in the runner: a single non-templated unit cannot have two live instances, so
+# a poll that fires while a ticket is still being worked cannot start a second
+# one. ADR 0004 §8 fixes the principle; raising it later means templating this
+# unit, which is a deliberate act rather than an oversight.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.cg.service.afk-agent;
+
+  stateDir = "/var/lib/afk-agent";
+
+  # The credentials this unit runs on: the name systemd exposes them under in
+  # $CREDENTIALS_DIRECTORY, mapped to the sops key each one is read from.
+  # Written once because three places need the same answer - the `sops.secrets`
+  # declarations, the `LoadCredential` list, and the preflight below - and a
+  # set that drifts between them fails at 04:00 on a host rather than here.
+  credentials = {
+    github-token = "gh-ci/dotfiles-afk-agent-PAT";
+    opencode-api-key = "opencode/api-key";
+    opencode-username = "opencode/username";
+  };
+
+  # The binaries the runner drives, keyed by the name it will invoke: `gh` for
+  # the claim, the PR and the relabel, `git` for the worktree, `opencode` for
+  # the work itself, and `nix` because the checks it has to pass before pushing
+  # are this repository's own. Keyed rather than listed for the same reason as
+  # above - the unit's PATH and the preflight's assertions are one list.
+  toolchain = {
+    git = pkgs.git;
+    gh = pkgs.gh;
+    opencode = pkgs.opencode;
+    jq = pkgs.jq;
+    nix = config.nix.package;
+  };
+
+  # The stand-in for item 5's runner.
+  #
+  # Named `preflight` rather than `poll` because it polls nothing: it asserts
+  # the two things this module is responsible for handing over - the
+  # credentials and the toolchain - and names each one it found, so
+  # checks/afk-agent.nix can assert the wiring from the outside without a
+  # runner existing. The name is what `systemctl cat afk-agent` shows, so it
+  # should say what is actually there.
+  #
+  # It prints names only, never values: this unit reads a PAT that can push to
+  # this repository, and the system journal is not a place to put it.
+  #
+  # Item 5 replaces this with the real loop and updates that check with it.
+  preflight = pkgs.writeShellApplication {
+    name = "afk-agent-preflight";
+    runtimeInputs = [ pkgs.coreutils ];
+    text = ''
+      creds="''${CREDENTIALS_DIRECTORY:?systemd passed no credentials directory}"
+
+      require_credential() {
+        if [ ! -s "$creds/$1" ]; then
+          echo "afk-agent: credential '$1' is missing or empty" >&2
+          exit 1
+        fi
+        echo "afk-agent: credential '$1' present"
+      }
+
+      require_tool() {
+        if ! command -v "$1" >/dev/null; then
+          echo "afk-agent: tool '$1' is not on this unit's PATH" >&2
+          exit 1
+        fi
+        echo "afk-agent: tool '$1' present"
+      }
+
+      ${lib.concatMapStringsSep "\n" (name: "require_credential ${name}") (lib.attrNames credentials)}
+
+      ${lib.concatMapStringsSep "\n" (name: "require_tool ${name}") (lib.attrNames toolchain)}
+
+      echo "afk-agent: runner not implemented yet - this is the item 4 scaffold." >&2
+      echo "afk-agent: see docs/plans/afk-agent-pipeline.md, item 5." >&2
+      exit 1
+    '';
+  };
+in
+{
+  options.cg.service.afk-agent = {
+    enable = lib.mkEnableOption ''
+      the unattended AFK ticket runner.
+
+      Leave this off until item 5 of docs/plans/afk-agent-pipeline.md has
+      landed its pre-push denylist gate. That is an ordering constraint rather
+      than a preference: `AFK_AGENT_TOKEN` carries the Workflows permission
+      (item 3), so nothing at GitHub's end stops this service pushing a branch
+      that edits `.github/workflows/`, and a pushed branch runs its own
+      workflow with the repository's secrets before anyone reads the PR. The
+      gate has to exist, and has to run before the push, or the denylist in
+      docs/agents/afk-eligibility.md is enforced by nothing
+    '';
+
+    schedule = lib.mkOption {
+      type = lib.types.str;
+      default = "*:0/15";
+      example = "hourly";
+      description = ''
+        How often to poll for eligible tickets, as a systemd calendar
+        expression (systemd.time(7)).
+
+        ADR 0004 §3 accepts up to one interval of latency between a ticket
+        becoming eligible and work starting, so this trades promptness against
+        how often the GitHub API is asked a question whose answer is almost
+        always "nothing to do". A quarter hour is well inside that tolerance
+        and well inside any rate limit.
+      '';
+    };
+
+    maxRuntime = lib.mkOption {
+      type = lib.types.str;
+      default = "4h";
+      example = "90min";
+      description = ''
+        Ceiling on a single run, as `TimeoutStartSec` (systemd.time(7)).
+
+        This is not decoration. A `oneshot` unit defaults to a 90-second start
+        timeout, which would kill every real run: the pilot measured 15-60
+        minutes per `opencode run`, and item 5 allows two retries on top of
+        that. The ceiling still has to exist, because concurrency here is one
+        unit - a run that hangs blocks every later poll until something stops
+        it, and "something" should not have to be a person.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # The three credentials this service needs (item 11), read from the file
+    # homelab01 itself decrypts. No `owner`: they are handed to the unit with
+    # `LoadCredential`, which systemd reads as root and copies into the unit's
+    # private credentials directory before it drops to the account below - so
+    # the sops-nix defaults (root:root 0400) are exactly right, and there is
+    # no per-secret ownership for this module to get wrong.
+    sops.secrets = lib.genAttrs (lib.attrValues credentials) (_: { });
+
+    # A dedicated account rather than root. It is the boundary around a
+    # process that runs generated code with repo-write credentials, which is
+    # the added blast radius ADR 0004 names in its consequences.
+    users.users.afk-agent = {
+      isSystemUser = true;
+      group = "afk-agent";
+      home = stateDir;
+      description = "Unattended AFK ticket runner";
+    };
+    users.groups.afk-agent = { };
+
+    systemd.services.afk-agent = {
+      description = "Work one ready-for-agent ticket, unattended";
+
+      # No `wantedBy`. The timer is the only thing that starts this, and a
+      # coding agent that also ran on every boot would be a surprise.
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      # coreutils on top of the toolchain proper: not something the runner
+      # drives by name, just the shell utilities any script assumes.
+      path = lib.attrValues toolchain ++ [ pkgs.coreutils ];
+
+      # opencode and gh both keep state under $HOME; without this they resolve
+      # it from the account's passwd entry, which is the same directory - but
+      # only by coincidence, and only until someone changes one of them.
+      environment.HOME = stateDir;
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = "afk-agent";
+        Group = "afk-agent";
+        StateDirectory = "afk-agent";
+        StateDirectoryMode = "0700";
+        WorkingDirectory = stateDir;
+        UMask = "0077";
+        TimeoutStartSec = cfg.maxRuntime;
+
+        LoadCredential = lib.mapAttrsToList (
+          alias: name: "${alias}:${config.sops.secrets.${name}.path}"
+        ) credentials;
+
+        ExecStart = lib.getExe preflight;
+
+        # Hardening, bounded by what the job actually is. This unit exists to
+        # run a coding agent: it needs the network, it needs to write a
+        # checkout, and it needs to build. The strict posture the other
+        # services here get is not available, so what is left is the subset
+        # that costs nothing.
+        #
+        # Proven against the placeholder below, not against a real run. The
+        # syscall filter in particular has only ever seen a shell script; item
+        # 5 is where a full `opencode run` first meets it, and loosening a line
+        # here is a legitimate outcome of that.
+        NoNewPrivileges = true;
+        ProtectSystem = "full";
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectHome = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictSUIDSGID = true;
+        RestrictRealtime = true;
+        LockPersonality = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" ];
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+          # Go and Node both enumerate interfaces and read resolver state over
+          # netlink, so `gh` and `opencode` need this even though nothing in
+          # this unit opens a netlink socket deliberately. Left in rather than
+          # discovered on the first real run.
+          "AF_NETLINK"
+        ];
+
+        # Two settings above are weaker than the obvious choice, both
+        # deliberately:
+        #
+        # ProtectSystem is "full" rather than "strict". Every `nix build` this
+        # runs is a client of the Nix daemon, and connecting to a unix socket
+        # needs write access to the socket inode - which lives under /nix/var,
+        # and which "strict" would remount read-only.
+        #
+        # MemoryDenyWriteExecute is absent entirely. opencode is a JIT'd
+        # JavaScript runtime and needs writable-executable pages; the digital
+        # garden dropped the same exemption when its Node toolchain went away,
+        # and this is that exemption coming back for the same reason.
+      };
+    };
+
+    systemd.timers.afk-agent = {
+      description = "Poll for ready-for-agent tickets";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.schedule;
+
+        # Explicitly not Persistent, unlike every other timer in this
+        # repository. Those catch up work that had to happen (a backup, a
+        # cleanup); a poll has nothing to catch up on. The tickets a missed
+        # poll would have found are still open at the next tick, and a
+        # Persistent timer would instead start a coding agent the moment a
+        # host finishes booting - including the reboot at the end of every
+        # nightly upgrade.
+        Persistent = false;
+      };
+    };
+  };
+}

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -9,15 +9,15 @@ Encrypted with [sops](https://github.com/getsops/sops) and age, decrypted by [so
 | File             | Read by                | Holds                                                                                                                    |
 | ---------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `shared.yaml`    | both servers           | Only what two machines must agree on. Every entry is justified in `cg.sops-nix.sharedSecrets` (`modules/nixos/sops-nix.nix`). |
-| `homelab01.yaml` | homelab01              | Everything only homelab01 declares — the tunnel, Grafana, miniflux, wallabag, the garden.                                  |
+| `homelab01.yaml` | homelab01              | Everything only homelab01 declares — the tunnel, Grafana, miniflux, wallabag, the garden, and the AFK agent's GitHub PAT and OpenCode credentials. |
 | `homelab02.yaml` | homelab02              | Everything only homelab02 declares — qBittorrent, the VPN, grimmory's database.                                            |
 | `xps15.yaml`     | xps15                  | The laptop's wifi PSKs. Nothing else on a machine that leaves the house.                                                   |
-| `operator.yaml`  | nobody — the user only | Secrets that belong to a person rather than a machine: the user's SSH keys, CI tokens, and web logins for services that keep their own user database. |
+| `operator.yaml`  | nobody — the user only | Secrets that belong to a person rather than a machine: the user's SSH keys, CI tokens no host declares, and web logins for services that keep their own user database. |
 
 Two consequences worth stating, because both are easy to get wrong:
 
 - **`prowlarr/api` is in `homelab02.yaml`, and Prowlarr runs on homelab01.** The file follows the declaration, and the only thing that declares that key is cross-seed, on homelab02. The service's location is not the question.
-- **A secret for a service that is switched off still lives in its host's file.** `vikunja/jwt-secret` and `digital-garden/deploy-key` are both parked in `homelab01.yaml` so that flipping the toggle works without an editing session. `operator.yaml` is for what no host will ever declare, not for what no host declares today.
+- **A secret for a service that is switched off still lives in its host's file.** `vikunja/jwt-secret` and `digital-garden/deploy-key` are both parked in `homelab01.yaml` so that flipping the toggle works without an editing session, and so are the AFK agent's three (`gh-ci/dotfiles-afk-agent-PAT`, `opencode/api-key`, `opencode/username`) — `modules/services/afk-agent.nix` declares them, and it ships disabled. `operator.yaml` is for what no host will ever declare, not for what no host declares today.
 
 Nothing in `modules/` names a file. A module writes `sops.secrets."<name>" = { ... }` and `cg.sops-nix` decides where the name is read from: `secrets/<hostname>.yaml`, or `shared.yaml` if the name is in `cg.sops-nix.sharedSecrets`. That option is the whole of the mapping and the place to change it.
 


### PR DESCRIPTION
Closes #170. Item 4 of `docs/plans/afk-agent-pipeline.md`, implementing ADR 0004 §1, §3 and §7.

## What this is

The AFK pipeline becomes a real NixOS module on homelab01 — a `oneshot` unit driven by a polling timer, with `cg.service.afk-agent.enable` as the one boolean that stops it.

**It is the unit around the runner, not the runner.** Item 5's poll → claim → worktree → implement loop is script logic driving `gh` and `opencode` and gets its own harness. What is settled here is everything surrounding it: the schedule, the runtime ceiling, the service account, the three credentials, the sandbox, and the toolchain on `PATH`. Until item 5 lands, `ExecStart` is a preflight that asserts exactly that plumbing and then exits non-zero — a host switching this on early gets a red unit that says why, rather than a green one that quietly does nothing.

The switch is written down as `false` on homelab01 and stays there until item 5's pre-push denylist gate exists and #190 is answered. That is the ordering constraint item 3 records, not a preference.

## Three departures from what the rest of the repo does

- **The timer is not `Persistent`**, alone among the timers here. The others catch up work that had to happen; a poll has nothing to catch up on, and a `Persistent` one would start a coding agent after every nightly upgrade's reboot.
- **`TimeoutStartSec` is an option (`maxRuntime`, 4h)**, because a `oneshot` unit's 90-second default would kill every real run — the pilot measured 15–60 minutes, with two retries on top.
- **`ProtectSystem` is `full`, and `MemoryDenyWriteExecute` is absent.** Every `nix build` the runner does is a Nix daemon client and needs write access to a socket inode under `/nix/var`; opencode is a JIT'd JavaScript runtime. Both are argued at the line.

## Testing

`checks/afk-agent.nix` boots the module both ways, because "the module evaluates" cannot tell a `lib.mkIf` that guards everything from one that guards half of it.

- **Enabled:** the timer is armed, nothing wants the service at boot, all three credentials and all five tools arrive, and — the one assertion about an absence — no credential value reaches the journal.
- **Disabled:** no timer, no service, no account, no state directory.

Credentials are `checks/stub-secrets.nix` fixtures; no real value enters the test.

`nix flake check --print-build-logs` → `all checks passed!` (all checks plus both host builds). `nix fmt -- --ci` clean.

## Two things worth knowing at review

- **The acceptance criterion asks that "the service+timer exist and are enabled".** The timer is enabled; the service deliberately has no `[Install]` section, because a unit that both a timer and `multi-user.target` want would start a coding agent on every boot. The check asserts the unit exists and that nothing wants it — the criterion's intent, inverted on the half where the literal reading would be a bug.
- **The sandbox has only ever met a shell script.** `SystemCallFilter = [ "@system-service" ]` in particular is unproven against a real `opencode run`. `AF_NETLINK` is already in `RestrictAddressFamilies` for the same reason, found in review rather than in production.

## Second commit

`docs(adr): drop the peak-pricing clause from ADR 0004 §3` — the poller was to avoid DeepSeek's weekday peak windows. That was never built (the pilot chose `glm-5.3-flash`, and plan item 10 was dropped), so the clause goes rather than earning an amendment. Item 10 remains the plan's record of why.