### PR TITLE
afk-agent: let the revision session read its pull request

### DIFF
--- a/checks/afk-agent-runner.nix
+++ b/checks/afk-agent-runner.nix
@@ -434,7 +434,7 @@ pkgs.runCommand "check-afk-agent-runner"
         # a runner that stopped addressing the model as a revision would
         # then fail the cases below rather than quietly fall through to
         # the implement path and pass.
-        "Address the human review comments"*) is_revise=yes ;;
+        "Address the review comments"*) is_revise=yes ;;
         "Revision attempt"*) is_revise=yes ;;
         "The revision on this branch"*) is_revise=yes ;;
         # The rebase-conflict session (#242): detected on the payload like
@@ -1732,10 +1732,25 @@ pkgs.runCommand "check-afk-agent-runner"
     # string exists somewhere in a file. The prompt asks for the same things;
     # this is the half that does not depend on the model reading it.
     run implement-guard mixed.json fresh good
-    for verb in "git push*" "gh pr*" "gh issue edit*" "gh issue comment*" "gh issue close*"; do
+    for verb in "git push*" "gh pr *" "gh issue edit*" "gh issue comment*" "gh issue close*"; do
       jq -e --arg v "$verb" '.permission.bash[$v] == "deny"' "$state/overlay-1" > /dev/null \
         || fail "the implement session was not denied '$verb'"
     done
+    # Read access: `gh pr view` is the one tracker verb allowed, so a
+    # session can read the pull request it is working on by number. The
+    # deny is written `gh pr *` - with the subcommand's separating space,
+    # which every real invocation carries - because the rules arrive
+    # sorted and the allow has to sort after the deny to win: opencode
+    # evaluates the LAST matching rule. A deny written `gh pr*` (no
+    # space) would sort after every gh pr-subcommand allow and starve it.
+    jq -e '.permission.bash["gh pr view*"] == "allow"' "$state/overlay-1" > /dev/null \
+      || fail "the implement session was not allowed to read its pull request"
+    # And the order that makes it win, asserted against the order the mock
+    # actually received, so a reordering that re-opens the write verbs is
+    # caught here rather than in production.
+    jq -e '.permission.bash | keys_unsorted as $keys
+      | ($keys | index("gh pr view*")) > ($keys | index("gh pr *"))' "$state/overlay-1" > /dev/null \
+      || fail "the gh pr view allow is not ordered after the gh pr deny"
 
     echo "case: the prompt names the skill, the ticket, and both halves of the denylist"
     # Discovery is not invocation. OpenCode exposes skills through a `skill` tool
@@ -2900,6 +2915,8 @@ pkgs.runCommand "check-afk-agent-runner"
     fi
     jq -e --arg v "git push*" '.permission.bash[$v] == "deny"' "$state/revise-overlay-1" >/dev/null \
       || fail "the revision session was not denied the tracker verbs"
+    jq -e '.permission.bash["gh pr view*"] == "allow"' "$state/revise-overlay-1" >/dev/null \
+      || fail "the revision session was not allowed to read its pull request"
     # It ran in the worktree named after the branch, on the branch itself.
     [ "$(cat "$state/revise-cwd")" = "$state/worktrees/$ticket" ] \
       || fail "the revision did not run in the resumed worktree: $(cat "$state/revise-cwd")"
@@ -3134,6 +3151,8 @@ pkgs.runCommand "check-afk-agent-runner"
       || fail "the revision's CI fix was not pinned to its worktree with --dir: $(flag_value "$state/revise-args-2" --dir)"
     jq -e --arg v "git push*" '.permission.bash[$v] == "deny"' "$state/revise-overlay-2" >/dev/null \
       || fail "the revision's CI fix session was not denied the tracker verbs"
+    jq -e '.permission.bash["gh pr view*"] == "allow"' "$state/revise-overlay-2" >/dev/null \
+      || fail "the revision's CI fix session was not allowed to read its pull request"
     [ "$(pushed_commits)" -eq 3 ] || fail "the fix did not reach origin"
     grep -q "gh pr edit 999 .* --add-label agent-ready-for-review" "$state/gh.log" \
       || fail "the branch did not come back to the reviewer: $(ghlog)"

--- a/modules/services/afk-agent.nix
+++ b/modules/services/afk-agent.nix
@@ -208,10 +208,27 @@ let
   # the one bound (`permissionOverlay` and `reviewOverlay` together) that
   # stops the agent doing its own writeback. Change here must land here, in
   # review, where the denial pattern is read as a decision.
+  #
+  # What is held is the write verbs, not the read ones. The one allow is
+  # for reading the pull request - `gh pr view PRNUMBER`, which the
+  # prompts name - carved out of the `gh pr` deny. opencode evaluates
+  # the LAST matching rule, and the JSON this produces is sorted by
+  # attribute name, so the two patterns are chosen to make that safe:
+  # the deny carries the subcommand's separating space (`gh pr *`, which
+  # matches every real invocation - a `gh pr` command always names a
+  # subcommand) and the allow is the literal `gh pr view*`, so the allow
+  # sorts after the deny and wins. Two stumbles are worth the record:
+  # a deny written as `gh pr*` (no space) sorts AFTER any gh pr-subcommand
+  # allow - including this view one - and starves it; and a bare `gh pr`
+  # matches nothing real, so it carries no weight. The revise cases in
+  # checks/afk-agent-runner.nix pin both the allow and its document
+  # order; a deny that lexicographically follows it loses there, not in
+  # production.
   permissionOverlay = builtins.toJSON {
     permission.bash = {
       "git push*" = "deny";
-      "gh pr*" = "deny";
+      "gh pr *" = "deny";
+      "gh pr view*" = "allow";
       "gh issue edit*" = "deny";
       "gh issue close*" = "deny";
       "gh issue comment*" = "deny";
@@ -229,13 +246,17 @@ let
 
   # The revision session's instructions (#196). Same shape
   # as the other two prompts. The clause that matters most is the one that
-  # is a property of the pipeline rather than of the prose: the runner
-  # hands this session the human's review comments and nothing else, so
-  # the prompt has to say that the agent's own words - the round comments,
-  # and the advisory review's findings, which since #202 arrive as a
-  # comment posted by the agent's own account - are not review input. The
-  # author filter below drops them before the prompt is built; the prose
-  # says the same. `PRNUMBER` is substituted at run time; the comments
+  # is a property of the pipeline rather than of the prose: the input the
+  # round was started with - the `/revise` comment's own text, or the
+  # comments behind it collected by the author filter - is what the runner
+  # feeds it, and what the round is judged against by the human who wrote
+  # it. The agent's own words - the round comments, and the advisory
+  # review's findings, which since #202 arrive as a comment posted by the
+  # agent's own account - never drive a round: the author filter keeps
+  # them out of the payload, and the prose says they are background to
+  # read, not instructions to follow. Reading, since `gh pr view` is
+  # allowed in permissionOverlay, covers the whole pull request thread.
+  # `PRNUMBER` is substituted at run time; the comments
   # travel beside the prompt, not inside it.
   revisePrompt = pkgs.writeText "afk-agent-revise-prompt" (
     builtins.readFile ./afk-agent/lib/prompts/revise.md

--- a/modules/services/afk-agent/lib/prompts/revise.md
+++ b/modules/services/afk-agent/lib/prompts/revise.md
@@ -1,15 +1,22 @@
-Address the human review comments on pull request #PRNUMBER in this
+Address the review comments on pull request #PRNUMBER in this
 repository. This round was started by a `/revise` comment on that pull
 request from an account other than the agent's own. When that comment
 carried text of its own, that text is this round's instruction and it
 follows, verbatim. When it did not, the runner collected the review
 comments written since its last word on the pull request from accounts
 other than the agent's own, and they follow instead, verbatim, oldest
-first. Either way they are the only review input for this round: do not
-read the pull request's body or description, and do not fetch anything
-else from the tracker - the advisory review's findings arrive as a
-comment posted by the agent's own account, and a comment from that
-account is not review input either, and none appear below.
+first. Either way what follows is the input this round was started with,
+and it is what the person who wrote it will judge the round against:
+work through it first and in order.
+
+You may read the pull request for reference - `gh pr view PRNUMBER`,
+its comments and its inline review comments - and that includes what
+the agent itself has said there: the advisory review's findings and any
+round reports from earlier revisions. Read all of it as background that
+helps you confirm, locate or rebut what follows below. It does not
+broaden this round: a finding not chosen by the `/revise` request is
+not addressed unless the request says so, and where the thread and the
+request disagree, the request wins.
 
 The work to revise is at the head of this branch; the comments refer to
 it. Work through them in order. Where you agree with a comment, make the
@@ -27,8 +34,10 @@ Scope:
   change nothing else in that file: no other key, no existing entry
   altered or removed. The name must match `^[a-z][a-z0-9-]*$` and must be a
   check the flake actually exposes.
-- Do not push, and do not comment on, edit, close or merge the pull
-  request. The runner does the pushing and the reporting, after the gate.
+- Reading the pull request is the one tracker verb you are given. Every
+  write - comment, edit, close, merge, push - is denied at the permission
+  layer; do not try them. The runner does the pushing and the reporting,
+  after the gate.
 - Before you commit, run `nix fmt` (write mode) from the repo root, so
   formatting lands in your commits rather than as uncommitted drift the
   push cannot carry. Then commit your work to this branch before you

--- a/modules/services/afk-agent/lib/stages/150-revise.sh
+++ b/modules/services/afk-agent/lib/stages/150-revise.sh
@@ -17,8 +17,10 @@
 # back to the model that wrote the code, and it was measured: 15 runs,
 # 0 catches, refusals grounded on true but immaterial observations. This
 # hands back the *human's* findings, the most reliable input in the
-# pipeline and the only one that had no path to the code. The
-# distinction is structural, not prose, and it is held at three places:
+# pipeline and the only one that drives the round's address list - the
+# advisory findings may be read, but nothing feeds them in unchosen. The
+# distinction is structural in what drives a round, and it is held at
+# three places:
 #
 # - The frontier query asks the tracker for the pull request's comments
 #   and review summaries, and for the inline review comments beside
@@ -33,8 +35,17 @@
 #   has posted - so a round is fed only the comments written since the
 #   last one, and never its own output from a previous round.
 # - The revision prompt repeats the boundary: what follows it is the
-#   only review input, and the body and the agent's own comments are off
-#   limits.
+#   input the round was started with, and what its author will judge the
+#   round against - and the agent's own words in the thread are
+#   background to read, never instructions that drive the round.
+# - The session may read the pull request itself: `gh pr view` is
+#   allowed in permissionOverlay (`gh pr view*` beside a `gh pr *` deny
+#   that sorts before it), carved out of the write verbs. A
+#   `/revise` comment may reference the findings without quoting them -
+#   "address findings 1-6, not 7" - and the reference has to resolve to
+#   something the round can read. What the overlay still holds is every
+#   write verb: the round's prose reaches the pull request only through
+#   the runner's round comment, past the gate and the push.
 #
 # The pull request is resumed at its head rather than claimed fresh: the
 # worktree is cut at `origin/$branch`, which is what the reviewer read.


### PR DESCRIPTION
## Why

The `/revise` trigger (#196) already takes whatever text the operator writes after the command - "address findings 1-6, not 7" - but the context that resolves such a reference (the advisory findings comment, the thread around it) was off limits: the revision session could not read the pull request it was being asked to change, by prompt clause and by `gh pr*` denied at the permission layer.

The hold was on the **write** verbs, not the read ones. Writeback is what the permission layer guards; reading the thread by number is how the session confirms, locates or rebuts what the `/revise` request chose. What a round is judged against stays exactly what it was: the payload the runner feeds it - the `/revise` instruction, or the author-filtered comments behind it. A finding not chosen by the request is not addressed unless the request says so (now said in `revise.md` rather than implied by an unavailability). Not a return to the uncurated fix-and-recheck item 6 measured at 0 catches.

## What

- `modules/services/afk-agent.nix`: `permissionOverlay` gains one allow, `gh pr view*`. The write deny is written as the space-carrying `gh pr *` (every real `gh pr` invocation names a subcommand), which is what makes the allow the last matching rule: opencode evaluates the last matching rule over insertion order, and the JSON keys arrive sorted - a space-less `gh pr*` deny would sort after every `gh pr ...` allow and starve it. Comment records both stumbles.
- `modules/services/afk-agent/lib/prompts/revise.md`: the round's input is what it works through first and what its author judges it by; the pull request thread (including the agent's own findings and earlier round reports) may be read as background, never as a broadened address list; every write verb stays denied.
- `modules/services/afk-agent/lib/stages/150-revise.sh` header: the boundary is now "what drives the round" rather than "what can be read at all"; the runner's frontier query is unchanged (it still never requests the body, and the author filter still shapes the payload).
- `checks/afk-agent-runner.nix`: the guard cases assert the allow (implement, revision, revision-CI-fix overlays) and pin the document order the allow must sit in to win; the mock's revise-lane detection follows the prompt's new opening words.

## Checks

- [x] `nix build .#checks.x86_64-linux.afk-agent-runner` (the revise lane, the guard, and the order assertions)
- [x] `nix build .#checks.x86_64-linux.afk-agent`
- [x] `nix build .#checks.x86_64-linux.fmt-gate` and `nix fmt`
- Full `nix flake check` not run locally: unrelated VM suites unaffected by this change; CI runs it.

Residual: the allow is prose-shaped at the session level ("read as background") same as reviewOverlay's report-only ask; the write denial is the layer, unchanged.