### PR TITLE
fix(reverse-proxy): update Caddy plugins hash

### DIFF
--- a/modules/services/reverse-proxy.nix
+++ b/modules/services/reverse-proxy.nix
@@ -67,7 +67,7 @@ let
     ];
     # NOTE: If build fails with hash mismatch, update this value
     # Leave empty ("") on first build to get the correct hash from error output
-    hash = "sha256-5d+U7sdSIUuwj6OK8WutZGsfvshtDj0FKRjkMDNfbxU=";
+    hash = "sha256-pOKH4KP0vbyhxlvMiWmkHoziKXu6O6PKRjPHjflPZuQ=";
   };
 
   # Rate limiting profiles for different service types


### PR DESCRIPTION
CI on master and PR #227 fails in checks reverse-proxy, deploy-activate and deploy-schema with a hash mismatch in caddy-src-with-plugins-2.11.4 (specified sha256-5d+U7sdSIUuwj6OK8WutZGsfvshtDj0FKRjkMDNfbxU=, got sha256-pOKH4KP0vbyhxlvMiWmkHoziKXu6O6PKRjPHjflPZuQ=). The withPlugins builder fetches Go modules at build time, so transitive deps drifted under the pinned nixpkgs (known limitation noted in-file, nixpkgs#450289). No Caddy change in-repo between last green (~16:40 UTC Sep 9) and first red (~18:07 UTC Sep 9).

This updates modules/services/reverse-proxy.nix to the hash CI reports. Verified locally: nix fmt -- --ci clean and nix build .#checks.x86_64-linux.reverse-proxy passes (VM test green).