### PR TITLE
docs: cleanup AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,46 +2,17 @@
 
 ## Repository
 
-This repository is Cory's NixOS fleet configuration. It manages `homelab01`,
-`homelab02`, and `xps15` through a gated GitOps pipeline.
-
-- `master` is the integration branch. Changes go through pull requests.
-- `deploy` is the only promoted ref and the only ref followed by the fleet.
-- CI builds every host and runs `nix flake check` before promoting `deploy`.
-- `flake.lock` is maintained by the scheduled `flake-update` workflow; do not
-  update it manually unless the user explicitly asks.
-- Never create a branch whose name starts with `deploy/`; Git ref layout makes
-  that conflict with the `deploy` branch.
-
-Read the relevant README, workflow documentation, ADR, or hardening-plan entry
-before changing behavior that affects deployment, rollback, services, or
-security. Prefer existing module patterns over introducing new abstractions.
-
-## Worktree Isolation
-
-When working on tasks that involve multiple concurrent agents or significant
-file changes, isolate work in a git worktree:
-
-1. `git worktree add ../repo-<task-slug> -b <branch-name>` from the repo root.
-2. Do all editing, building, and checking inside that worktree directory.
-3. Report the branch name and changed files when done. Clean up with
-   `git worktree remove` after the branch merges.
-
-Skip this step for trivial fixes or when the user explicitly works in the main
-checkout.
+This repository is Cory's NixOS fleet configuration. It manages the hosts through a gated GitOps pipeline (see further: [[.github/workflows/README.md]]).
 
 ## Working Method
 
-1. Inspect the relevant files and trace how the current configuration works
+1. Always isolate work in a git worktree.
+2. Inspect the relevant files and trace how the current configuration works
    before editing.
-2. State important assumptions when the request is ambiguous. Do not broaden a
+3. State important assumptions when the request is ambiguous. Do not broaden a
    focused change into an unrelated refactor.
-3. Make the smallest correct change and preserve established naming and layout.
-4. Add or update a check when changing observable service behavior, especially
-   for configuration parsing, HTTP behavior, publication filters, or deployment
-   safety.
-5. Review `git diff` and `git status` after editing. Do not modify or revert
-   unrelated user changes.
+4. Make the smallest correct change and preserve established naming and layout.
+5. Add or update a check when changing observable service behavior, CI should always gate objective _correctness_.
 6. Run the narrowest useful checks, then run the full relevant check when
    practical. Report commands, results, and any checks that could not run.
 
@@ -76,16 +47,9 @@ service starts or that its generated configuration is valid.
 
 ## Secrets And Safety
 
-- Never print, decrypt, expose, or commit plaintext secrets, age private keys,
-  tokens, or credentials.
-- Treat everything under `secrets/` and the SOPS configuration as sensitive. Use `sops`
-  for intentional secret edits and avoid including secret values in command
-  output or summaries.
+- All repo secrets are encrypted with `sops` in `secrets/`. See further: [[secrets/README.md]].
 - Do not weaken SSH, firewall, SOPS, service confinement, deployment gates, or
   branch protections to make a check pass.
-- Do not force-push, delete, or manually move `deploy`. Recovery requires
-  deliberate operator confirmation and follows the documented procedure in
-  `.github/workflows/README.md`.
 - Do not run destructive commands, remote activation, or production-affecting
   operations without explicit confirmation.
 
@@ -108,10 +72,10 @@ service starts or that its generated configuration is valid.
 
 ## Response Expectations
 
-For each completed task, summarize:
+For each completed task, summarise:
 
 - What changed and why.
-- Files changed, especially any security- or deployment-sensitive files.
+- Files changed, especially any security or deployment-sensitive files.
 - Checks run and their results.
 - Assumptions, residual risks, or skipped verification.
 


### PR DESCRIPTION
- Refer to other documents where relevant
- Decrease double-up and overly-explained directions