### PR TITLE
feat(caddy): auto-update plugin pins and vendor hash via package-update

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -26,13 +26,13 @@ The laptop follows `deploy` too, but never switches on its own: it builds in the
 | -------------------- | --------------------------- | ------------------------------------------------------------------ |
 | `ci.yml`             | every PR and push to master | builds all three hosts, runs each check in `checks/` on its own runner, lints, fast-forwards `deploy` |
 | `flake-update.yml`   | daily, 15:00 UTC            | `nix flake update`, per-host closure diff, PR, auto-merge on green |
-| `package-update.yml` | Mondays, 03:00 UTC          | runs each package's own updater, one PR per package                |
+| `package-update.yml` | Mondays, 03:00 UTC          | runs each package's own updater, one PR per package, auto-merged only when the package opts in via `passthru.autoMerge` |
 | `dependabot-auto-merge.yml` | every Dependabot PR  | schedules the merge; `nixos ci` is still the gate                  |
 | `automerge-nudge.yml`       | push to master + 15-min cron | rebases the first stale auto-merge PR on a `deps/*` branch onto `master` |
 
 CI builds are pushed to a [Cachix](https://cachix.org) cache that the hosts substitute from, so a closure is built once rather than once per machine.
 
-Lock updates auto-merge when green. Package updates do not - they cross an upstream release boundary, where "it built" is the weakest form of evidence.
+Lock updates auto-merge when green. Package updates do not by default - they cross an upstream release boundary, where "it built" is the weakest form of evidence. The exception is a package that opts in with `passthru.autoMerge` (currently only `caddy-with-plugins`): its diff is a version string plus a SHA no review can validate, and a stale hash keeps the whole gate red, so holding it for a human buys nothing and the `nixos ci` check remains the gate.
 
 ### Dependabot
 
@@ -97,11 +97,11 @@ Naming the shards rather than discovering them is what keeps that saving: discov
 
 **`deploy` rejects non-fast-forward pushes, with zero bypass actors.** Not even an admin, `GITHUB_TOKEN`, or the deploy key in the next invariant can force-push or delete it. This is deliberate, and it means the recovery below requires temporarily relaxing a ruleset - there is no way around it from the client side.
 
-**`deploy` accepts a push from exactly one identity, and it is not `GITHUB_TOKEN`.** The `restrict-deploy-updates` ruleset puts an `update` rule over `refs/heads/deploy` whose only bypass actor is `ci-promote-deploy`, a write deploy key, so `promote` pushes over SSH with the `PROMOTE_DEPLOY_KEY` secret and every PAT is refused - `FLAKE_UPDATE_TOKEN`, `AFK_AGENT_TOKEN`, and your own, since a fine-grained PAT acts as the repository owner and the owner is not on that list. `GITHUB_TOKEN` could not have been the exception: GitHub refuses the GitHub Actions app as a bypass actor on a **user-owned** repository (`422 Actor GitHub Actions integration must be part of the ruleset source or owner organization`) - the same organization-only shape as merge queues above, and the second time this repo has designed around it. It is a *second* ruleset rather than a rule inside `protect-deploy` because a bypass belongs to the whole ruleset, and the invariant above has to stay true. [ADR 0005](../../docs/adr/0005-only-a-deploy-key-may-move-deploy.md) has the reasoning and the probes that ruled out the alternatives.
+**`deploy` accepts a push from exactly one identity, and it is not `GITHUB_TOKEN`.** The `restrict-deploy-updates` ruleset puts an `update` rule over `refs/heads/deploy` whose only bypass actor is `ci-promote-deploy`, a write deploy key, so `promote` pushes over SSH with the `PROMOTE_DEPLOY_KEY` secret and every PAT is refused - `FLAKE_UPDATE_TOKEN`, `AFK_AGENT_TOKEN`, and your own, since a fine-grained PAT acts as the repository owner and the owner is not on that list. `GITHUB_TOKEN` could not have been the exception: GitHub refuses the GitHub Actions app as a bypass actor on a **user-owned** repository (`422 Actor GitHub Actions integration must be part of the ruleset source or owner organization`) - the same organization-only shape as merge queues above, and the second time this repo has designed around it. It is a _second_ ruleset rather than a rule inside `protect-deploy` because a bypass belongs to the whole ruleset, and the invariant above has to stay true. [ADR 0005](../../docs/adr/0005-only-a-deploy-key-may-move-deploy.md) has the reasoning and the probes that ruled out the alternatives.
 
 **The deploy key does not close the workflow path to `deploy`, and is not meant to.** `PROMOTE_DEPLOY_KEY` is a repository secret, and a `pull_request` event runs the workflow file from the PR's head branch, so an edited `ci.yml` can still read it and push. That is why `.github/workflows/` stays on the AFK path denylist (`docs/agents/afk-eligibility.md`) even though every diff is reviewed before merge. What the ruleset closes is the short way - one `git push` from any write credential - not the long one.
 
-**Two things have to move together to rotate that key.** The repository's deploy key and the `PROMOTE_DEPLOY_KEY` secret are separate objects, and replacing one without the other is a red `promote` on the next push to master. `gh api repos/{owner}/{repo}/keys` should list exactly one key, `ci-promote-deploy`; the `DeployKey` bypass names the actor *type* rather than one key, so a second write key added later silently joins the bypass list.
+**Two things have to move together to rotate that key.** The repository's deploy key and the `PROMOTE_DEPLOY_KEY` secret are separate objects, and replacing one without the other is a red `promote` on the next push to master. `gh api repos/{owner}/{repo}/keys` should list exactly one key, `ci-promote-deploy`; the `DeployKey` bypass names the actor _type_ rather than one key, so a second write key added later silently joins the bypass list.
 
 **Promotion is deliberately not a force push.** `ci.yml` pushes without `--force`, so a `deploy` that has diverged fails the job loudly rather than silently discarding whatever is there. A red promote step is the pipeline working.
 
@@ -154,7 +154,7 @@ git cherry origin/master origin/deploy | grep '^+'   # expect no output
 
 Any `+` line is a commit that exists _only_ on the deployment ref - stop and work out where it came from, because realigning would discard it.
 
-**Relax the rulesets - both of them.** GitHub → Settings → Rules → Rulesets → `protect-deploy` → Enforcement status → Disabled, and the same for `restrict-deploy-updates`. `protect-deploy` is what rejects the non-fast-forward; `restrict-deploy-updates` is what rejects *you*, since the push below comes from your own credential rather than from CI's deploy key. Prefer the UI: the API equivalent is a `PUT`, which replaces the whole ruleset, so a mistyped call is a rewrite rather than a toggle. `gh api repos/corygyarmathy/dotfiles/rulesets` lists them if you want the IDs.
+**Relax the rulesets - both of them.** GitHub → Settings → Rules → Rulesets → `protect-deploy` → Enforcement status → Disabled, and the same for `restrict-deploy-updates`. `protect-deploy` is what rejects the non-fast-forward; `restrict-deploy-updates` is what rejects _you_, since the push below comes from your own credential rather than from CI's deploy key. Prefer the UI: the API equivalent is a `PUT`, which replaces the whole ruleset, so a mistyped call is a rewrite rather than a toggle. `gh api repos/corygyarmathy/dotfiles/rulesets` lists them if you want the IDs.
 
 **Push the ref, with an explicit lease** so the push aborts if the remote is not where you think it is. The target is `origin/master`, since that is what it would have been fast-forwarded to anyway:
 
@@ -190,4 +190,4 @@ If it fails to build, the same revision will fail identically in CI - reproduce 
 
 **Adding a check** means adding it to `checks/default.nix` _and_ to the `check` matrix in `ci.yml`. A check that CI does not run is a check that protects nothing. The `lint` job compares the two lists and fails if they disagree, so forgetting is a red gate rather than a silent gap.
 
-**Adding an auto-updating package** means editing the package, not `package-update.yml`, which discovers anything declaring `passthru.autoUpdate`. The updater contract is in that workflow's header comment.
+**Adding an auto-updating package** means editing the package, not `package-update.yml`, which discovers anything declaring `passthru.autoUpdate`. The updater contract is in that workflow's header comment. A package whose update diff no review can validate (a version string plus a SHA) may additionally set `passthru.autoMerge` so the PR merges on green; anything crossing an upstream release boundary on "it built" evidence stays manual.

--- a/.github/workflows/package-update.yml
+++ b/.github/workflows/package-update.yml
@@ -21,6 +21,17 @@ name: package-update
 #     and any further lines are detail for the PR body
 #
 # One PR per package, so a single broken update cannot hold up the others.
+#
+# Those PRs do not auto-merge by default: unlike a lock bump, they cross an
+# upstream release boundary, where building successfully is weaker evidence
+# than it looks (ADR 0001). A package opts into auto-merge with
+# `passthru.autoMerge`, for the case where holding the PR for review buys
+# nothing: the diff is a version string plus a SHA no review can validate, and
+# keeping it open keeps CI red - which is exactly the caddy-with-plugins
+# position, where every host builds Caddy and a stale vendor hash fails them
+# all. --auto only sets the intent; the required `nixos ci` check still gates
+# the merge, and the `automerge-nudge` workflow rebases the stale `deps/*`
+# branch onto master like any other auto-merge PR.
 
 on:
   schedule:
@@ -157,6 +168,7 @@ jobs:
         run: nix build --print-build-logs --no-link ".#${{ matrix.package }}"
 
       - name: Open pull request
+        id: cpr
         if: steps.run.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
@@ -183,9 +195,29 @@ jobs:
             opened, so a version that cannot build never gets proposed. The
             `nixos ci` gate still has to pass before it can merge.
 
-            Not auto-merged: unlike a lock bump, these move a package across an
+            Not auto-merged by default: unlike a lock bump, these move a package across an
             upstream release boundary, where building successfully is weaker
-            evidence than it looks.
+            evidence than it looks. A package opts into auto-merge with
+            `passthru.autoMerge` (see the header comment) when its diff is a
+            version string plus a SHA no review can validate; the `nixos ci`
+            gate still has to pass before it can merge.
           labels: |
             dependencies
             nix
+
+      # Schedules the merge for packages that opted in with passthru.autoMerge;
+      # the rest stay open for a human. The ruleset's required check is the
+      # actual gate. Idempotent, so re-running against an existing PR is safe -
+      # the same shape flake-update.yml uses for the nightly lock bump.
+      - name: Enable auto-merge when the package opts in
+        if: steps.run.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.FLAKE_UPDATE_TOKEN }}
+        run: |
+          set -euo pipefail
+          auto_merge="$(nix eval --json '.#packages.x86_64-linux' --apply "ps: (ps.${{ matrix.package }}.autoMerge or false)" | jq -r .)"
+          if [ "$auto_merge" != "true" ]; then
+            echo "::notice::${{ matrix.package }} does not opt into auto-merge; leaving for a human."
+            exit 0
+          fi
+          gh pr merge --auto --squash "${{ steps.cpr.outputs.pull-request-number }}"

--- a/modules/services/reverse-proxy.nix
+++ b/modules/services/reverse-proxy.nix
@@ -26,19 +26,15 @@
 # and add a single tls block with the dns challenge
 #
 # ════════════════════════════════════════════════════════════════════════════
-# IMPORTANT: Hash Management for Caddy Plugins
+# Caddy build: packages/caddy-with-plugins
 # ════════════════════════════════════════════════════════════════════════════
-# The `hash` value for withPlugins changes when:
-#   1. Caddy version updates in nixpkgs
-#   2. Plugin version changes
-#
-# To get the correct hash:
-#   1. Set hash = "" (empty string)
-#   2. Run: nixos-rebuild build
-#   3. Copy the hash from the error message
-#   4. Update the hash below
-#
-# This is a known limitation - see: https://github.com/nixos/nixpkgs/issues/450289
+# Caddy ships with the Cloudflare DNS and rate-limit plugins, built in
+# packages/caddy-with-plugins. The plugin pins and the vendor `hash` live
+# there - not here - and are refreshed by that package's own updateScript
+# (weekly PR via .github/workflows/package-update.yml). The hash covers the
+# vendored Go modules and drifts even under a pinned nixpkgs (transitive deps
+# resolve at build time), which used to red CI until someone hand-updated it -
+# see https://github.com/nixos/nixpkgs/issues/450289.
 # ════════════════════════════════════════════════════════════════════════════
 {
   config,
@@ -51,24 +47,9 @@ let
   fleet = config.cg.fleet;
   inherit (fleet) domain;
 
-  # Build Caddy with Cloudflare DNS plugin
-  # This is required for DNS-01 challenge
-  #
-  # To find the latest plugin version:
-  #   nix-shell -p go
-  #   go mod init temp
-  #   go get github.com/caddy-dns/cloudflare
-  #   grep 'caddy-dns/cloudflare' go.mod
-  #
-  caddyWithPlugins = pkgs.caddy.withPlugins {
-    plugins = [
-      "github.com/caddy-dns/cloudflare@v0.2.2"
-      "github.com/mholt/caddy-ratelimit@v0.1.0"
-    ];
-    # NOTE: If build fails with hash mismatch, update this value
-    # Leave empty ("") on first build to get the correct hash from error output
-    hash = "sha256-pOKH4KP0vbyhxlvMiWmkHoziKXu6O6PKRjPHjflPZuQ=";
-  };
+  # Caddy with the Cloudflare DNS and rate-limit plugins, built and refreshed
+  # in packages/caddy-with-plugins (see the header comment above).
+  caddyWithPlugins = pkgs.caddy-with-plugins;
 
   # Rate limiting profiles for different service types
   rateLimitProfiles = {

--- a/packages/caddy-with-plugins/default.nix
+++ b/packages/caddy-with-plugins/default.nix
@@ -1,0 +1,43 @@
+# Caddy with the plugins the reverse proxy needs.
+#
+# The plugin pins and the vendor `hash` must move together: the hash covers the
+# vendored Go modules for exactly these pins, and it drifts even under a pinned
+# nixpkgs because transitive dependencies resolve at build time
+# (https://github.com/nixos/nixpkgs/issues/450289). Bumping a pin - or taking a
+# nixpkgs Caddy bump - without rehashing is a red gate on every host, as in
+# #229. Both are refreshed by ./update.sh, which is also this package's
+# passthru.updateScript for .github/workflows/package-update.yml, so the weekly
+# updater proposes the next hash rather than a broken CI run.
+{ caddy }:
+
+(caddy.withPlugins {
+  plugins = [
+    "github.com/caddy-dns/cloudflare@v0.2.4"
+    "github.com/mholt/caddy-ratelimit@v0.1.0"
+  ];
+  # Refreshed by ./update.sh - never hand-edit.
+  hash = "sha256-aYsGQTUvBNC24YCLqGZ+1BR0rpmtkZ1oNL/TVpMEuhg=";
+}).overrideAttrs
+  (old: {
+    passthru = (old.passthru or { }) // {
+      # Opt in to .github/workflows/package-update.yml. Explicit rather than
+      # inferred from updateScript's presence: nixpkgs' buildPythonApplication
+      # sets a default updateScript of its own, so every Python package here
+      # would otherwise be picked up and "updated" against no upstream at all.
+      autoUpdate = true;
+
+      # A stale hash reds the whole gate (every host builds Caddy), and the diff
+      # is a version string plus a SHA no review can validate - the same argument
+      # dependabot-auto-merge.yml makes for action pins. --auto only sets the
+      # intent; the required `nixos ci` check (host builds plus the
+      # reverse-proxy VM test, which boots this binary against the generated
+      # Caddyfile) still gates the merge. Packages that cross an upstream release
+      # boundary on "it built" evidence alone (comskip, obsidian-headless) stay
+      # manual, per ADR 0001.
+      autoMerge = true;
+
+      # Repo-relative rather than a store path: the script edits the plugin pins
+      # in this directory, which nix-update cannot do.
+      updateScript = [ "packages/caddy-with-plugins/update.sh" ];
+    };
+  })

--- a/packages/caddy-with-plugins/update.sh
+++ b/packages/caddy-with-plugins/update.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Refresh the Caddy plugin pins and the withPlugins vendor hash in default.nix.
+#
+# Both have to move together: the hash covers the vendored Go modules for
+# exactly the pinned plugins, and it drifts even under a pinned nixpkgs because
+# transitive dependencies resolve at build time
+# (https://github.com/nixos/nixpkgs/issues/450289). One script does both so one
+# weekly PR carries both; the summary names each part so a plugin crossing a
+# release boundary reads differently from a hash-only refresh.
+#
+# Usage:
+#   packages/caddy-with-plugins/update.sh   # refresh pins + hash, no-op if current
+#
+# Requires nix, git and network. Prints nothing on stdout when already current;
+# on a change the first stdout line is a one-line summary (the updater contract
+# in .github/workflows/package-update.yml) and any further lines are detail for
+# the PR body.
+set -euo pipefail
+
+cd "$(dirname "$(readlink -f "$0")")/../.." # repo root, wherever invoked from
+FILE="packages/caddy-with-plugins/default.nix"
+
+latest_tag() { # $1 = owner/repo
+	# Stable tags only: a prerelease is never proposed unattended.
+	git ls-remote --tags --refs "https://github.com/$1" 2>/dev/null |
+		sed -n 's|.*refs/tags/||p' |
+		grep -E '^v?[0-9]+\.[0-9]+(\.[0-9]+)?$' |
+		sort -V |
+		tail -1
+}
+
+summaries=()
+
+# 1. Plugin pins. The module path implies the repo (github.com/<owner>/<repo>).
+specs="$(grep -o '"github\.com/[^"]*@[^"]*"' "$FILE" | tr -d '"' || true)"
+if [ -z "$specs" ]; then
+	echo "no plugin pins found in $FILE" >&2
+	exit 1
+fi
+while read -r spec; do
+	mod="${spec%@*}"
+	current="${spec#*@}"
+	repo="${mod#github.com/}"
+	latest="$(latest_tag "$repo")"
+	if [ -z "$latest" ]; then
+		echo "could not list tags for $repo" >&2
+		exit 1
+	fi
+	if [ "$latest" != "$current" ]; then
+		sed -i "s|\"$mod@$current\"|\"$mod@$latest\"|" "$FILE"
+		summaries+=("$repo $current -> $latest")
+	fi
+done <<<"$specs"
+
+# 2. Vendor hash: rebuild; on a mismatch adopt the hash Nix reports, then verify.
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+if nix build --no-link --print-build-logs ".#caddy-with-plugins" >"$log" 2>&1; then
+	:
+else
+	got="$(grep -m1 'got:' "$log" | grep -o 'sha256-[A-Za-z0-9+/=]*' || true)"
+	if [ -z "$got" ]; then
+		echo "caddy-with-plugins build failed for another reason:" >&2
+		tail -n 30 "$log" >&2
+		exit 1
+	fi
+	old_hash="$(sed -n 's/^[[:space:]]*hash = "\(sha256-[^"]*\)";$/\1/p' "$FILE")"
+	sed -i "s|hash = \"$old_hash\"|hash = \"$got\"|" "$FILE"
+	if ! nix build --no-link --print-build-logs ".#caddy-with-plugins" >"$log" 2>&1; then
+		echo "rebuild with refreshed hash still fails:" >&2
+		tail -n 30 "$log" >&2
+		exit 1
+	fi
+	summaries+=("vendor hash ${old_hash:0:15} -> ${got:0:15}")
+fi
+
+[ "${#summaries[@]}" -gt 0 ] || {
+	echo "caddy-with-plugins is already current" >&2
+	exit 0
+}
+
+# Trust the working tree, not the narration.
+if git diff --quiet -- "$FILE"; then
+	echo "caddy-with-plugins printed a summary but changed no files" >&2
+	exit 0
+fi
+
+{
+	summary="$(printf '%s; ' "${summaries[@]}")"
+	echo "caddy-with-plugins: ${summary%; }"
+	git diff -- "$FILE"
+}

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -57,6 +57,11 @@ pkgs: {
   # Obsidian Sync headless CLI (`ob`)
   obsidian-headless = pkgs.callPackage ./obsidian-headless { };
 
+  # Caddy with the reverse proxy's plugins. The plugin pins and the vendor hash
+  # live in the package and are refreshed by its own updateScript (weekly PR via
+  # .github/workflows/package-update.yml), so a drifted hash never reds CI.
+  caddy-with-plugins = pkgs.callPackage ./caddy-with-plugins { };
+
   # Example custom package:
   # bootdevcli = pkgs.callPackage ./bootdevcli {};
 }


### PR DESCRIPTION
Weekly updater for the Caddy build instead of hand-updating the hash after CI goes red (#229).

## What changes

- **New `packages/caddy-with-plugins`**: the `withPlugins` build moves out of `modules/services/reverse-proxy.nix` into a real package, so it participates in `package-update.yml` discovery via `passthru.autoUpdate`.
- **`update.sh`** refreshes both things that must move together: plugin pins (latest stable tags via `git ls-remote`, prereleases excluded) and the vendor hash (build, adopt the `got:` hash on mismatch, rebuild to verify). Obeys the updater contract: silent on stdout when current, one-line summary plus diff on change.
- **Opt-in auto-merge** (`passthru.autoMerge`): a stale hash fails every host build, and the diff is a version string plus a SHA no review can validate. `--auto` only sets the intent; `nixos ci` still gates. `comskip`/`obsidian-headless` stay manual.
- **First finding included**: cloudflare `v0.2.2 -> v0.2.4` with rehashed vendor tree.
- Docs: workflow header comment and `.github/workflows/README.md` record the `autoMerge` opt-in.

## Design notes for review

- Plugins and hash share one script/PR deliberately: they are adjacent lines in one file and must move together, so separate PRs would conflict. The summary distinguishes release-boundary bumps from hash-only refreshes.
- Residual risk: an auto-merged plugin bump crosses an upstream release boundary on CI evidence alone. Mitigation is the same posture as the daily lock auto-merge, with stronger evidence here (the reverse-proxy VM test boots this exact binary against the generated Caddyfile).

## Checks run

- `packages/caddy-with-plugins/update.sh`: proposed the bump + rehash on first run, silent (0 bytes stdout) on re-run.
- `nix build .#caddy-with-plugins`: pass (inside the script, twice).
- `nix build .#checks.x86_64-linux.reverse-proxy`: pass (all subtests).
- `nix build .#nixosConfigurations.homelab01.config.system.build.toplevel`: pass.
- `nix fmt -- --ci`: clean. Workflow YAML parsed with yamllint (0 errors).