### PR TITLE
fix(afk-agent): bound the run's memory, and build the checks one at a time

### DIFF
--- a/checks/afk-agent-runner.nix
+++ b/checks/afk-agent-runner.nix
@@ -1071,7 +1071,17 @@ pkgs.runCommand "check-afk-agent-runner"
     # for it. Each of these is a CI job that would otherwise go red on a branch
     # this stage had already called finished.
     grep -q -- "nix fmt -- --ci" "$state/nix.log" || fail "the gate does not check formatting"
-    grep -q -- "nix flake check" "$state/nix.log" || fail "the gate does not run the checks"
+    # One `nix build` per check rather than one `nix flake check`, which is
+    # what CI's own `checks` matrix does and, since 2026-09-10, what this gate
+    # does too: `nix flake check` evaluates every output of this flake in one
+    # process and reached 8.3 GB on homelab01, taking the run with it. Asserted
+    # as "built at least one check, and did not reach for the single-process
+    # form" - the exact set is the `diff` against ci.yml's matrix two lines
+    # above, which is a stronger statement than a list repeated here.
+    grep -q -- "nix build --no-link .#checks" "$state/nix.log" \
+      || fail "the gate does not build the flake's checks"
+    ! grep -q -- "nix flake check" "$state/nix.log" \
+      || fail "the gate ran 'nix flake check', which is what exhausted the host on 2026-09-10"
     grep -q "nixosConfigurations.fixturehost.config.system.build.toplevel" "$state/nix.log" \
       || fail "the gate did not build the hosts it discovered: $(cat "$state/nix.log")"
     # The one gate `nix flake check` cannot see: a check added under checks/
@@ -1226,7 +1236,15 @@ pkgs.runCommand "check-afk-agent-runner"
     [ "$rc" -ne 0 ] || fail "a gate that built no hosts was treated as a pass"
     [ "$(attempts)" -eq 3 ] || fail "expected the budget to run out, got $(attempts) attempt(s)"
     grep -q "the gate failed" "$state/out.log" || fail "the empty host list was not reported as a gate failure"
-    if grep -q "nix build" "$state/nix.log"; then fail "something was built from an empty host list"; fi
+    # Narrowed to *host* builds on 2026-09-10, when the gate stopped running
+    # one `nix flake check` and started building each check with its own `nix
+    # build`. Those run before host discovery, so a bare "nix build" search
+    # now finds them and reads a working gate as a broken one. The property
+    # this case exists for is unchanged and still asserted: an empty host list
+    # fails the gate, and no host was built from it.
+    if grep -q -- "nix build --no-link .#nixosConfigurations" "$state/nix.log"; then
+      fail "something was built from an empty host list"
+    fi
 
     echo "case: the session is opened with the verbs it must not use denied"
     # Read back from what the mock actually received, rather than grepped out of

--- a/checks/afk-agent.nix
+++ b/checks/afk-agent.nix
@@ -191,6 +191,38 @@
             f"the fix gave the service account a login shell instead: {passwd_shell}"
         )
 
+    with subtest("a run cannot exhaust the host's memory"):
+        # 2026-09-10: a run reached 8.3 GB in one `nix` process and the kernel
+        # OOM killer fired globally - `CONSTRAINT_NONE`, the whole machine
+        # rather than this cgroup. It picked this unit because it was biggest;
+        # it could have picked any service on the host. The ceiling is what
+        # makes that a contained failure, and the ticket then ends on the stuck
+        # path like any other dead run.
+        limit = enabled.succeed(
+            "systemctl show -p MemoryMax --value afk-agent.service"
+        ).strip()
+        assert limit not in ("", "infinity"), (
+            f"the unit has no memory ceiling, so a run can still take the host down: {limit}"
+        )
+
+        # And the gate does not put it straight back over. `nix flake check`
+        # evaluates every output of this flake in one process, which is what
+        # overran; the gate builds each check separately, the way ci.yml's
+        # matrix does.
+        #
+        # Matched on the invocation rather than on the phrase. The prompt in
+        # this same script names `nix flake check` on purpose - it is what
+        # tells the model not to run one - so a bare substring search reads
+        # the warning as the offence, which is exactly what it did when this
+        # subtest was first written.
+        body = enabled.succeed(f"cat {script}")
+        assert "step nix flake check" not in body, (
+            "the gate runs `nix flake check` again, which is what exhausted the host"
+        )
+        assert 'nix build --no-link ".#checks.' in body, (
+            "the gate no longer builds the checks one at a time"
+        )
+
     with subtest("no credential value reaches the journal"):
         # The unit reads four secrets on every poll. A debug echo left behind
         # in the runner would put a repo-write App key into the system journal,

--- a/modules/services/afk-agent.nix
+++ b/modules/services/afk-agent.nix
@@ -469,10 +469,17 @@ let
       not exist: the next stage pushes commits, and nothing else.
 
     The gate your work has to pass is this repository's own: `nix fmt -- --ci`,
-    `nix flake check`, a build of every host, and agreement between the checks
-    the flake exposes and the matrix in `ci.yml`. `AGENTS.md` is the rest of
-    the house style. You will be told what the gate said and given two further
-    attempts to fix it.
+    a `nix build` of each check the flake exposes, a build of every host, and
+    agreement between the checks the flake exposes and the matrix in `ci.yml`.
+    `AGENTS.md` is the rest of the house style. You will be told what the gate
+    said and given two further attempts to fix it.
+
+    Run the checks one `nix build .#checks.x86_64-linux.<name>` at a time, and
+    do not run `nix flake check`. It evaluates every output of this flake in
+    one process and peaks around 8 GB on this host, which is enough to invoke
+    the kernel's OOM killer and lose your session and your uncommitted work
+    with it. That is measured, on a run that had finished the work and was
+    killed proving it.
 
     Five ways real runs of this pipeline have produced work that looked
     finished and was not. They are measured, not hypothetical:
@@ -696,9 +703,9 @@ let
     Opened unattended by the AFK agent (ADR 0004). The work on `BRANCH` was
     claimed from `ready-for-agent`, implemented by `IMPLEMODEL` across ATTEMPTS
     session(s), and pushed only once this repository's own gate passed on the
-    commit at the head of the branch: `nix fmt -- --ci`, `nix flake check`, a
-    build of every host, and agreement between the checks the flake exposes and
-    the matrix in `ci.yml`. The diff was checked against the path denylist in
+    commit at the head of the branch: `nix fmt -- --ci`, a build of every check
+    the flake exposes, a build of every host, and agreement between the checks
+    the flake exposes and the matrix in `ci.yml`. The diff was checked against the path denylist in
     `docs/agents/afk-eligibility.md` immediately before every push, as well as
     before the claim.
 
@@ -1638,7 +1645,34 @@ let
             | LC_ALL=C sort > "$run_dir/matrix-checks" || exit 1
           step diff -u "$run_dir/flake-checks" "$run_dir/matrix-checks" || exit 1
 
-          step nix flake check || exit 1
+          # Every check the flake exposes, one `nix build` each, rather than
+          # the single `nix flake check` this used to be. Not a style
+          # preference - `nix flake check` evaluates every output in one
+          # process, and on this flake that is three `nixosConfigurations`
+          # plus the NixOS system each VM test builds inside itself, all live
+          # in one evaluator heap at once. Measured, on the run that found it:
+          # 8.3 GB resident in a single `nix`, on a 15 GB host with no swap
+          # that already had ~6 GB of services on it. The kernel's OOM killer
+          # took the unit (`CONSTRAINT_NONE` - the whole machine, not a
+          # cgroup), and with it a ticket that had already implemented itself
+          # and passed its own tests.
+          #
+          # One process per check is what CI has always done - `ci.yml`'s
+          # `checks` job is a matrix, one runner each - so this stops being a
+          # cheaper proxy for CI and starts being the same shape as CI. The
+          # `diff` immediately above is what makes the loop total: it has just
+          # asserted that this list and ci.yml's matrix name the same checks,
+          # so iterating it cannot silently skip one.
+          #
+          # What is lost is `nix flake check`'s own validation of the outputs
+          # around the checks - devShells, formatter, the flake's shape. CI
+          # does not gate on that either, and a gate that disagrees with CI is
+          # the thing this whole function exists not to be.
+          local check
+          while read -r check; do
+            [ -n "$check" ] || continue
+            step nix build --no-link ".#checks.x86_64-linux.$check" || exit 1
+          done < "$run_dir/flake-checks"
 
           local hosts
           hosts="$(step nix eval --raw .#nixosConfigurations \
@@ -2671,6 +2705,44 @@ in
         request untouched too, past the push (ADR 0007).
       '';
     };
+
+    maxMemory = lib.mkOption {
+      type = lib.types.str;
+      default = "6G";
+      example = "4G";
+      description = ''
+        Ceiling on a single run's memory, as `MemoryMax` (systemd.resource-control(5)).
+
+        `maxRuntime` above bounds how long a run may take and nothing bounded
+        how much of the host it may take while doing it. On 2026-09-10 a run
+        that had already implemented its ticket and passed its own tests was
+        killed proving it: `nix flake check` reached 8.3 GB resident on a 15 GB
+        host with no swap, and the kernel's OOM killer fired with
+        `CONSTRAINT_NONE` - a global out-of-memory, not a cgroup one. It chose
+        the biggest process, which happened to be this unit's. It could as
+        easily have chosen Grafana, Prometheus or Jellyfin: an unattended
+        coding agent had become a denial-of-service risk to every other service
+        on the machine.
+
+        This is the containment for that, and the per-check gate above is what
+        makes it comfortable rather than tight. Scope it honestly: a `nix
+        build` hands the work to `nix-daemon.service`, which has a cgroup of
+        its own, so what this actually bounds is the evaluator, opencode, and
+        anything the model runs directly - which is precisely what overran.
+
+        The default leaves roughly 9 GB for everything else on homelab01,
+        whose other services sit at about 6 GB. Reaching it kills inside this
+        cgroup: the run dies, its worktree is left, and the next poll's guard
+        hands the ticket back (item 8) - the same ending as the runtime
+        ceiling, and a far better one than taking the host with it.
+
+        `MemoryHigh` is deliberately not set alongside it. `MemoryHigh`
+        throttles and reclaims before killing, which earns its place when
+        there is swap to reclaim into; homelab01 has none, and the memory in
+        question is a Nix evaluator's anonymous heap. It would buy a stall
+        rather than a survival.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -2728,6 +2800,12 @@ in
         WorkingDirectory = stateDir;
         UMask = "0077";
         TimeoutStartSec = cfg.maxRuntime;
+
+        # See `maxMemory`. The runtime ceiling's counterpart: this unit runs a
+        # coding agent that builds things, and until 2026-09-10 nothing stopped
+        # it exhausting the host's memory and taking unrelated services down
+        # with it.
+        MemoryMax = cfg.maxMemory;
 
         LoadCredential = lib.mapAttrsToList (
           alias: name: "${alias}:${config.sops.secrets.${name}.path}"


### PR DESCRIPTION
The incident behind #196's hand-back. The run had **already done the work** — 1462 insertions across the module and the harness, six new revision-loop cases, all six passing, `nix fmt` clean — and was killed on the last step of the gate.

```
Sep 10 01:37:38 kernel: oom-kill:constraint=CONSTRAINT_NONE, global_oom,
                        task_memcg=/system.slice/afk-agent.service, task=nix, uid=982
Sep 10 01:37:38 kernel: Out of memory: Killed process (nix) anon-rss:8335568kB
Sep 10 01:37:40 systemd[1]: afk-agent.service: Failed with result 'oom-kill'.
                            8.4G memory peak
```

`CONSTRAINT_NONE` is the part that matters: a **global** out-of-memory, not a cgroup one. The kernel picked the largest process and it happened to be this unit's. It could as easily have picked Grafana, Prometheus or Jellyfin — an unattended coding agent had become a denial-of-service risk to every other service on homelab01.

## Two problems, two changes

**The gate no longer runs `nix flake check`.** That command evaluates every output of this flake in one process — three `nixosConfigurations` plus the NixOS system each VM test builds inside itself, all in one evaluator heap. CI has never done this; `ci.yml`'s `checks` job is a 22-entry matrix, one runner each. The gate now iterates the check list it *already computes* for the matrix comparison, one `nix build` per check. The `diff` immediately above the loop is what makes it total — it has just asserted that list and ci.yml's matrix name the same checks.

The prompt is corrected alongside it, and this is the part that actually caused the incident: the process that overran was the **model's own**. The prompt described the gate as `nix flake check`, so the model ran one. It now describes the per-check form and says why not to reach for the other, with the measurement attached.

**A `maxMemory` option wired to `MemoryMax`, defaulting to 6G.** `maxRuntime` bounded how long a run may take; nothing bounded how much of the host it could take while doing it. Scoped honestly in the option description: `nix build` hands the work to `nix-daemon.service` and its own cgroup, so this bounds the evaluator, opencode, and whatever the model runs directly — precisely what overran. Reaching it kills inside this cgroup, so the run dies, its worktree is left, and the next poll's guard hands the ticket back: the same ending as the runtime ceiling.

`MemoryHigh` is deliberately absent — it throttles and reclaims before killing, which earns its place when there is swap to reclaim into. homelab01 has none, and this is an evaluator's anonymous heap, so it would buy a stall rather than a survival.

## Tests

`checks/afk-agent.nix` gains a subtest asserting the unit has a ceiling and the gate does not reach for `nix flake check` again. `checks/afk-agent-runner.nix` asserts the gate builds the checks and does not.

Two existing assertions moved rather than broke, both recorded in comments where they live: the harness's gate assertion now matches the per-check invocation, and the empty-host-list case narrowed to *host* builds, since check builds legitimately run before host discovery now.

Worth noting the first draft of the new subtest failed honestly — it searched the script for the string `nix flake check` and found it in the prompt's own warning against running one. Matching the invocation instead is what it does now.

`checks.afk-agent`, `checks.afk-agent-runner` and the homelab01 toplevel all green.

## Not in this PR

The dead-run guard deleted that 1462-line diff because it was uncommitted and the branch was never pushed. That is a change to a decision the plan records, so it gets its own PR.