### PR TITLE
docs(afk-agent): record the successor agent's design and amend the prototype's ADRs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,7 @@
+# Dotfiles
+
+The fleet's configuration and the services it runs: two NixOS hosts, their modules, and the automation that maintains them. This glossary covers only terms whose meaning here is narrower than, or different from, their ordinary use.
+
+## AFK agent
+
+The unattended runner's vocabulary - job, transition, claim, lease, command, hand-off - is defined in the [`afk-agent`](https://github.com/corygyarmathy/afk-agent) repository's `CONTEXT.md`, not here. This repository holds the NixOS module that packages and configures the runner, and (until cutover) the bash prototype it replaces; neither owns the language.

--- a/docs/adr/0004-afk-agent-runs-self-hosted-with-a-harness-split.md
+++ b/docs/adr/0004-afk-agent-runs-self-hosted-with-a-harness-split.md
@@ -1,6 +1,19 @@
 # ADR 0004: AFK agent runs self-hosted, with a harness split from planning
 
 - **Status:** Proposed. The pipeline runs on homelab01 as a working prototype, not yet a settled design; three clauses are amended by later ADRs. [ADR 0006](0006-the-runner-is-a-github-app.md): §4's credential is an App installation token rather than a fine-grained PAT - its no-second-account clause is upheld rather than reversed, because a GitHub App is not a second account; and §3's claim marker is a label rather than an assignee, because an App cannot hold an assignment. [ADR 0007](0007-the-pull-request-opens-before-the-review.md): §6's closing "never a PR" is narrowed - the pull request now opens before the review, so a run that fails after the push leaves one open, and the same section's retry-in-the-same-session rule is extended to a red CI run. Every other decision here, §9 included, stands.
+
+    **Amended 2026-09-11 (the prototype is being replaced, not extended).** The runner this ADR describes is a bash prototype, and its successor is a Go program in its own repository - [`corygyarmathy/afk-agent`](https://github.com/corygyarmathy/afk-agent), ADR 0001 - whose founding decisions are recorded there rather than here. Four clauses of this ADR are changed by that, and the rest continue to describe the prototype accurately for as long as it runs.
+
+    §2's harness split holds - Claude Code interactive, OpenCode unattended - but the clause leaves model choice to a pilot, and the pilot's answer has been superseded by a structure rather than a name: a job kind declares the capabilities and quality tier it requires, and a resolver picks among models a human has enrolled in that tier. A single settled model name is no longer the shape of the answer.
+
+    §6's retry semantics are relocated rather than reversed. "Retry inside the session that produced the failure" and "review is always a fresh context" both stand, but the unit that retries becomes a transition rather than a session, and a transient provider failure retries at the next enrolled model in the same tier instead of consuming the ticket's budget.
+
+    §8 is superseded. Serial execution was chosen because an unproven runner should fail in one place at a time; the successor replaces it with two independent limits - worker parallelism, and named capacity-limited resource tokens a transition must hold to run - so that one nix build at a time and many concurrent API calls can both be true. See `afk-agent` ADR 0001 §8.
+
+    §3's claim convention is refined. A tracker-visible claim cannot express "held by a process that may have died", which is the root of the duplicate-reply defects observed against this prototype. The successor keeps the claim and adds a local expiring lease alongside it, as two distinct concepts.
+
+    Not changed by any of this: §1 (self-hosted on homelab01), §4 (the runner's own GitHub identity, as already amended by ADR 0006), §5 (eligibility bounded by a path denylist, enforced twice), §7 (a real NixOS module with a one-boolean kill switch - which now packages the Go agent as a flake input), and §9 (merge stays a human act), which the successor restates for its own repository.
+
 - **Date:** 2026-09-07
 - **Related Artefacts:**
     - Implemented by: `modules/services/afk-agent.nix`, which owns this design's parameters - counts, prefixes, paths and option names; this ADR states decisions only. The measured evidence behind them is in `docs/research/afk-agent-pilot-findings.md`.

--- a/docs/adr/0007-the-pull-request-opens-before-the-review.md
+++ b/docs/adr/0007-the-pull-request-opens-before-the-review.md
@@ -1,6 +1,13 @@
 # ADR 0007: The pull request opens before the review, and CI is the gate
 
-- **Status:** Proposed
+- **Status:** Proposed.
+
+    **Amended 2026-09-11 (labels stop carrying instructions).** §7 established that the hand-off label is a signal rather than a control. That principle is generalised in the successor agent ([`corygyarmathy/afk-agent`](https://github.com/corygyarmathy/afk-agent) ADR 0001 §14): every label becomes status the agent writes, and the only imperative channel from a human is a comment command resolved through a registry mapping command to job kind. One exception is retained - the eligibility label on an issue, which is how work enters the queue at all, and which is a filter rather than an instruction.
+
+    Two things follow. Adding a command - `/review` on a pull request the operator raised themselves, say - becomes a registry entry and a job kind rather than a new path through the pipeline. And "have I already acted on this?" gets a single place to be answered, instead of one answer for labels and another for comments.
+
+    Everything else here stands. §1's ordering, §3's division between CI as the correctness gate and the review as an advisory quality pass, and §6's placement of the denylist gate immediately before every push are all carried into the successor unchanged.
+
 - **Date:** 2026-09-09
 - **Related Artefacts:**
     - Amends: [ADR 0004](0004-afk-agent-runs-self-hosted-with-a-harness-split.md) §6, whose closing "never a PR" was written when the review was a gate. Its retry-in-the-same-session rule is upheld here and extended to a new kind of failure; §9 is untouched


### PR DESCRIPTION
Groundwork for replacing the bash runner with a Go agent in its own repository (`corygyarmathy/afk-agent`). Documentation only - no behaviour changes, nothing here touches the running service.

## What changed

**ADR 0004 and ADR 0007 amended in place.** Both are Proposed, and `docs/agents/domain.md` says a Proposed ADR is amended rather than superseded - so this adds "Amended 2026-09-11" blocks instead of opening ADR 0009.

- 0004: §2 (model choice becomes a resolver over enrolled models and tiers, not a single settled name), §3 (a claim gains a distinct local expiring lease alongside it), §6 (the retrying unit becomes a transition, not a session), §8 (serial execution superseded by worker parallelism plus resource tokens). §1, §4, §5, §7 and §9 explicitly unchanged.
- 0007: §7's "a label is a signal rather than a control" generalised to every label. Comment commands become the only imperative channel; the eligibility label is the one exception, as a queue filter rather than an instruction.

**`CONTEXT.md` added**, deliberately thin: the agent's vocabulary lives in the new repository, and this file points at it rather than keeping a second copy to drift.

## Related

- Closes #234 - the behaviour-preserving port is not what is happening; a like-for-like port would carry the linear pipeline into Go, and the linear pipeline is the defect.
- Closes #221 - the usage endpoint was probed and the findings recorded there; the design it feeds moves to the successor's tracker.
- #275 promotes the polled repository to an option, so the prototype can work the tickets that build its replacement.