### PR TITLE
fix(afk-agent): give the model a shell that will run a command

### DIFF
--- a/checks/afk-agent.nix
+++ b/checks/afk-agent.nix
@@ -157,6 +157,40 @@
             f"the run never reached the poll:\n{journal}"
         )
 
+    with subtest("the model gets a shell that will run a command"):
+        # This is here because its absence cost a live run. opencode spawns
+        # `$SHELL` for every bash call the model makes; systemd fills `$SHELL`
+        # in from the service account's passwd entry unless the unit says
+        # otherwise; and an `isSystemUser` account's passwd shell is `nologin`.
+        # So the first real ticket claimed, cloned and isolated, and then every
+        # command the agent ran answered "This account is currently not
+        # available." - while the runner's own `gh` and `git` calls, which
+        # never go through a shell, worked throughout.
+        #
+        # Two assertions rather than one, because they fail differently. The
+        # unit's own `$SHELL` is the fix; `require_shell` firing in the journal
+        # is what makes a future regression fail on an empty poll rather than
+        # on a ticket that has already been claimed.
+        shell = enabled.succeed(
+            "systemctl show -p Environment --value afk-agent.service"
+            " | tr ' ' '\n' | sed -n 's/^SHELL=//p'"
+        ).strip()
+        assert shell, "the unit sets no SHELL, so opencode inherits the account's nologin"
+        enabled.succeed(f"test -x {shell}")
+        enabled.succeed(f"{shell} -c 'exit 0'")
+
+        assert f"shell '{shell}' runs commands" in journal, (
+            f"the preflight did not check the shell, so a nologin would reach a claimed ticket:\n{journal}"
+        )
+
+        # And the account itself is still not one anybody can log into. The
+        # shell is a property of the unit, not a login shell handed to a system
+        # account that has no other use for one.
+        passwd_shell = enabled.succeed("getent passwd afk-agent | cut -d: -f7").strip()
+        assert "nologin" in passwd_shell, (
+            f"the fix gave the service account a login shell instead: {passwd_shell}"
+        )
+
     with subtest("no credential value reaches the journal"):
         # The unit reads four secrets on every poll. A debug echo left behind
         # in the runner would put a repo-write App key into the system journal,

--- a/modules/services/afk-agent.nix
+++ b/modules/services/afk-agent.nix
@@ -188,6 +188,18 @@ let
     # not have caught it: the build sandbox has stdenv's `diff` on PATH.
     diff = pkgs.diffutils;
     nix = config.nix.package;
+    # Not a tool the runner drives - a tool the *model* drives, through
+    # opencode's bash tool, and the reason it is pinned here is that leaving it
+    # implicit cost a live run. opencode spawns `$SHELL` for every bash call it
+    # makes; systemd sets `$SHELL` from the service account's passwd entry; and
+    # `isSystemUser` accounts get `nologin`. So every command the model ran came
+    # back "This account is currently not available." while the runner's own
+    # `gh` and `git` calls, which never go through a shell, worked perfectly -
+    # a ticket that claims, clones and isolates and then cannot read a file.
+    # `environment.SHELL` below points at this, so the account keeps `nologin`
+    # and stays unloginnable; the shell is a property of the unit, not of the
+    # user.
+    bash = pkgs.bashInteractive;
   };
 
   # Rule 1 of docs/agents/afk-eligibility.md, held here as the runner's own
@@ -1163,6 +1175,32 @@ let
       )}
 
       ${lib.concatMapStringsSep "\n      " (name: "require_tool ${name}") (lib.attrNames toolchain)}
+
+      # A shell that will actually run a command, which is not the same
+      # question as `bash` being on the PATH above and is why this is asked
+      # separately. opencode spawns `$SHELL` for every bash call the model
+      # makes, so a `$SHELL` that refuses leaves the model unable to read a
+      # file, run a test or make a commit - while every `gh` and `git` call
+      # this script makes itself keeps working, because none of them go
+      # through a shell. That asymmetry is what made it expensive to find: the
+      # run claims a ticket, clones, cuts a worktree, and only then discovers
+      # that the agent inside it can do nothing.
+      #
+      # Executable is not enough to test: `nologin` is executable, and exits 1
+      # with a message. So run something through it.
+      require_shell() {
+        if [ -z "''${SHELL:-}" ]; then
+          echo "afk-agent: SHELL is unset; opencode's bash tool has no shell to spawn" >&2
+          exit 1
+        fi
+        if ! "$SHELL" -c 'exit 0' >/dev/null 2>&1; then
+          echo "afk-agent: SHELL is '$SHELL', which will not run a command - opencode's bash tool cannot work through it" >&2
+          exit 1
+        fi
+        echo "afk-agent: shell '$SHELL' runs commands"
+      }
+
+      require_shell
 
       # --- the credential, which expires part-way through a run -------------
       #
@@ -2671,6 +2709,15 @@ in
       # it from the account's passwd entry, which is the same directory - but
       # only by coincidence, and only until someone changes one of them.
       environment.HOME = stateDir;
+
+      # opencode spawns `$SHELL` for every bash call the model makes. Left
+      # unset, systemd fills it in from the service account's passwd entry,
+      # which is `nologin` for an `isSystemUser` account - so this is set here
+      # rather than by giving the account a login shell it has no other use
+      # for. See `toolchain.bash`, and `require_shell` in the preflight, which
+      # is what turns getting this wrong into a failed empty poll rather than a
+      # ticket claimed and then abandoned.
+      environment.SHELL = lib.getExe toolchain.bash;
 
       serviceConfig = {
         Type = "oneshot";


### PR DESCRIPTION
Found by the first live run, which #222 enabled. It claimed #156, cloned, cut a worktree, opened an implement session — and then every command the agent ran answered:

```
$ gh issue view 156
This account is currently not available.
```

## Cause

opencode spawns `$SHELL` for every bash call the model makes. systemd fills `$SHELL` in from the service account's passwd entry unless the unit says otherwise, and an `isSystemUser` account's passwd shell is `nologin`.

So the agent could not read a file, run a test or make a commit — while every `gh` and `git` call the runner makes *itself* worked throughout, because none of them go through a shell. That asymmetry is what made it expensive to find: nothing is wrong until a ticket has already been claimed and isolated.

**Confirmed rather than inferred.** Running opencode as a user whose passwd shell *is* bash, with `SHELL` pointed at nologin, reproduces the message exactly — so `$SHELL` is what decides this, not the passwd entry. That is also why the fix is the one below rather than a login shell on the account.

## Fix

- `environment.SHELL` on the unit, not `users.users.afk-agent.shell`. The shell is a property of the unit; the account keeps `nologin` and stays unloginnable.
- `pkgs.bashInteractive` joins `toolchain` — the module's one list for what the unit's PATH carries and what the preflight asserts — with a comment saying it is the *model's* shell, not a tool the runner drives.
- `require_shell` joins the preflight. This belongs beside the credential and tool assertions that already exist so a missing input "fails on an empty tracker rather than halfway through a claimed ticket", which is precisely what this failed to do. Executable is not a sufficient test — `nologin` is executable and exits 1 with a message — so it runs a command through it.

## Test

`checks/afk-agent.nix` gains a subtest that pins the unit's `$SHELL` is set, is executable, runs a command, and is reported by the preflight; plus that the account's passwd shell is still `nologin`, so the fix cannot later regress into handing a system account a login shell. Verified it asserts rather than passes vacuously — the run's journal now carries `afk-agent: shell '…/bash-interactive-5.3p15/bin/bash' runs commands`.

`checks.afk-agent` and `checks.afk-agent-runner` both green.

## Please merge before 04:07 AWST

`deploy` is on `0a45ac4`, which has the bug. homelab01 is currently running a hand-deployed build, but tonight's `nixos-upgrade` would replace it with `0a45ac4` **and re-arm the timer** — which would then work through the eligible tickets marking each one `agent-stuck` in turn.