### PR TITLE
feat(afk-agent): poll, re-check the denylist, claim, and isolate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,7 @@ jobs:
       matrix:
         check:
           - afk-agent
+          - afk-agent-runner
           - alert-rules
           - alert-rules-unit
           - alertmanager-config

--- a/checks/afk-agent-runner.nix
+++ b/checks/afk-agent-runner.nix
@@ -1,0 +1,413 @@
+# checks/afk-agent-runner.nix
+#
+# The AFK runner's poll -> denylist -> claim -> isolate logic (#171), tested at
+# the level it actually lives at.
+#
+# NOT A VM TEST, and not for the usual reason. checks/afk-agent.nix already
+# boots this module both ways; what it cannot do is exercise the runner, which
+# talks to the GitHub API and clones a repository - neither of which exists
+# inside the Nix build sandbox. So `gh` is mocked and `origin` is a fixture
+# repository on disk, while `git` is the real thing: the branch and the
+# worktree this asserts are genuine git objects, not a recorded intention.
+# checks/download-root-canary-script.nix set this shape; this is the second
+# use of it, and the first outside a monitored service.
+#
+# The script under test is taken from the module's own evaluated ExecStart -
+# never a copy - and driven through the two environment overrides it supports.
+#
+# What is under test here is the part of the pipeline that is irreversible from
+# the outside. A wrong claim writes to a tracker a human shares, and a wrong
+# eligibility decision is how a workflow edit reaches a branch that runs with
+# the repository's secrets (docs/agents/afk-eligibility.md). The cases below
+# are chosen for that: which tickets are picked, which are refused, that the
+# claim lands before anything else is touched, and that a second ticket cannot
+# start while a first is unfinished.
+{
+  inputs,
+  pkgs,
+  self,
+}:
+let
+  eval = inputs.nixpkgs.lib.nixosSystem {
+    system = "x86_64-linux";
+    specialArgs = {
+      inherit self inputs;
+    };
+    modules = [
+      inputs.sops-nix.nixosModules.sops
+      ../modules/services/afk-agent.nix
+      {
+        cg.service.afk-agent.enable = true;
+        system.stateVersion = "24.11";
+      }
+    ];
+  };
+
+  runnerScript = eval.config.systemd.services.afk-agent.serviceConfig.ExecStart;
+in
+pkgs.runCommand "check-afk-agent-runner"
+  {
+    nativeBuildInputs = [
+      pkgs.git
+      pkgs.jq
+    ];
+    script = builtins.toString runnerScript;
+    eligibilityDoc = ../docs/agents/afk-eligibility.md;
+  }
+  ''
+    set -euo pipefail
+
+    fail() { echo "FAIL: $*" >&2; exit 1; }
+
+    work=$PWD/work
+    mkdir -p "$work"
+    export HOME=$work/home
+    mkdir -p "$HOME"
+
+    git config --global user.email "afk-agent@example.invalid"
+    git config --global user.name "afk agent test"
+    git config --global init.defaultBranch master
+    git config --global protocol.file.allow always
+
+    # --- the fixture the runner clones -----------------------------------
+    #
+    # A real repository, so `git worktree add -b afk/<slug> <path>
+    # origin/master` either produces a branch and a checked-out tree or fails
+    # for a reason worth knowing about.
+    mkdir -p "$work/seed"
+    (
+      cd "$work/seed"
+      git init -q -b master
+      echo "fixture" > README.md
+      git add README.md
+      git commit -qm "seed"
+    )
+    git clone -q --bare "$work/seed" "$work/origin.git"
+    export AFK_REPO_URL="file://$work/origin.git"
+
+    # --- the credentials item 4 hands over -------------------------------
+    mkdir -p "$work/creds"
+    echo "not-a-real-token" > "$work/creds/github-token"
+    echo "not-a-real-key"   > "$work/creds/opencode-api-key"
+    echo "not-a-real-user"  > "$work/creds/opencode-username"
+    export CREDENTIALS_DIRECTORY="$work/creds"
+
+    # --- the mocks --------------------------------------------------------
+    #
+    # `gh` answers `issue list` from whichever fixture the case selected and
+    # records every invocation, so an assertion can be made about what the
+    # runner asked the tracker to do as well as about what it did locally.
+    # `issue edit` can be made to fail, which is the only way to observe that
+    # the claim really does come before the worktree.
+    #
+    # Anything else exits 64: a runner that grew a `gh` call nobody thought
+    # about should fail this test rather than quietly succeed through a
+    # permissive mock.
+    mkdir -p "$work/bin"
+
+    cat > "$work/bin/gh" <<'MOCK'
+    #!/bin/sh
+    echo "gh $*" >> "$GH_LOG"
+    case "$1 $2" in
+      "issue list")
+        cat "$GH_ISSUES"
+        ;;
+      "issue edit")
+        if [ -n "''${GH_EDIT_FAIL:-}" ]; then
+          echo "mock gh: refusing to assign" >&2
+          exit 1
+        fi
+        ;;
+      *)
+        echo "mock gh: unexpected invocation: $*" >&2
+        exit 64
+        ;;
+    esac
+    MOCK
+
+    # The runner asserts these are on its PATH before it does anything. Nothing
+    # here invokes them, so a stub that exists is the whole requirement - and
+    # is a great deal cheaper than putting a real `nix` in a test closure.
+    for stub in opencode nix; do
+      printf '#!/bin/sh\nexit 0\n' > "$work/bin/$stub"
+    done
+
+    chmod +x "$work/bin"/*
+    export PATH="$work/bin:$PATH"
+
+    # --- fixtures ---------------------------------------------------------
+    #
+    # `blockedBy` carries every dependency edge with its state, closed ones
+    # included, which is why the runner counts open blockers rather than
+    # trusting `totalCount`. #301 and #302 are that distinction: one open
+    # blocker versus one closed blocker, identical in `totalCount`.
+    mkdir -p "$work/fixtures"
+
+    cat > "$work/fixtures/mixed.json" <<'JSON'
+    [
+      { "number": 303, "title": "Later but clean", "body": "Touch modules/services only.",
+        "assignees": [], "blockedBy": { "nodes": [], "totalCount": 0 } },
+      { "number": 300, "title": "Already claimed", "body": "Nothing denied here.",
+        "assignees": [{ "login": "corygyarmathy" }], "blockedBy": { "nodes": [], "totalCount": 0 } },
+      { "number": 301, "title": "Still blocked", "body": "Nothing denied here.",
+        "assignees": [], "blockedBy": { "nodes": [{ "number": 299, "state": "OPEN" }], "totalCount": 1 } },
+      { "number": 302, "title": "Unblocked at last", "body": "Nothing denied here.",
+        "assignees": [], "blockedBy": { "nodes": [{ "number": 298, "state": "CLOSED" }], "totalCount": 1 } }
+    ]
+    JSON
+
+    cat > "$work/fixtures/denied-then-clean.json" <<'JSON'
+    [
+      { "number": 310, "title": "Shard the CI matrix", "body": "Edit .github/workflows/ci.yml to add a job.",
+        "assignees": [], "blockedBy": { "nodes": [], "totalCount": 0 } },
+      { "number": 311, "title": "Clean follow-up", "body": "Only modules/nixos changes.",
+        "assignees": [], "blockedBy": { "nodes": [], "totalCount": 0 } }
+    ]
+    JSON
+
+    cat > "$work/fixtures/denied-workflows.json" <<'JSON'
+    [
+      { "number": 312, "title": "Shard the CI matrix", "body": "Edit .github/workflows/ci.yml to add a job.",
+        "assignees": [], "blockedBy": { "nodes": [], "totalCount": 0 } }
+    ]
+    JSON
+
+    cat > "$work/fixtures/denied-secrets.json" <<'JSON'
+    [
+      { "number": 313, "title": "Rotate the tunnel token", "body": "Re-encrypt secrets/homelab01.yaml.",
+        "assignees": [], "blockedBy": { "nodes": [], "totalCount": 0 } }
+    ]
+    JSON
+
+    cat > "$work/fixtures/denied-sops.json" <<'JSON'
+    [
+      { "number": 314, "title": "Add a recipient", "body": "A new age key belongs in .sops.yaml.",
+        "assignees": [], "blockedBy": { "nodes": [], "totalCount": 0 } }
+    ]
+    JSON
+
+    cat > "$work/fixtures/denied-in-title.json" <<'JSON'
+    [
+      { "number": 315, "title": "Tidy .github/workflows/ci.yml", "body": "No detail given.",
+        "assignees": [], "blockedBy": { "nodes": [], "totalCount": 0 } }
+    ]
+    JSON
+
+    cat > "$work/fixtures/denied-by-intent-only.json" <<'JSON'
+    [
+      { "number": 317, "title": "Add a job to the CI matrix", "body": "The build matrix in the CI workflow needs one more entry.",
+        "assignees": [], "blockedBy": { "nodes": [], "totalCount": 0 } }
+    ]
+    JSON
+
+    cat > "$work/fixtures/none.json" <<'JSON'
+    []
+    JSON
+
+    cat > "$work/fixtures/all-taken.json" <<'JSON'
+    [
+      { "number": 316, "title": "Taken", "body": "Nothing denied.",
+        "assignees": [{ "login": "corygyarmathy" }], "blockedBy": { "nodes": [], "totalCount": 0 } }
+    ]
+    JSON
+
+    cat > "$work/fixtures/punctuation-title.json" <<'JSON'
+    [
+      { "number": 320, "title": "Fix: the *bar*, //again// (v2)!", "body": "Nothing denied.",
+        "assignees": [], "blockedBy": { "nodes": [], "totalCount": 0 } }
+    ]
+    JSON
+
+    cat > "$work/fixtures/second-ticket.json" <<'JSON'
+    [
+      { "number": 330, "title": "A different ticket", "body": "Nothing denied.",
+        "assignees": [], "blockedBy": { "nodes": [], "totalCount": 0 } }
+    ]
+    JSON
+
+    # --- the harness ------------------------------------------------------
+    #
+    # Each case gets its own state directory unless it deliberately inherits
+    # one, because the runner's own memory between polls *is* that directory.
+    state=""
+    rc=0
+
+    run() {
+      local name=$1 fixture=$2 reuse=''${3:-fresh}
+      state="$work/state/$name"
+      if [ "$reuse" = "fresh" ]; then rm -rf "$state"; fi
+      mkdir -p "$state"
+
+      export AFK_STATE_DIR="$state"
+      export GH_ISSUES="$work/fixtures/$fixture"
+      export GH_LOG="$state/gh.log"
+      : > "$GH_LOG"
+
+      set +e
+      "$script" > "$state/out.log" 2> "$state/err.log"
+      rc=$?
+      set -e
+    }
+
+    ghlog() { cat "$state/gh.log"; }
+    claims() { grep -c "issue edit" "$state/gh.log" || true; }
+    worktrees() { find "$state/worktrees" -mindepth 1 -maxdepth 1 -printf '%f\n' 2>/dev/null | sort; }
+    # Scoped to refs/heads/afk: the clone brings its own `master` along, and
+    # what is under test is which branch the runner cut, not that a clone has
+    # the branch it was cloned from.
+    branches() { git -C "$state/checkout" for-each-ref --format='%(refname:short)' refs/heads/afk 2>/dev/null | sort; }
+
+    echo "case: the plumbing is asserted before anything is polled"
+    run plumbing none.json
+    [ "$rc" -eq 0 ] || fail "an empty tracker should be a quiet success, got $rc: $(cat "$state/err.log")"
+    for credential in github-token opencode-api-key opencode-username; do
+      grep -q "credential '$credential' present" "$state/out.log" \
+        || fail "$credential was not asserted before the poll"
+    done
+    for tool in git gh opencode nix jq; do
+      grep -q "tool '$tool' present" "$state/out.log" || fail "$tool was not asserted before the poll"
+    done
+    [ "$(claims)" -eq 0 ] || fail "claimed something from an empty tracker"
+
+    echo "case: the query asks the tracker for the right issues in the first place"
+    # The mock answers `issue list` from a fixture whatever it is asked, which
+    # is what lets the filtering cases below be written - and also means the
+    # query itself is only under test if something reads it back. Without this
+    # the runner could stop asking for the label entirely, poll every open
+    # issue in the repository, and every other case here would still pass.
+    run query mixed.json
+    grep -q -- "--label ready-for-agent" "$state/gh.log" || fail "the poll no longer filters by label: $(ghlog)"
+    grep -q -- "--state open" "$state/gh.log" || fail "the poll no longer filters to open issues: $(ghlog)"
+    # Oldest-first has to be asked of the API. `gh issue list` returns newest
+    # first, so past --limit it is the oldest tickets that fall off the end -
+    # and this claims the oldest survivor. A local sort cannot recover a ticket
+    # that was never in the page.
+    grep -q -- "--search sort:created-asc" "$state/gh.log" \
+      || fail "the poll no longer asks for oldest-first, so a long backlog would hide its own front: $(ghlog)"
+
+    echo "case: only unassigned, unblocked issues are picked up, oldest first"
+    run mixed mixed.json
+    [ "$rc" -eq 0 ] || fail "a clean run exited $rc: $(cat "$state/err.log")"
+    [ "$(claims)" -eq 1 ] || fail "expected exactly one claim, got: $(ghlog)"
+    grep -q "gh issue edit 302 .* --add-assignee @me" "$state/gh.log" \
+      || fail "did not claim #302 with the documented convention: $(ghlog)"
+    # The three it must not have touched, each for its own reason: assigned,
+    # open blocker, and simply later in the queue.
+    for skipped in 300 301 303; do
+      if grep -q "gh issue edit $skipped " "$state/gh.log"; then fail "claimed #$skipped"; fi
+    done
+    [ "$(worktrees)" = "302-unblocked-at-last" ] || fail "worktree not isolated: $(worktrees)"
+    [ "$(branches)" = "afk/302-unblocked-at-last" ] || fail "branch not cut: $(branches)"
+    # An isolated worktree, not just a directory: a real checkout of the base
+    # branch, on its own branch, with nothing of the seed's history missing.
+    [ -f "$state/worktrees/302-unblocked-at-last/README.md" ] \
+      || fail "the worktree has no working tree"
+    head="$(git -C "$state/worktrees/302-unblocked-at-last" rev-parse --abbrev-ref HEAD)"
+    [ "$head" = "afk/302-unblocked-at-last" ] || fail "worktree is on $head"
+    # And with no upstream. `git worktree add -b <b> <path> origin/master`
+    # tracks origin/master unless told not to, which would make #174's push -
+    # under git's default push.default of `simple` - aim at master. Nothing
+    # else in this pipeline would notice before the push was attempted.
+    upstream="$(git -C "$state/checkout" for-each-ref \
+      --format='%(upstream:short)' refs/heads/afk/302-unblocked-at-last)"
+    [ -z "$upstream" ] || fail "the ticket branch tracks $upstream"
+
+    echo "case: a ticket whose scope names a denied path is refused before the claim"
+    run denied-then-clean denied-then-clean.json
+    [ "$rc" -eq 0 ] || fail "the fall-through should succeed, got $rc: $(cat "$state/err.log")"
+    if grep -q "gh issue edit 310 " "$state/gh.log"; then fail "claimed a denylisted ticket"; fi
+    grep -q "skipping #310" "$state/out.log" || fail "the rejection was not reported"
+    grep -q "gh issue edit 311 " "$state/gh.log" || fail "did not fall through to the clean ticket"
+    [ "$(worktrees)" = "311-clean-follow-up" ] || fail "isolated the wrong ticket: $(worktrees)"
+
+    echo "case: each denied path is refused on its own, in the body or in the title"
+    for case_name in denied-workflows denied-secrets denied-sops denied-in-title; do
+      run "$case_name" "$case_name.json"
+      [ "$rc" -eq 0 ] || fail "$case_name exited $rc: $(cat "$state/err.log")"
+      [ "$(claims)" -eq 0 ] || fail "$case_name claimed a denylisted ticket: $(ghlog)"
+      [ -z "$(worktrees)" ] || fail "$case_name isolated a denylisted ticket"
+      if [ -d "$state/checkout" ]; then fail "$case_name cloned before deciding eligibility"; fi
+    done
+
+    echo "case: the denylist reads words, not intent - and this pins the limit"
+    # Not a bug being blessed: a record of how far this control reaches, so the
+    # cases above cannot be read as proving more than they do. #317 plainly
+    # means to edit .github/workflows/ci.yml and never writes the path, so the
+    # pre-claim check does not see it - matching prose is all that is possible
+    # before a line of code exists. What catches it is the pre-push gate on the
+    # actual diff (item 7, #174) and triage before that. If a future change
+    # makes this rejected, this expectation is what will say so, and it should
+    # be flipped rather than deleted.
+    run denied-by-intent-only denied-by-intent-only.json
+    [ "$rc" -eq 0 ] || fail "exited $rc: $(cat "$state/err.log")"
+    [ "$(claims)" -eq 1 ] \
+      || fail "the prose check has changed reach - update this case rather than removing it: $(ghlog)"
+
+    echo "case: a tracker with nothing claimable is a quiet success"
+    run all-taken all-taken.json
+    [ "$rc" -eq 0 ] || fail "exited $rc on an all-assigned tracker"
+    [ "$(claims)" -eq 0 ] || fail "claimed an assigned issue"
+    grep -q "nothing to claim" "$state/out.log" || fail "said nothing about an idle poll"
+
+    echo "case: the claim happens before anything local is touched"
+    # The only way to observe ordering from outside: make the claim fail and
+    # check that nothing local survived it. A runner that cut the branch first
+    # would leave one behind.
+    export GH_EDIT_FAIL=1
+    run claim-first mixed.json
+    unset GH_EDIT_FAIL
+    [ "$rc" -ne 0 ] || fail "a failed claim was reported as success"
+    [ -z "$(worktrees)" ] || fail "a worktree exists for a ticket that was never claimed"
+    if [ -d "$state/checkout" ]; then fail "cloned before the claim landed"; fi
+
+    echo "case: an issue title only ever becomes a safe branch name"
+    run punctuation punctuation-title.json
+    [ "$rc" -eq 0 ] || fail "exited $rc: $(cat "$state/err.log")"
+    [ "$(branches)" = "afk/320-fix-the-bar-again-v2" ] \
+      || fail "unsafe or unexpected branch name: $(branches)"
+
+    echo "case: one ticket at a time - a live worktree stops the next poll"
+    # Reusing the state the `mixed` case left behind: #302 is claimed and its
+    # worktree is on disk. systemd cannot prevent this on its own - two runs
+    # never overlap, but a run that died leaves exactly this behind - so the
+    # runner has to refuse, loudly, rather than start a second ticket beside it.
+    run mixed second-ticket.json reuse
+    [ "$rc" -ne 0 ] || fail "started a second ticket while one was still in flight"
+    [ "$(claims)" -eq 0 ] || fail "claimed #330 with #302 unfinished: $(ghlog)"
+    grep -qi "still here" "$state/err.log" || fail "did not say why it refused: $(cat "$state/err.log")"
+    [ "$(worktrees)" = "302-unblocked-at-last" ] || fail "the in-flight worktree was disturbed"
+
+    echo "case: merge is never in the runner's command surface"
+    # ADR 0004 §9 - merge stays a human act - is enforced by nothing else.
+    # Item 3 found that no GitHub ruleset can carry it here: ADR 0004 §4 rules
+    # out a second account, so an AFK PR is authored by the person who would
+    # approve it, and GitHub does not let an author approve their own PR. This
+    # grep is the whole control.
+    if grep -qE 'gh[[:space:]]+pr[[:space:]]+merge|--auto' "$script"; then
+      fail "the runner can merge its own pull request"
+    fi
+
+    echo "case: the runner's denylist still matches the document it implements"
+    # Two independent readings of one rule (ADR 0004 §5) only stay independent
+    # while they agree. This compares the runner's own array against rule 1's
+    # list in docs/agents/afk-eligibility.md, so a path added or dropped in one
+    # place fails here rather than in production, silently, months later.
+    mapfile -t doc_paths < <(
+      awk '
+        /^No AFK-produced diff may touch:$/ { in_list = 1; next }
+        in_list && /^- / { print; next }
+        in_list && NF { exit }
+      ' "$eligibilityDoc" | grep -o '`[^`]*`' | tr -d '`' | sort
+    )
+    mapfile -t script_paths < <(
+      sed -n '/^denied=($/,/^)$/p' "$script" | grep -o '"[^"]*"' | tr -d '"' | sort
+    )
+    [ "''${#doc_paths[@]}" -gt 0 ] \
+      || fail "could not read rule 1's path list out of afk-eligibility.md - has it been reformatted?"
+    [ "''${#script_paths[@]}" -gt 0 ] \
+      || fail "could not read the denied= array out of the runner - has it been restructured?"
+    [ "''${doc_paths[*]}" = "''${script_paths[*]}" ] \
+      || fail "denylist drift: the document says [''${doc_paths[*]}], the runner enforces [''${script_paths[*]}]"
+
+    touch $out
+  ''

--- a/checks/afk-agent.nix
+++ b/checks/afk-agent.nix
@@ -8,13 +8,17 @@
 # boots the module both ways and looks at the running system: two nodes, one
 # with the switch on and one with it off.
 #
-# The other half is the plumbing the scaffold exists to prove. The poller
-# itself is item 5 of docs/plans/afk-agent-pipeline.md and is not written yet;
-# what item 4 owns is everything around it - that the unit is reached by the
-# timer rather than at boot, that its three credentials arrive, and that the
-# toolchain the runner will drive is on its PATH. The placeholder ExecStart
-# checks exactly those and then exits non-zero, so this test can assert them
-# without pretending a runner exists.
+# The other half is the plumbing the runner is handed. What this file owns is
+# everything around the logic - that the unit is reached by the timer rather
+# than at boot, that its three credentials arrive, and that the toolchain the
+# runner drives is on its PATH. The runner asserts exactly those before it
+# polls anything, which is what lets a VM with no network still prove them.
+#
+# The runner's own behaviour is not testable here and is not attempted: it
+# talks to the GitHub API and clones a repository, and the sandbox has neither.
+# That is checks/afk-agent-runner.nix, which drives this same script against a
+# mocked `gh` and a fixture origin. Here the run is expected to fail at its
+# first outbound call, and the assertion is about how far it got first.
 #
 # The credentials are plaintext fixtures via ./stub-secrets.nix; sops cannot
 # decrypt in the sandbox, and no real value belongs in a test either way. They
@@ -98,9 +102,11 @@
         assert state == "inactive", f"the poller ran without the timer firing: {state}"
 
     with subtest("a run reaches its three credentials and the toolchain it drives"):
-        # The placeholder ExecStart exits non-zero on purpose - the runner is
-        # item 5 and does not exist yet - so the failure here is the expected
-        # result, and the journal is where the evidence is.
+        # The run fails, and is expected to: the VM has no network, so the
+        # first `gh issue list` cannot succeed. Everything asserted below
+        # happens before that call by design - a credential missing or a tool
+        # off the PATH should fail on an empty tracker rather than halfway
+        # through a ticket that has already been claimed.
         enabled.fail("systemctl start afk-agent.service")
         journal = enabled.succeed("journalctl -u afk-agent.service --no-pager")
 
@@ -112,7 +118,12 @@
         for tool in ["git", "gh", "opencode", "nix", "jq"]:
             assert f"tool '{tool}' present" in journal, f"{tool} is not on the unit's PATH:\n{journal}"
 
-        assert "runner not implemented" in journal, f"the placeholder is gone but this test is not:\n{journal}"
+        # It got past the plumbing and into the work. Without this the two
+        # loops above would still pass on a runner that asserted its inputs
+        # and then did nothing at all.
+        assert "polling corygyarmathy/dotfiles" in journal, (
+            f"the run never reached the poll:\n{journal}"
+        )
 
     with subtest("no credential value reaches the journal"):
         # The unit reads three secrets on every poll. A debug echo left behind

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -321,6 +321,12 @@ in
       '';
 
   afk-agent = testLib.mkTest ./afk-agent.nix;
+
+  # Not a VM: the runner talks to the GitHub API and clones a repository,
+  # neither of which exists in the sandbox, so `gh` is mocked and `origin` is
+  # a fixture repo on disk. The file says why that is the only level this
+  # logic is reachable at.
+  afk-agent-runner = import ./afk-agent-runner.nix { inherit pkgs self inputs; };
   digital-garden = testLib.mkTest ./digital-garden.nix;
   digital-garden-sync-health = import ./digital-garden-sync-health.nix {
     inherit pkgs;

--- a/docs/agents/afk-eligibility.md
+++ b/docs/agents/afk-eligibility.md
@@ -161,8 +161,15 @@ That leaves all three enforcement moments above as the agent checking itself, so
 the diff check sketched here is the only control rather than an extra - and it
 has to run **before the push**. The push becomes a PR, the PR runs the head
 branch's workflow with the repository's secrets before anyone reads it, and
-after that there is nothing left to gate. Item 5 owns implementing it as a
-pre-push gate, and item 4 does not switch the runner on before it exists.
+after that there is nothing left to gate. Item 7 owns implementing it as a
+pre-push gate, and the runner is not switched on before it exists.
+
+Item 5's runner does re-check the denylist before it claims (moment 2 above),
+but that check reads the ticket's prose and this exception cannot be judged
+from prose at all: whether a `ci.yml` diff is additions-only to the matrix is a
+question about a diff that does not exist yet. The two are not substitutes, and
+the prose check is the weaker one - it is also blunt in the other direction,
+refusing any ticket that so much as names a denied path.
 
 This exception is the one place the denylist is not purely path-shaped, and the
 only one that *widens* it rather than narrowing it. Like rule 2 below, it is

--- a/docs/plans/afk-agent-pipeline.md
+++ b/docs/plans/afk-agent-pipeline.md
@@ -1,6 +1,6 @@
 # Plan: the AFK agent pipeline
 
-Status: in progress — item 1 is done (`opencode-go/glm-5.3-flash` at `high`; see its Built note and cost-sustainability finding); item 2 is done (both eligibility rules written down, and the checks-matrix conflict settled with a narrow exception); item 3 is done (the token exists, is scoped to this repo alone, and was proven on a live PR); item 4 is done as a scaffold (the module, the kill-switch check, and the switch itself, written down as `false` on homelab01 - the runner it wraps is item 5, so its "Done when" only completes with that item); nothing else has started. Follows [ADR 0004](../adr/0004-afk-agent-runs-self-hosted-with-a-harness-split.md), which covers the architectural decisions (platform, harness split, identity, trigger, retries, kill switch) and the alternatives rejected along the way; this plan is the work items that implement it.
+Status: in progress — item 1 is done (`opencode-go/glm-5.3-flash` at `high`; see its Built note and cost-sustainability finding); item 2 is done (both eligibility rules written down, and the checks-matrix conflict settled with a narrow exception); item 3 is done (the token exists, is scoped to this repo alone, and was proven on a live PR); item 4 is done as a scaffold (the module, the kill-switch check, and the switch itself, written down as `false` on homelab01 - the runner it wraps is item 5, so its "Done when" only completes with that item); item 5 is in progress - its poll → denylist → claim → isolate half (#171) is built and tested, the implement stage it hands to (#172) is not; nothing else has started. Follows [ADR 0004](../adr/0004-afk-agent-runs-self-hosted-with-a-harness-split.md), which covers the architectural decisions (platform, harness split, identity, trigger, retries, kill switch) and the alternatives rejected along the way; this plan is the work items that implement it.
 
 The engineering skills (`.agents/skills/`) already carry a ticket from idea through `to-tickets`, which publishes a GitHub issue labelled `ready-for-agent` per `docs/agents/triage-labels.md`. `implement` already runs `/tdd`, tests, and a self-review, then commits. Everything below starts at the gap right after that: nothing currently claims a `ready-for-agent` ticket unattended, pushes it, opens a PR, or tells anyone.
 
@@ -12,7 +12,7 @@ Item 1 gates the stages that depend on a model choice - item 5's implement step 
 | 2  | Triage: AFK eligibility              | small  | done        |
 | 3  | AFK identity (`AFK_AGENT_TOKEN`)     | small  | done        |
 | 4  | `modules/services/afk-agent.nix`     | medium | done        |
-| 5  | Runner: claim → worktree → implement | large  | not started |
+| 5  | Runner: claim → worktree → implement | large  | in progress |
 | 6  | Review stage                         | small  | not started |
 | 7  | Raise the PR                         | small  | not started |
 | 8  | Stuck path                           | small  | not started |
@@ -713,6 +713,44 @@ On each poll:
 
 Not a NixOS VM test — this is script logic driving `gh` and `opencode`, neither of which can run inside the Nix build sandbox. A script-level test harness instead, with `gh` and `opencode` mocked: assert the poller only picks up unassigned `ready-for-agent` issues, claims via assignee before touching anything, re-checks the path denylist from item 2 and bails correctly on a ticket that would violate it, accepts a `ci.yml` diff that adds only a well-formed matrix entry while rejecting one that also changes anything else, removes an entry, or adds a name outside `^[a-z][a-z0-9-]*$`, and stops after 2 retries rather than looping indefinitely. It also asserts the absence of a thing: no `gh pr merge` anywhere in the runner's command surface, with or without `--auto`. ADR 0004 §9 is enforced by nothing else - see item 3's finding on why no ruleset can carry it. There's no prior art for this in the repo yet - script-level tests outside `checks/` are new here, so this sets the pattern rather than following one. Items 8 and 10 reuse this same harness rather than inventing their own.
 
+### Built: poll → denylist → claim → isolate, 2026-09-08
+
+The first half of this item, #171. `modules/services/afk-agent.nix` no longer holds item 4's placeholder: its `ExecStart` now polls, re-checks the denylist, claims, and cuts an isolated worktree, then stops and says that the implement stage is #172. `checks/afk-agent-runner.nix` is the harness described above; `checks/afk-agent.nix` keeps proving the plumbing around it.
+
+**The candidate query has a trap in it.** `gh issue list --json blockedBy` returns `{nodes, totalCount}`, and `totalCount` counts every dependency edge including closed ones - #171 itself reports `totalCount: 2` with both blockers closed. So "unblocked" has to be counted from the nodes' `state`, and a reading that trusted the count would work on tickets that never had a blocker and quietly ignore every ticket that ever did. The check pins the distinction with two fixtures identical in `totalCount` and different in state.
+
+**The denylist re-check reads prose, because prose is all there is before a line of code exists.** It matches the three denied paths against the ticket's title and body, and is deliberately biased towards rejecting: a ticket that merely mentions `secrets/` is refused along with one that means to edit it. A false rejection costs one ticket being worked by a human; a false accept is how a workflow edit reaches a branch that runs with the repository's secrets before anybody reads the PR. The consequence worth knowing: this file, `docs/agents/afk-eligibility.md` and ADR 0004 all name the denied paths, so a ticket about the AFK pipeline's own documentation will usually be refused by its own runner.
+
+That also means this check is *not* the `ci.yml` matrix exception. That one is diff-shaped, cannot be judged from a ticket body at all, and stays where afk-eligibility.md puts it - a pre-push gate, owned by item 7 (#174). The `enable` option's description says so at the switch, where somebody deciding to flip it will read it.
+
+**A rejected ticket is skipped, not relabelled.** Telling the tracker about it is the stuck path (item 8), and a rejection that stopped the poll would let one ineligible ticket block every eligible one behind it. Until item 8 lands, a denylisted ticket is re-read and re-skipped on every poll, which is cheap and silent.
+
+**Concurrency 1 needed a second half after all.** Item 4 recorded that systemd enforces it, and that is true of two *live* runs - but says nothing about a run that died: the runtime ceiling, or the kill switch, leaves a worktree on disk and the next poll would happily claim a second ticket beside it. So the runner refuses to start when `worktrees/` is non-empty, and refuses loudly - a red unit every quarter hour, on the grounds that a wedged pipeline should be noisy rather than quiet. Item 8 is what makes it self-clearing; until then the leftover is removed by hand.
+
+**Worktrees are gathered under one directory** rather than dropped beside the checkout as siblings, which is the one departure from `AGENTS.md`'s `../repo-<task-slug>`. The sibling form is for a human's interactive tree; here both the in-flight guard above and item 8's clean-up need to enumerate what is in flight, and a directory they own is how they do that. The branch is cut from `origin/master`, never from whatever the checkout is sitting on, so a tree an earlier run left dirty cannot leak into the next ticket's diff.
+
+**Found by running it, not by reading it: `git worktree add -b <branch> <path> origin/master` sets the new branch's upstream to `origin/master`.** With git's default `push.default` of `simple`, item 7's push would then aim at `master` rather than at the ticket branch. `protect-main` would refuse it, so the failure would have been loud rather than dangerous - but a runner whose push target is correct only because a branch protection rule holds is the wrong shape, so the worktree is cut `--no-track` and the harness asserts the branch has no upstream. Nothing before the push would have noticed.
+
+**An issue title becomes a git ref and a directory name**, so the slug is validated against `^[0-9]+(-[a-z0-9]+)*$` rather than trusted - checked against what is allowed, not against a list of what is not.
+
+**One assertion is about an absence**, and it is the only thing enforcing ADR 0004 §9: the harness greps the runner's whole command surface for `gh pr merge` and for `--auto`. Item 3 established that no GitHub ruleset can carry that decision here - ADR 0004 §4 rules out a second account, so an AFK PR is authored by the person who would approve it, and GitHub does not let an author approve their own PR.
+
+**A second assertion is about drift.** ADR 0004 §5 asks for the denylist twice, and two readings only stay independent while they agree, so the harness compares the runner's own array against rule 1's list in `docs/agents/afk-eligibility.md`. A path added or dropped on one side fails the build rather than silently un-enforcing a control.
+
+**Found in review, and worth recording because reading the code did not show it: `gh issue list` returns newest first.** The query took the first 100 and sorted them ascending, which is oldest-first only while the whole backlog fits in one page - and past that it is precisely the oldest tickets that fall off the end, so the ticket at the front of the queue would have become permanently unreachable at exactly the point a backlog got long enough to matter. Fixed by asking the API for the order (`--search "sort:created-asc"`) rather than sorting the page it chose to send; the local `sort_by` stays, so the ordering holds whatever the API does. The harness now reads the query back out of the mock's log, because a mock that answers whatever it is asked cannot otherwise tell you the runner stopped asking for the label at all.
+
+**The pre-claim check's reach is now pinned by a fixture rather than left implicit.** A ticket that plainly means to edit `ci.yml` but never writes the path - "add a job to the CI matrix" - is claimed, because matching prose is all that is possible before a diff exists. The case asserts that outcome and says in place that it records a limit rather than blessing a bug: if a later change makes it rejected, that expectation is what will say so.
+
+**Nothing here gives a claim back.** Past `gh issue edit`, a failure - an unsafe slug, a clone that fails, a branch that already exists - leaves the ticket assigned, and the assignment is also what filters it out of every later poll. So a failure after the claim is a ticket that quietly leaves the queue. That is item 8's job and is the main reason this half is not enough to switch the service on by itself; it is said at the claim in the runner as well as here.
+
+**Also from review, and fixed rather than argued: `cg.service.afk-agent.repository` was an option nobody set.** One fleet, one value, no consumer - an option like that is a claim about configurability the repository does not honour, so it is a plain binding now.
+
+Proven against deliberate breaks, the way every check here has been: trusting `blockedBy.totalCount`, removing the denylist re-check, moving the claim after the worktree, dropping the in-flight guard, adding a path to the runner that the document lacks, and letting `slugify` stop sanitising. Each failed the harness with a message naming what broke.
+
+**Run by hand against the live tracker, unstubbed, on #171 itself** - the candidate list narrowed to that one ticket so the run could not claim something nobody had chosen, every `gh` call real. It claimed #171, cloned, and cut `afk/171-afk-agent-poll-claim-and-isolate-a-ticket` with a clean tree and no upstream. Then the two halves of "never double-processed": a second poll with the worktree still on disk refused and said why, and a third with the worktree cleared found nothing, because the assignee it had written was now filtering it out. An earlier dry run - real reads, the one write intercepted - went the whole way on the unnarrowed tracker and picked #156, the oldest eligible ticket.
+
+**The sandbox has now met `git` and `gh` for real** - the VM check's run reaches its first `gh issue list` and fails there for want of a network, which is the expected result and is what that assertion now pins. `SystemCallFilter = [ "@system-service" ]` has still never seen an `opencode run`; #172 is where it first does.
+
 ### Done when
 
 A real `ready-for-agent` ticket, run through this loop by hand once, ends with a commit on an `afk/*` branch in an isolated worktree, with the source issue correctly claimed and never double-processed on a second poll.
@@ -748,6 +786,8 @@ This is the step `implement` never does today - nothing currently pushes or open
 ### Approach
 
 Push the `afk/*` branch and open the PR with `AFK_AGENT_TOKEN` (item 3), `afk-agent` labelled, body linking back to the source issue. No auto-merge (ADR 0004 §9) - it lands exactly like any other PR, waiting on human review.
+
+**This item owns the pre-push denylist gate**, and it is the last moment anything can. `docs/agents/afk-eligibility.md` sketches the diff check for the `ci.yml` matrix exception and says why it cannot wait: the push becomes a PR, and a `pull_request` event runs the workflow file *from the head branch* with the repository's secrets before a human reads it. Item 5's pre-claim check does not cover this - it reads ticket prose, and whether a diff is additions-only to the matrix is a question about a diff that did not exist at claim time. `AFK_AGENT_TOKEN` carries the Workflows permission (item 3) precisely so the exception can be exercised, so nothing at GitHub's end refuses the push either. Run it against `git diff` before the push, and refuse the push rather than the PR.
 
 ### Testing
 

--- a/modules/services/afk-agent.nix
+++ b/modules/services/afk-agent.nix
@@ -1,33 +1,37 @@
 # The AFK agent: an unattended runner for `ready-for-agent` tickets.
 #
-# Item 4 of docs/plans/afk-agent-pipeline.md, implementing ADR 0004 §1, §3
-# and §7: the pipeline runs on homelab01, it is triggered by a polling systemd
-# timer rather than a webhook, and it is a real NixOS module so that turning it
-# off in an emergency is one boolean rather than remembering which script to
-# kill. `cg.service.afk-agent.enable = false` removes the timer, the unit and
-# the service account, which is what checks/afk-agent.nix pins.
+# Items 4 and 5 of docs/plans/afk-agent-pipeline.md, implementing ADR 0004 §1,
+# §3, §5, §7 and §8: the pipeline runs on homelab01, it is triggered by a
+# polling systemd timer rather than a webhook, eligibility is re-checked
+# against the path denylist rather than trusted from the label, and the whole
+# thing is a real NixOS module so that turning it off in an emergency is one
+# boolean rather than remembering which script to kill.
+# `cg.service.afk-agent.enable = false` removes the timer, the unit and the
+# service account, which is what checks/afk-agent.nix pins.
 #
-# WHAT THIS MODULE OWNS, AND WHAT IT DOES NOT. This is the unit around the
-# runner, not the runner. The poll -> claim -> worktree -> implement loop is
-# item 5 and is deliberately a separate piece of work: it is script logic
-# driving `gh` and `opencode`, neither of which can run inside the Nix build
-# sandbox, so it gets a script-level test harness rather than a VM test. What
-# is settled here is everything that surrounds it - the schedule, the runtime
-# ceiling, the service account, the credentials, the sandbox, and the toolchain
-# on its PATH - so that item 5 writes logic against plumbing that is already
-# proven rather than plumbing and logic at once.
+# WHAT THIS MODULE OWNS, AND HOW FAR THE RUNNER GETS. Item 4 settled everything
+# around the runner - the schedule, the runtime ceiling, the service account,
+# the credentials, the sandbox, and the toolchain on its PATH. The runner
+# itself is item 5, and lands in pieces: this file currently carries the
+# poll -> denylist -> claim -> isolate half (#171). It stops with a ticket
+# claimed and an empty worktree on an `afk/*` branch, and says so. The implement
+# stage (#172), the review stage (#173), the push and PR (#174) and the stuck
+# path that cleans up after a failure (#175) each extend the same script.
 #
-# Until item 5 lands, ExecStart is a placeholder that checks that plumbing and
-# then exits non-zero. That is on purpose: a host that switches this on early
-# should get a red unit saying why, not a green one that silently does
-# nothing. There is a real ordering constraint behind it - see the `enable`
-# option's description.
+# The script is written so that its whole state is relocatable through the
+# environment, which is how checks/afk-agent-runner.nix drives this exact
+# script - never a copy - against a fixture origin repository and a mocked
+# `gh`. It follows download-root-canary.nix, which does the same for the same
+# reason: neither script's real behaviour is reachable from a VM test.
 #
 # CONCURRENCY IS ONE, and it is systemd that enforces it rather than anything
 # in the runner: a single non-templated unit cannot have two live instances, so
 # a poll that fires while a ticket is still being worked cannot start a second
 # one. ADR 0004 §8 fixes the principle; raising it later means templating this
-# unit, which is a deliberate act rather than an oversight.
+# unit, which is a deliberate act rather than an oversight. The runner adds one
+# thing systemd cannot: a guard against a *dead* run's leftovers, since a unit
+# that was killed mid-ticket leaves a worktree behind and systemd would happily
+# start the next poll on top of it.
 {
   config,
   lib,
@@ -38,6 +42,14 @@ let
   cfg = config.cg.service.afk-agent;
 
   stateDir = "/var/lib/afk-agent";
+
+  # The `owner/name` this runner polls, claims from, and clones. One value
+  # rather than two, because `gh` and `git` need the same answer and a runner
+  # pointed at one repository's tracker while working another's checkout would
+  # be a confusing way to find that out. Not an option: there is one fleet
+  # here and one value, and an option nobody sets is a claim about
+  # configurability the repository does not honour.
+  repository = "corygyarmathy/dotfiles";
 
   # The credentials this unit runs on: the name systemd exposes them under in
   # $CREDENTIALS_DIRECTORY, mapped to the sops key each one is read from.
@@ -63,23 +75,71 @@ let
     nix = config.nix.package;
   };
 
-  # The stand-in for item 5's runner.
+  # Rule 1 of docs/agents/afk-eligibility.md, held here as the runner's own
+  # copy so that ADR 0004 §5's "enforced twice" is two independent readings
+  # rather than one list consulted twice. checks/afk-agent-runner.nix asserts
+  # this list and the document's still agree, because a denylist that has
+  # quietly drifted from the document it implements is a control that has
+  # stopped controlling anything without anybody noticing.
   #
-  # Named `preflight` rather than `poll` because it polls nothing: it asserts
-  # the two things this module is responsible for handing over - the
-  # credentials and the toolchain - and names each one it found, so
-  # checks/afk-agent.nix can assert the wiring from the outside without a
-  # runner existing. The name is what `systemctl cat afk-agent` shows, so it
-  # should say what is actually there.
-  #
-  # It prints names only, never values: this unit reads a PAT that can push to
-  # this repository, and the system journal is not a place to put it.
-  #
-  # Item 5 replaces this with the real loop and updates that check with it.
-  preflight = pkgs.writeShellApplication {
-    name = "afk-agent-preflight";
+  # Matched against the ticket's *prose* - its title and body - which is all
+  # there is to read before a line of code has been written. That is a blunt
+  # instrument, and deliberately biased: a ticket that merely mentions
+  # `secrets/` in passing is rejected along with one that means to edit it.
+  # A false rejection costs one ticket being worked by a human; a false accept
+  # costs a workflow edit that runs with the repository's secrets before
+  # anybody reads the PR (see afk-eligibility.md, "Why these three"). The
+  # diff-shaped half of the denylist - including the narrow `ci.yml` matrix
+  # exception, which cannot be judged from prose at all - is a pre-push gate
+  # and belongs to item 7 (#174).
+  deniedPaths = [
+    ".github/workflows/"
+    "secrets/"
+    ".sops.yaml"
+  ];
+
+  runner = pkgs.writeShellApplication {
+    name = "afk-agent-run";
+
+    # Deliberately only coreutils. The tools the runner drives arrive from the
+    # unit's PATH (see `path` below) rather than being baked in here, so that
+    # the check can substitute a mocked `gh` for the real one - a runtimeInput
+    # would be prepended to PATH and shadow it. `require_tool` below is what
+    # turns that looser coupling into something that still fails loudly.
     runtimeInputs = [ pkgs.coreutils ];
+
     text = ''
+      # Everything the runner keeps outside its own process is relocatable, so
+      # that the check can point it at a scratch directory and a fixture origin
+      # repository. Nothing else is overridable: the label, the branch prefix
+      # and the denylist are the behaviour under test, not the fixture around
+      # it.
+      state_dir="''${AFK_STATE_DIR:-${stateDir}}"
+      repo="${repository}"
+      repo_url="''${AFK_REPO_URL:-https://github.com/${repository}.git}"
+
+      label="ready-for-agent"
+      base_branch="master"
+      branch_prefix="afk/"
+
+      checkout="$state_dir/checkout"
+      worktrees="$state_dir/worktrees"
+
+      denied=(
+        ${lib.concatMapStringsSep "\n        " (p: ''"${p}"'') deniedPaths}
+      )
+
+      log() { echo "afk-agent: $*"; }
+      die() { echo "afk-agent: $*" >&2; exit 1; }
+
+      # --- what item 4 hands over ------------------------------------------
+      #
+      # Asserted before anything is polled or claimed, so that a missing
+      # credential or a tool that fell off the unit's PATH fails on an empty
+      # tracker rather than halfway through a claimed ticket. Names only, never
+      # values: this unit reads a PAT that can push to this repository, and the
+      # system journal is not a place to put it.
+
       creds="''${CREDENTIALS_DIRECTORY:?systemd passed no credentials directory}"
 
       require_credential() {
@@ -98,13 +158,175 @@ let
         echo "afk-agent: tool '$1' present"
       }
 
-      ${lib.concatMapStringsSep "\n" (name: "require_credential ${name}") (lib.attrNames credentials)}
+      ${lib.concatMapStringsSep "\n      " (name: "require_credential ${name}") (
+        lib.attrNames credentials
+      )}
 
-      ${lib.concatMapStringsSep "\n" (name: "require_tool ${name}") (lib.attrNames toolchain)}
+      ${lib.concatMapStringsSep "\n      " (name: "require_tool ${name}") (lib.attrNames toolchain)}
 
-      echo "afk-agent: runner not implemented yet - this is the item 4 scaffold." >&2
-      echo "afk-agent: see docs/plans/afk-agent-pipeline.md, item 5." >&2
-      exit 1
+      export GH_TOKEN
+      GH_TOKEN="$(cat "$creds/github-token")"
+      export GH_PROMPT_DISABLED=1
+      export GH_NO_UPDATE_NOTIFIER=1
+
+      # --- one ticket at a time --------------------------------------------
+      #
+      # systemd already makes two live runs impossible (see the module header),
+      # but it has nothing to say about a run that died: a unit killed by the
+      # runtime ceiling, or by the kill switch, leaves its worktree behind, and
+      # the next poll would otherwise claim a second ticket beside the wreckage
+      # of the first. Refusing to start is the conservative half of that; the
+      # other half - deciding whether to resume or to tear it down - is the
+      # stuck path, item 8 (#175). Until that exists this goes red on every poll, which
+      # is the intended noise: a wedged pipeline should be loud, not quiet.
+      mkdir -p "$worktrees"
+      leftover="$(find "$worktrees" -mindepth 1 -maxdepth 1 -print -quit)"
+      if [ -n "$leftover" ]; then
+        die "a worktree from an earlier run is still here ($leftover); a run died mid-ticket. Clean-up is item 8 (#175); until then, remove it by hand"
+      fi
+
+      # --- poll -------------------------------------------------------------
+      #
+      # Unassigned, because the assignee *is* the claim (docs/agents/issue-tracker.md)
+      # and so also the lock that stops a ticket being worked twice - by this
+      # runner on a later poll, or by a human right now.
+      #
+      # Unblocked has a trap in it worth naming: `blockedBy.totalCount` counts
+      # every dependency edge, closed ones included, so it is not the gate it
+      # looks like. The open ones have to be counted from the nodes.
+      #
+      # `sort:created-asc` is doing real work, and is not the same thing as the
+      # `sort_by` below. `gh issue list` returns newest first, so past the
+      # limit it is the *oldest* tickets that fall off the end - and this
+      # claims the oldest survivor, so without it the ticket at the front of
+      # the queue would become permanently unreachable at exactly the point a
+      # backlog got long enough to matter. The search decides which hundred
+      # come back; the `sort_by` decides the order among them, and is kept so
+      # the ordering holds whatever the API does.
+      log "polling $repo for unassigned, unblocked '$label' issues"
+
+      candidates="$(
+        gh issue list \
+          --repo "$repo" \
+          --label "$label" \
+          --state open \
+          --search "sort:created-asc" \
+          --limit 100 \
+          --json number,title,body,assignees,blockedBy \
+          | jq -c '
+              [ .[]
+                | select((.assignees | length) == 0)
+                | select([.blockedBy.nodes[]? | select(.state == "OPEN")] | length == 0)
+              ] | sort_by(.number)
+            '
+      )"
+
+      total="$(jq 'length' <<<"$candidates")"
+      log "$total eligible candidate(s)"
+
+      # --- re-check the denylist, then claim the first survivor -------------
+      #
+      # Oldest first, which is the only ordering the tracker offers that is
+      # stable across polls. A ticket rejected here is skipped rather than
+      # relabelled: telling the tracker about it is the stuck path (#175), and
+      # a rejection that stopped the poll would let one ineligible ticket block
+      # every eligible one behind it.
+      first_denied() {
+        local text=$1 path
+        for path in "''${denied[@]}"; do
+          if printf '%s' "$text" | grep -qiF -- "$path"; then
+            printf '%s' "$path"
+            return 0
+          fi
+        done
+        return 1
+      }
+
+      picked=""
+      index=0
+      while [ "$index" -lt "$total" ]; do
+        candidate="$(jq -c ".[$index]" <<<"$candidates")"
+        index=$((index + 1))
+
+        scope="$(jq -r '.title + "\n" + (.body // "")' <<<"$candidate")"
+
+        if denied_path="$(first_denied "$scope")"; then
+          log "skipping #$(jq -r '.number' <<<"$candidate"): its scope names the denied path '$denied_path' (docs/agents/afk-eligibility.md rule 1)"
+          continue
+        fi
+
+        picked="$candidate"
+        break
+      done
+
+      if [ -z "$picked" ]; then
+        log "nothing to claim this poll"
+        exit 0
+      fi
+
+      number="$(jq -r '.number' <<<"$picked")"
+      title="$(jq -r '.title' <<<"$picked")"
+
+      # Everything past this point has a claimed ticket behind it, and nothing
+      # here gives it back: a failure below leaves #$number assigned, which is
+      # also what filters it out of every later poll. That is the stuck path's
+      # job (#175, plan item 8) and is the main reason this half is not enough
+      # to switch the service on by itself.
+      log "claiming #$number: $title"
+      gh issue edit "$number" --repo "$repo" --add-assignee @me
+
+      # --- isolate ----------------------------------------------------------
+      #
+      # AGENTS.md's worktree-isolation pattern, with the worktrees gathered
+      # under one directory rather than dropped beside the checkout as siblings:
+      # that form exists for a human's interactive tree, and here it is what
+      # both the in-flight guard above and item 8 (#175)'s clean-up need to be able to
+      # enumerate.
+      #
+      # The branch is cut from `origin/$base_branch` rather than from whatever
+      # the checkout happens to be sitting on, so a checkout left dirty or
+      # detached by an earlier run cannot leak into the next ticket's diff.
+      slugify() {
+        printf '%s' "$1" \
+          | tr '[:upper:]' '[:lower:]' \
+          | sed -e 's/[^a-z0-9]\+/-/g' -e 's/^-\+//' -e 's/-\+$//' \
+          | cut -c1-48 \
+          | sed -e 's/-\+$//'
+      }
+
+      slug="$number-$(slugify "$title")"
+
+      # The slug becomes both a git ref and a directory name, and its input is
+      # an issue title. Checked rather than trusted, and checked against what
+      # is allowed rather than against a list of what is not.
+      if ! [[ "$slug" =~ ^[0-9]+(-[a-z0-9]+)*$ ]]; then
+        die "refusing to build a branch name from #$number: '$slug' is not a safe slug"
+      fi
+
+      branch="$branch_prefix$slug"
+      worktree="$worktrees/$slug"
+
+      if [ ! -d "$checkout/.git" ]; then
+        log "cloning $repo_url into $checkout"
+        git clone "$repo_url" "$checkout"
+      fi
+
+      git -C "$checkout" fetch --prune origin
+
+      if git -C "$checkout" show-ref --verify --quiet "refs/heads/$branch"; then
+        die "branch $branch already exists in $checkout; #$number looks half-worked"
+      fi
+
+      # --no-track is not a detail. Without it git sets the new branch's
+      # upstream to origin/master, and item 7 (#174)'s push - with git's default
+      # push.default of `simple` - would then aim at master rather than at the
+      # branch. Protection on master would refuse it, so the failure would be
+      # loud rather than dangerous, but a runner whose push target depends on a
+      # branch protection rule holding is the wrong shape.
+      git -C "$checkout" worktree add --no-track -b "$branch" "$worktree" "origin/$base_branch"
+
+      log "claimed #$number, isolated on $branch at $worktree"
+      log "stopping here: the implement stage is item 5's second half (#172) and is not wired in yet"
     '';
   };
 in
@@ -113,13 +335,14 @@ in
     enable = lib.mkEnableOption ''
       the unattended AFK ticket runner.
 
-      Leave this off until item 5 of docs/plans/afk-agent-pipeline.md has
-      landed its pre-push denylist gate. That is an ordering constraint rather
-      than a preference: `AFK_AGENT_TOKEN` carries the Workflows permission
-      (item 3), so nothing at GitHub's end stops this service pushing a branch
-      that edits `.github/workflows/`, and a pushed branch runs its own
-      workflow with the repository's secrets before anyone reads the PR. The
-      gate has to exist, and has to run before the push, or the denylist in
+      Leave this off until item 7 (#174) has landed its pre-push denylist gate. That is
+      an ordering constraint rather than a preference: `AFK_AGENT_TOKEN`
+      carries the Workflows permission (item 3), so nothing at GitHub's end
+      stops this service pushing a branch that edits `.github/workflows/`, and
+      a pushed branch runs its own workflow with the repository's secrets
+      before anyone reads the PR. The pre-claim denylist below is a scope check
+      on ticket prose and does not replace it: the gate has to run against the
+      diff, before the push, or the `ci.yml` exception in
       docs/agents/afk-eligibility.md is enforced by nothing
     '';
 
@@ -207,7 +430,7 @@ in
           alias: name: "${alias}:${config.sops.secrets.${name}.path}"
         ) credentials;
 
-        ExecStart = lib.getExe preflight;
+        ExecStart = lib.getExe runner;
 
         # Hardening, bounded by what the job actually is. This unit exists to
         # run a coding agent: it needs the network, it needs to write a
@@ -215,10 +438,10 @@ in
         # services here get is not available, so what is left is the subset
         # that costs nothing.
         #
-        # Proven against the placeholder below, not against a real run. The
-        # syscall filter in particular has only ever seen a shell script; item
-        # 5 is where a full `opencode run` first meets it, and loosening a line
-        # here is a legitimate outcome of that.
+        # Proven against the poll/claim/isolate half, not against a full run.
+        # The syscall filter in particular has still never seen an `opencode
+        # run`; #172 is where it first does, and loosening a line here is a
+        # legitimate outcome of that.
         NoNewPrivileges = true;
         ProtectSystem = "full";
         PrivateTmp = true;


### PR DESCRIPTION
Closes #171. The first half of plan item 5: item 4's placeholder `ExecStart` becomes a real loop that finds an eligible ticket, re-checks the path denylist against its described scope, claims it by assignee, and cuts an isolated worktree on an `afk/*` branch. It stops there and says so — the implement stage is #172.

`cg.service.afk-agent.enable` stays `false` on homelab01. It should, until item 7 (#174) lands the pre-push diff gate; the `enable` description says why at the switch.

## Two things running it showed that reading it did not

**`blockedBy.totalCount` counts closed dependency edges.** #171 itself reports `totalCount: 2` with both blockers closed, so the count is not the gate it looks like — "unblocked" is counted from the nodes' `state`. A reading that trusted the count would have worked on tickets that never had a blocker and quietly ignored every ticket that ever did. Two fixtures identical in `totalCount` and different in state pin it.

**`git worktree add -b <branch> <path> origin/master` sets the branch's upstream to `origin/master`.** Under git's default `push.default`, item 7's push would then have aimed at master. `protect-main` would have refused it, so the failure would have been loud rather than dangerous — but a runner whose push target is correct only because a branch protection rule holds is the wrong shape. Cut `--no-track` now, with an assertion pinning it.

## Testing

`checks/afk-agent-runner.nix` is a script-level harness rather than a VM test, because the runner talks to the GitHub API and clones a repository and the sandbox has neither. `gh` is mocked and `origin` is a fixture repository, but `git` is real — the branch and worktree it asserts are genuine objects, not a recorded intention. It follows `checks/download-root-canary-script.nix`, and takes the script from the module's own evaluated `ExecStart` rather than a copy.

Twelve cases, proven against nine deliberate breaks: trusting `totalCount`, removing the denylist re-check, claiming after the worktree, dropping the in-flight guard, drifting the denylist from the document it implements, un-sanitising the slug, dropping `--no-track`, dropping `--label`, and dropping the oldest-first sort. Each failed with a message naming what broke.

Two assertions are about absences. One greps the runner's whole command surface for `gh pr merge` and `--auto`: ADR 0004 §9 is enforced by nothing else, since item 3 established that no ruleset can carry it here. The other compares the runner's denylist against rule 1's list in `docs/agents/afk-eligibility.md`, because ADR 0004 §5 asks for the check twice and two readings only stay independent while they agree.

`checks/afk-agent.nix` keeps proving the plumbing around the runner and now asserts the run reaches the poll — it fails there for want of a network, which is the expected result in a sandbox.

Run by hand against the live tracker, unstubbed, on #171 itself (candidate list narrowed to that one ticket so it could not claim something nobody had chosen). It claimed #171, cloned, and cut `afk/171-afk-agent-poll-claim-and-isolate-a-ticket` clean with no upstream. A second poll with the worktree still present refused; a third with it cleared found nothing, because the assignee it had written was doing the filtering.

## From review

- The poll now asks the API for oldest-first. `gh issue list` returns newest first, so past `--limit` it is the oldest tickets that fall off the end — and this claims the oldest survivor, so the front of the queue would have become unreachable exactly when a backlog got long enough to matter.
- The harness reads the query back out of the mock's log. A mock that answers whatever it is asked cannot otherwise notice the runner has stopped filtering by label at all — dropping `--label` passed the entire suite before this.
- A fixture pins how far the prose-level denylist reaches, rather than leaving it implicit: a ticket that plainly means to edit `ci.yml` but never writes the path is claimed. That is the limit of matching prose before a diff exists, and it is recorded rather than blessed.
- `docs/agents/afk-eligibility.md` and plan item 7 now agree on who owns the pre-push diff gate. The doc still said item 5 while this change moved it to item 7, which left the only control on the `ci.yml` exception owned by nobody in writing.

## Known gap, and it belongs to #175

Past `gh issue edit`, nothing gives a claim back. A failure after that point — an unsafe slug, a failed clone, a branch that already exists — leaves the ticket assigned, and the assignment is also what filters it out of every later poll, so the ticket quietly leaves the queue. That is item 8's job, and it is the main reason this half is not enough to switch the service on by itself. Said at the claim in the runner as well as in the plan.