### PR TITLE
build(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1788395115,
-        "narHash": "sha256-7sprixDLchHgjQt1yNoc91d0L0lnbd1VUb3OPZpsIJk=",
+        "lastModified": 1788879443,
+        "narHash": "sha256-qb9sL86UCUEd3SYAda4ItN1NV0vhMSdbpA64WckvVI0=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "a591d4600e8ada8b22489093ebf50337f4d98065",
+        "rev": "414ac5f35d79aabe5a0bf52451d8cf61eadf6c88",
         "type": "github"
       },
       "original": {
@@ -203,11 +203,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1788335262,
-        "narHash": "sha256-3jBEq8avfzlrsY4UpW4d5TOmm7ocseZfnitEJhqauyc=",
+        "lastModified": 1788942796,
+        "narHash": "sha256-CLoJCCRi9sogsyGXYn8rOCWBLKAntfKUB9Rli/YXgEY=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "44d95795ee2d475b3d687325e26dcf4ca9104557",
+        "rev": "83bbc895120516d6e86885a188c04beced6535d9",
         "type": "github"
       },
       "original": {
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788651960,
-        "narHash": "sha256-v9wJd32eZ2bvhBzVOd7TIjLQd011P7nwOhjKtWlci5I=",
+        "lastModified": 1789047607,
+        "narHash": "sha256-TvkqeCjWyQvQs7jZ/2WcOWF1GMSgKtAP3qrw7eKpp1k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2c0350c759688177331b8f5242311fae8877bdb3",
+        "rev": "f7f333f04ff6e2f94f955642a1b4956d4fcd3010",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1788690626,
-        "narHash": "sha256-+v4I4LawmRD/mVxO7QIAerRrCkElp3YImzWkkUnvOTg=",
+        "lastModified": 1789009968,
+        "narHash": "sha256-GB16oaxpsrnGNnGIE+0uYBqMRzB9X6FYDUvjvnJAYew=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c25784012c9982bca5b3e0de87e90bbdac8927d3",
+        "rev": "d58a46e3bc02d91ebe04667f8397752a749c0024",
         "type": "github"
       },
       "original": {
@@ -267,11 +267,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1788761488,
-        "narHash": "sha256-mu5sizob4fS6ECwiwFMIlLRn5OZt/DlY29E1xK7ArZc=",
+        "lastModified": 1789034407,
+        "narHash": "sha256-7X4GZ0KK5qHF9lppR9IlfXShYGcxxw1Kcjj8m5+19H0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9485e5e151b6bcea0fef6980325ec8fb4194d30c",
+        "rev": "3824e02a19d7dccf95c30aa1cab8c857323d2201",
         "type": "github"
       },
       "original": {
@@ -283,11 +283,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1788752844,
-        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
+        "lastModified": 1789006805,
+        "narHash": "sha256-xB8mKMOx1IA9vTDNLmJZ6n4wCMq/cuWBBOzGCRnqxrU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
+        "rev": "8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe",
         "type": "github"
       },
       "original": {
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788337237,
-        "narHash": "sha256-gkSH8VUtCo6hnysNmb9DbTuDepH2t5pv+QWjP75xKAk=",
+        "lastModified": 1788914643,
+        "narHash": "sha256-4GuMPW90JSxXWDPUB9M+1m7fYbe3H0apOd86/zBQ2Kw=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "fbf759290e0cb0a98dfc813a4eb7d53ad1dacb57",
+        "rev": "13616fff713a9f94055c66f15687ebdc17a335df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `flake.lock` update.

The per-host deltas below are recorded in the commit body so they
land in `git log` on merge (ADR 0001).

Each host was built at the current lock and at the updated one, and
the closures compared. All three builds passing is a precondition of
this PR existing at all — but the `nixos ci` gate still has to pass
before it can merge, and merging is what promotes `deploy`.

### homelab01

bcachefs-tools: 1.39.2 → 1.39.4, 204.0 KiB
dotnet-aspnetcore-runtime: 9.0.19 removed, -98.7 MiB
dotnet-aspnetcore-runtime-wrapped: 9.0.19 removed
frei0r-plugins: 3.2.3 → 3.5.0, 136.3 KiB
hm-putter.json: (no version) added
initrd-linux: 6.18.49 → 6.18.50, 19.4 KiB
intel-compute-runtime: 63.3 MiB
jellyfin: 10.11.11 → 12.0, -801.1 KiB
jellyfin-ffmpeg: 7.1.4-3 → 8.1.2-4, -2.6 MiB
jellyfin-web: 10.11.11 → 12.0, 715.5 KiB
kguiaddons: 6.29.0 → 6.30.0
linux: 6.18.49 → 6.18.50, 41.4 KiB
nixos-manual: 26.8 KiB
nixos-system-homelab01: 26.11.20260907.dc5d91f → 26.11.20260910.8ce4ef6
ruff: 0.16.5 → 0.16.6, 68.5 KiB
shfmt: 3.14.0 → 3.14.1
sops-install-secrets: 8.6 KiB
source: 218.5 KiB

### homelab02

bcachefs-tools: 1.39.2 → 1.39.4, 204.0 KiB
hm-putter.json: (no version) added
initrd-linux: 6.18.49 → 6.18.50, 18.7 KiB
intel-compute-runtime: 63.3 MiB
kguiaddons: 6.29.0 → 6.30.0
linux: 6.18.49 → 6.18.50, 41.6 KiB
nixos-manual: 26.8 KiB
nixos-system-homelab02: 26.11.20260907.dc5d91f → 26.11.20260910.8ce4ef6
ruff: 0.16.5 → 0.16.6, 68.5 KiB
shfmt: 3.14.0 → 3.14.1
sops-install-secrets: 8.6 KiB
source: 218.5 KiB
zfs-kernel: 2.4.4-6.18.49 → 2.4.4-6.18.50

### xps15

audacity: 3.7.9 → 4.0.0, 30.2 MiB
bcachefs-tools: 1.39.2 → 1.39.4, 204.0 KiB
breeze-icons: 6.29.0 → 6.30.0, 39.1 KiB
claude-code: 2.1.260 → 2.1.266, 1.2 MiB
docker-compose: 5.5.0 → 5.5.1, -14.9 MiB
electron: 43.4.1 → 43.5.1
electron-unwrapped: 43.4.1 → 43.5.1, 2.4 MiB
extra-cmake-modules: 6.29.0 → 6.30.0, 36.5 KiB
google-chrome: 152.0.7977.82 → 153.0.8010.36, -2.1 MiB
herdr: 0.8.2 → 0.9.0, 2.0 MiB
hm-putter.json: (no version) added, 22.3 KiB
home-manager: -17.7 KiB
initrd-linux: 7.2.3 → 7.2.4, -135.7 KiB
intel-compute-runtime: 63.3 MiB
karchive: 6.29.0 → 6.30.0
kauth: 6.29.0 → 6.30.0
kbookmarks: 6.29.0 → 6.30.0
kcmutils: 6.29.0 → 6.30.0
kcodecs: 6.29.0 → 6.30.0
kcolorscheme: 6.29.0 → 6.30.0
kcompletion: 6.29.0 → 6.30.0
kconfig: 6.29.0 → 6.30.0
kconfigwidgets: 6.29.0 → 6.30.0
kcontacts: 6.29.0 → 6.30.0
kcoreaddons: 6.29.0 → 6.30.0
kcrash: 6.29.0 → 6.30.0
kdbusaddons: 6.29.0 → 6.30.0
kdoctools: 6.29.0 → 6.30.0
kglobalaccel: 6.29.0 → 6.30.0
kguiaddons: 6.29.0 → 6.30.0
ki18n: 6.29.0 → 6.30.0
kiconthemes: 6.29.0 → 6.30.0
kio: 6.29.0 → 6.30.0, 208.0 KiB
kirigami: 6.29.0 → 6.30.0, -109.1 KiB
kitemmodels: 6.29.0 → 6.30.0
kitemviews: 6.29.0 → 6.30.0
kjobwidgets: 6.29.0 → 6.30.0
knotifications: 6.29.0 → 6.30.0
kpackage: 6.29.0 → 6.30.0
kpeople: 6.29.0 → 6.30.0
kservice: 6.29.0 → 6.30.0
kstatusnotifieritem: 6.29.0 → 6.30.0
ktextwidgets: 6.29.0 → 6.30.0
kwallet: 6.29.0 → 6.30.0, -254.8 KiB
kwidgetsaddons: 6.29.0 → 6.30.0
kwindowsystem: 6.29.0 → 6.30.0
kxmlgui: 6.29.0 → 6.30.0
libwacom: 2.19.1 → 2.20.0, 12.6 KiB
linux: 7.2.3 → 7.2.4, -35.3 KiB
modemmanager-qt: 6.29.0 → 6.30.0
nixos-manual: 26.8 KiB
nixos-system-xps15: 26.11.20260907.dc5d91f → 26.11.20260910.8ce4ef6
nvidia-open: 595.99.02-7.2.3 → 595.99.02-7.2.4
obsidian: 1.13.4 → 1.13.7
portmidi: 2.0.8 removed, -120.9 KiB
protonmail-desktop: 1.13.4 → 1.14.0, 1.3 MiB
qqc2-desktop-style: 6.29.0 → 6.30.0, -18.8 KiB
qtnetworkauth: 6.11.2 added, 645.4 KiB
ruff: 0.16.5 → 0.16.6, 68.5 KiB
shfmt: 3.14.0 → 3.14.1
slirp4netns: 1.3.4 → 1.3.5
solid: 6.29.0 → 6.30.0
sonnet: 6.29.0 → 6.30.0
sops-install-secrets: 8.6 KiB
source: 218.5 KiB
wine: 8.0 MiB
wxwidgets: -364.4 KiB
x86_energy_perf_policy: 6.18.49 → 6.18.50
zotero: 10.0.0 → 10.0.1, 9.8 KiB